### PR TITLE
Feature/ele 273 keyboard navigation in planningoverview

### DIFF
--- a/src/components/PlanningTable/index.tsx
+++ b/src/components/PlanningTable/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import {
   type ColumnDef,
   type ColumnFiltersState,
@@ -18,14 +18,14 @@ import { Table, TableBody, TableCell, TableRow } from '@ttab/elephant-ui'
 import { Pagination } from './Pagination'
 import { Toolbar } from './Toolbar'
 
-
 interface PlanningTableProps<TData, TValue> {
   columns: Array<ColumnDef<TData, TValue>>
   data: TData[]
+  onRowSelected?: (row?: TData) => void
 }
 
 
-export const PlanningTable = <TData, TValue>({ columns, data }: PlanningTableProps<TData, TValue>): JSX.Element => {
+export const PlanningTable = <TData, TValue>({ columns, data, onRowSelected }: PlanningTableProps<TData, TValue>): JSX.Element => {
   const [rowSelection, setRowSelection] = useState({})
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({})
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
@@ -41,6 +41,7 @@ export const PlanningTable = <TData, TValue>({ columns, data }: PlanningTablePro
       columnFilters
     },
     enableRowSelection: true,
+    enableMultiRowSelection: false,
     onRowSelectionChange: setRowSelection,
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
@@ -52,6 +53,55 @@ export const PlanningTable = <TData, TValue>({ columns, data }: PlanningTablePro
     getFacetedRowModel: getFacetedRowModel(),
     getFacetedUniqueValues: getFacetedUniqueValues()
   })
+
+  // Handle navigation using arrow keys
+  useEffect(() => {
+    if (!onRowSelected) {
+      return
+    }
+
+    const keyDownHandler = (evt: KeyboardEvent): void => {
+      if (!table || !['ArrowDown', 'ArrowUp', 'Escape'].includes(evt.key)) {
+        return
+      }
+
+      evt.preventDefault()
+      const rows = table.getRowModel().rows
+      if (!rows?.length) {
+        return
+      }
+
+      const selectedRows = table.getSelectedRowModel()
+      const selectedRow = selectedRows?.rows[0]
+
+      if (evt.key === 'Escape') {
+        if (selectedRow) {
+          selectedRow.toggleSelected(false)
+        }
+      } else if (!selectedRow) {
+        const idx = evt.key === 'ArrowDown' ? 0 : rows.length - 1
+        rows[idx].toggleSelected(true)
+      } else {
+        const nextIdx = selectedRow.index + ((evt.key === 'ArrowDown') ? 1 : -1)
+        const idx = nextIdx < 0 ? rows.length - 1 : nextIdx >= rows.length ? 0 : nextIdx
+        rows[idx].toggleSelected(true)
+      }
+    }
+
+    document.addEventListener('keydown', keyDownHandler)
+
+    return () => document.removeEventListener('keydown', keyDownHandler)
+  }, [table, onRowSelected])
+
+
+  // When row selection changes, report back to callback
+  useEffect(() => {
+    if (onRowSelected) {
+      const selectedRows = table.getSelectedRowModel()
+      onRowSelected(selectedRows?.rows[0]?.original)
+    }
+  }, [table, rowSelection, onRowSelected])
+
 
   const TableBodyElement = (): React.ReactNode => {
     if (table.getRowModel().rows?.length === 0) {
@@ -71,6 +121,14 @@ export const PlanningTable = <TData, TValue>({ columns, data }: PlanningTablePro
       <TableRow
         key={row.id}
         data-state={row.getIsSelected() && 'selected'}
+        onClick={(event) => {
+          if (!onRowSelected) {
+            return
+          }
+
+          event.preventDefault()
+          row.toggleSelected(!row.getIsSelected())
+        }}
       >
         {row.getVisibleCells().map((cell) => (
           <TableCell key={cell.id}>

--- a/src/components/PlanningTable/index.tsx
+++ b/src/components/PlanningTable/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React, { useState } from 'react'
 import {
   type ColumnDef,
   type ColumnFiltersState,
@@ -14,12 +14,10 @@ import {
   useReactTable
 } from '@tanstack/react-table'
 
-import {
-  Table, TableBody, TableCell, TableRow
-} from '@ttab/elephant-ui'
-
+import { Table, TableBody, TableCell, TableRow } from '@ttab/elephant-ui'
 import { Pagination } from './Pagination'
 import { Toolbar } from './Toolbar'
+
 
 interface PlanningTableProps<TData, TValue> {
   columns: Array<ColumnDef<TData, TValue>>
@@ -27,17 +25,11 @@ interface PlanningTableProps<TData, TValue> {
 }
 
 
-export const PlanningTable = <TData, TValue>({
-  columns,
-  data
-}: PlanningTableProps<TData, TValue>): JSX.Element => {
-  const [rowSelection, setRowSelection] = React.useState({})
-  const [columnVisibility, setColumnVisibility] =
-    React.useState<VisibilityState>({})
-  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
-    []
-  )
-  const [sorting, setSorting] = React.useState<SortingState>([])
+export const PlanningTable = <TData, TValue>({ columns, data }: PlanningTableProps<TData, TValue>): JSX.Element => {
+  const [rowSelection, setRowSelection] = useState({})
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({})
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
+  const [sorting, setSorting] = useState<SortingState>([])
 
   const table = useReactTable({
     data,
@@ -76,19 +68,19 @@ export const PlanningTable = <TData, TValue>({
     }
 
     return table.getRowModel().rows.map((row) => (
-        <TableRow
-          key={row.id}
-          data-state={row.getIsSelected() && 'selected'}
-        >
-          {row.getVisibleCells().map((cell) => (
-            <TableCell key={cell.id}>
-              {flexRender(
-                cell.column.columnDef.cell,
-                cell.getContext()
-              )}
-            </TableCell>
-          ))}
-        </TableRow>
+      <TableRow
+        key={row.id}
+        data-state={row.getIsSelected() && 'selected'}
+      >
+        {row.getVisibleCells().map((cell) => (
+          <TableCell key={cell.id}>
+            {flexRender(
+              cell.column.columnDef.cell,
+              cell.getContext()
+            )}
+          </TableCell>
+        ))}
+      </TableRow>
     ))
   }
 

--- a/src/components/PlanningTable/index.tsx
+++ b/src/components/PlanningTable/index.tsx
@@ -25,7 +25,11 @@ interface PlanningTableProps<TData, TValue> {
 }
 
 
-export const PlanningTable = <TData, TValue>({ columns, data, onRowSelected }: PlanningTableProps<TData, TValue>): JSX.Element => {
+export const PlanningTable = <TData, TValue>({
+  columns,
+  data,
+  onRowSelected
+}: PlanningTableProps<TData, TValue>): JSX.Element => {
   const [rowSelection, setRowSelection] = useState({})
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({})
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])

--- a/src/views/PlanningOverview/PlanningList.tsx
+++ b/src/views/PlanningOverview/PlanningList.tsx
@@ -43,7 +43,13 @@ export const PlanningList = ({ date }: { date: Date }): JSX.Element => {
   return (
     <>
       {data?.ok === true &&
-        <PlanningTable data={data?.hits} columns={columns} />
+        <PlanningTable data={data?.hits} columns={columns} onRowSelected={(row): void => {
+          if (row) {
+            console.log(`Selected planning item ${row._id}`)
+          } else {
+            console.log('Deselected row')
+          }
+        }} />
       }
     </>
   )


### PR DESCRIPTION
Added initial boilerplate code for navigation up/down in planning list using arrow keys. I removed support for multi line selections to simplify the code. If no callback is provided it is not possible to select rows as it does not make sense to select rows without functionality connected to it.

Would it make more sense to send just the data id back to the callback?