### PR TITLE
feat: remove view that dont fit

### DIFF
--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -1,5 +1,6 @@
 export { useNavigation } from '@/navigation/hooks/useNavigation'
 export { useTheme } from './useTheme'
 export { useHistory } from '@/navigation/hooks/useHistory'
+export { useResize } from '@/navigation/hooks/useResize'
 export { useSession } from './useSession'
 export { useQuery } from './useQuery'

--- a/src/navigation/components/NavigationProvider/index.tsx
+++ b/src/navigation/components/NavigationProvider/index.tsx
@@ -9,10 +9,8 @@ import type { NavigationState, NavigationAction } from '@/types'
 import { NavigationActionType } from '@/types'
 import { init } from '@/lib/init'
 
-import { useHistory } from '@/hooks'
+import { useHistory, useResize } from '@/hooks'
 import { navigationReducer } from '@/navigation/lib'
-import { useResize } from '@/navigation/hooks/useResize'
-
 
 const initialState = init()
 

--- a/src/navigation/components/NavigationProvider/index.tsx
+++ b/src/navigation/components/NavigationProvider/index.tsx
@@ -11,6 +11,7 @@ import { init } from '@/lib/init'
 
 import { useHistory } from '@/hooks'
 import { navigationReducer } from '@/navigation/lib'
+import { useResize } from '@/navigation/hooks/useResize'
 
 
 const initialState = init()
@@ -23,6 +24,7 @@ export const NavigationContext = createContext<{
 export const NavigationProvider = ({ children }: PropsWithChildren): JSX.Element => {
   const [state, dispatch] = useReducer(navigationReducer, initialState)
   const historyState = useHistory()
+  const screenSize = useResize()
 
   useLayoutEffect(() => {
     // Create history state for initial content based on url
@@ -58,7 +60,7 @@ export const NavigationProvider = ({ children }: PropsWithChildren): JSX.Element
         contentState: history.state.contentState.slice(1, history.state.contentState.length)
       }, document.title, window.location.href)
     }
-  }, [state])
+  }, [state, screenSize])
 
   return (
     <NavigationContext.Provider value={{ state, dispatch }}>

--- a/src/navigation/hooks/index.tsx
+++ b/src/navigation/hooks/index.tsx
@@ -1,2 +1,3 @@
 export { useHistory } from './useHistory'
 export { useNavigation } from './useNavigation'
+export { useResize } from './useResize'

--- a/src/navigation/hooks/useResize.tsx
+++ b/src/navigation/hooks/useResize.tsx
@@ -1,0 +1,15 @@
+import { useSyncExternalStore } from 'react'
+
+export const useResize = (): number => {
+  function subscribe(callback: () => void): () => void {
+    window.addEventListener('resize', callback)
+    return () => {
+      window.removeEventListener('resize', callback)
+    }
+  }
+
+  function getSnapshot(): number {
+    return window.innerWidth
+  }
+  return useSyncExternalStore(subscribe, getSnapshot)
+}


### PR DESCRIPTION
Partial of https://linear.app/tt-nyhetsbyran/issue/ELE-183/views-in-the-app-should-be-addedremoved-when-window-size-changes

In this:
* Add `useResize` to be able to register resize
* Remove if view doesn't fit new size

To be able to add a view after resize to bigger viewport we need to have a discussion about how. Might be a weird pattern if we readd views that have been removed?
And we need to set a overall strategy for `min-width` and `max-width` for views.