### PR TITLE
Feature/ele 289 use base for serving app

### DIFF
--- a/__tests__/commandMenu.test.tsx
+++ b/__tests__/commandMenu.test.tsx
@@ -22,6 +22,6 @@ describe('CommandMenu', () => {
     await userEvent.keyboard('{Control>}k')
     expect(screen.getByText('Planning overview')).toBeInTheDocument()
     await userEvent.click(screen.getByRole('option'))
-    expect(history.state.itemName).toBe('PlanningOverview')
+    expect(history.state.viewName).toBe('PlanningOverview')
   })
 })

--- a/__tests__/commandMenu.test.tsx
+++ b/__tests__/commandMenu.test.tsx
@@ -13,7 +13,7 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
 describe('CommandMenu', () => {
   it('should render CommandMenu component', async () => {
     render(
-      <SessionProvider endpoint={new URL('/user', 'http://localhost')}>
+      <SessionProvider>
         <NavigationProvider>
           <CommandMenu />
         </NavigationProvider>

--- a/__tests__/link.test.tsx
+++ b/__tests__/link.test.tsx
@@ -8,7 +8,7 @@ import { Link } from '@/components'
 describe('Link', () => {
   it('should render Link component', async () => {
     render(
-      <SessionProvider endpoint={new URL('/user', 'http://localhost')}>
+      <SessionProvider>
         <NavigationProvider>
           <Link to='Editor' props={{ documentId: 'abc123' }}>
             Planning Overview

--- a/__tests__/link.test.tsx
+++ b/__tests__/link.test.tsx
@@ -21,7 +21,7 @@ describe('Link', () => {
     await userEvent.click(screen.getByText('Planning Overview'))
     setTimeout(() => {
       expect(history.state.contentState[0].props.documentId).toBe('abc123')
-      expect(history.state.itemName).toBe('Editor')
+      expect(history.state.viewName).toBe('Editor')
       expect(history.state.contentState[0].path).toBe('/editor?documentId=abc123')
     })
   })

--- a/__tests__/navigation.test.tsx
+++ b/__tests__/navigation.test.tsx
@@ -13,6 +13,6 @@ describe('Use NavigationProvider', () => {
         </NavigationProvider>
       </SessionProvider>
     )
-    expect(await screen.findByText(/AaaBbbCcc/)).toBeInTheDocument()
+    expect(await screen.findByText(/Planeringsöversikt/)).toBeInTheDocument()
   })
 })

--- a/__tests__/navigation.test.tsx
+++ b/__tests__/navigation.test.tsx
@@ -7,7 +7,7 @@ import { render, screen } from '../setupTests'
 describe('Use NavigationProvider', () => {
   it('should render view from registry', async () => {
     render(
-      <SessionProvider endpoint={new URL('/user', 'http://localhost')}>
+      <SessionProvider>
         <NavigationProvider>
           <App />
         </NavigationProvider>

--- a/__tests__/viewFocus.test.tsx
+++ b/__tests__/viewFocus.test.tsx
@@ -26,7 +26,7 @@ const mockDispatch = jest.fn() as Dispatch<NavigationActionType>
 describe('ViewFocus', () => {
   it('should render ViewFocus component', async () => {
     render(
-      <SessionProvider endpoint={new URL('/user', 'http://localhost')}>
+      <SessionProvider>
         <NavigationProvider>
           <ViewFocus id={'abc123'} />
         </NavigationProvider>

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,9 +2,27 @@ import type { JestConfigWithTsJest } from 'ts-jest/dist/types'
 
 const config: JestConfigWithTsJest = {
   testEnvironment: 'jsdom',
-  preset: 'ts-jest',
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
   transform: {
     '^.+\\.tsx?$': ['ts-jest', {
+      diagnostics: {
+        ignoreCodes: [1343]
+      },
+      astTransformers: {
+        before: [
+          {
+            path: 'ts-jest-mock-import-meta',
+            options: {
+              metaObjectReplacement: {
+                env: {
+                  BASE_URL: ''
+                }
+              }
+            }
+          }
+        ]
+      },
+      useESM: true,
       tsconfig: {
         jsx: 'react-jsx'
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "pretty-format": "^29.7.0",
         "tailwindcss": "^3.3.5",
         "ts-jest": "^29.1.1",
+        "ts-jest-mock-import-meta": "^1.1.0",
         "tsx": "^4.1.4",
         "typescript": "^5.0.2",
         "vite": "^5.0.0",
@@ -10865,6 +10866,15 @@
         "esbuild": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ts-jest-mock-import-meta": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ts-jest-mock-import-meta/-/ts-jest-mock-import-meta-1.1.0.tgz",
+      "integrity": "sha512-PTmdWGbDZOPh8vyZUmCTK5PjeD2X3YO25MQPTbm0lMlNFigUDwz3opwXOlsrgD0i5u/MpDX0gdZKoVONxVjVEw==",
+      "dev": true,
+      "peerDependencies": {
+        "ts-jest": ">=20.0.0"
       }
     },
     "node_modules/ts-node": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "node --env-file .env dist/src-srv/index.js",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "tsc": "tsc --noEmit",
-    "test": "tsc --noEmit && jest",
+    "test": "jest",
     "test:coverage": "jest --coverage",
     "preview": "vite preview"
   },
@@ -82,6 +82,7 @@
     "pretty-format": "^29.7.0",
     "tailwindcss": "^3.3.5",
     "ts-jest": "^29.1.1",
+    "ts-jest-mock-import-meta": "^1.1.0",
     "tsx": "^4.1.4",
     "typescript": "^5.0.2",
     "vite": "^5.0.0",

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -5,17 +5,14 @@ export * from '@testing-library/react'
 const JWT = { sub: 'abc', sub_name: 'ABC', units: ['a', 'b', 'c'], scope: 'AbC', access_token: 'xxx' }
 
 function mockUrl(url: string): unknown {
-  const path = new URL(url).pathname
-
-  switch (path) {
-    case '/user':
+  switch (url) {
+    case '/api/user':
       return JSON.stringify(JWT)
 
-    // Fixme: Add and anonymize planning data for mocks
     case '/core_planning_item/_search':
       return planning
     default:
-      throw new Error(`No mock data for ${path}`)
+      throw new Error(`No mock data for ${url}`)
   }
 }
 global.fetch = jest.fn().mockImplementation(async (url: string) => {

--- a/src-srv/index.ts
+++ b/src-srv/index.ts
@@ -17,7 +17,6 @@ const PROTOCOL = (NODE_ENV === 'production') ? 'https' : process.env.VITE_PROTOC
 
 const HOST = process.env.VITE_HOST || '127.0.0.1'
 const PORT = process.env.VITE_PORT ? parseInt(process.env.VITE_PORT) : 5183
-const API_URL = `${PROTOCOL}://${HOST}:${PORT}`
 
 const REPOSITORY_URL = process.env.REPOSITORY_URL
 const JWKS_URL = process.env.JWKS_URL
@@ -45,9 +44,9 @@ async function runServer(): Promise<string> {
     process.env.REDIS_PASSWORD
   )
 
-  if (!await cache.connect()) {
+  /* if (!await cache.connect()) {
     throw new Error('Failed connecting to Redis')
-  }
+  } */
 
   // Connect to repository
   const jwks = createRemoteJWKSet(new URL(JWKS_URL))
@@ -89,8 +88,7 @@ async function runServer(): Promise<string> {
   })
 
   app.listen(PORT)
-
-  return API_URL
+  return `${PROTOCOL}://${HOST}:${PORT}`
 }
 
 (async () => {

--- a/src-srv/index.ts
+++ b/src-srv/index.ts
@@ -46,9 +46,9 @@ async function runServer(): Promise<string> {
     process.env.REDIS_PASSWORD
   )
 
-  /* if (!await cache.connect()) {
+  if (!await cache.connect()) {
     throw new Error('Failed connecting to Redis')
-  } */
+  }
 
   // Connect to repository
   const jwks = createRemoteJWKSet(new URL(JWKS_URL))

--- a/src-srv/index.ts
+++ b/src-srv/index.ts
@@ -21,6 +21,8 @@ const PORT = process.env.VITE_PORT ? parseInt(process.env.VITE_PORT) : 5183
 const REPOSITORY_URL = process.env.REPOSITORY_URL
 const JWKS_URL = process.env.JWKS_URL
 
+const BASE_URL = process.env.BASE_URL || ''
+
 console.info(`Starting API environment "${NODE_ENV}"`)
 
 async function runServer(): Promise<string> {
@@ -72,7 +74,7 @@ async function runServer(): Promise<string> {
   }))
   app.use(cookieParser())
   app.use(express.json())
-  app.use(express.static(distDir))
+  app.use(BASE_URL || '', express.static(distDir))
 
   connectRouteHandlers(app, routes, {
     repository

--- a/src-srv/routes.ts
+++ b/src-srv/routes.ts
@@ -142,7 +142,7 @@ function connectRouteHandler(app: Application, routePath: string, func: RouteHan
     }).catch(ex => {
       console.error(ex)
       res.statusCode = 500
-      res.statusMessage = ex?.message || 'Uknown error'
+      res.statusMessage = ex?.message || 'Unknown error'
       res.send('')
     })
   }

--- a/src-srv/utils/RedisCache.ts
+++ b/src-srv/utils/RedisCache.ts
@@ -17,12 +17,11 @@ export class RedisCache {
   }
 
   get url(): string {
-    const credentials = this.#user && this.#password ? `${this.#user}:${this.#password}@` : ''
-    return `redis://${credentials}${this.#host}:${this.#port}`
+    return `redis://${this.#host}:${this.#port}`
   }
 
   async connect(): Promise<boolean> {
-    const client = createClient({
+    const options = {
       username: this.#user,
       password: this.#password,
       socket: {
@@ -30,7 +29,9 @@ export class RedisCache {
         port: this.#port,
         tls: true
       }
-    })
+    }
+
+    const client = createClient(options.username ? options : { url: this.url })
 
     try {
       const result = await client.connect()

--- a/src-srv/utils/hocuspocus.ts
+++ b/src-srv/utils/hocuspocus.ts
@@ -25,7 +25,7 @@ export async function createServer(options: CreateServerOptions): Promise<Hocusp
     : {}
 
   const server = Server.configure({
-    port: process.env.API_PORT ? parseInt(process.env.API_PORT) : 5183,
+    port: process.env.VITE_PORT ? parseInt(process.env.VITE_PORT) : 5183,
     extensions: [
       new Logger(),
       new Redis({

--- a/src/components/Link/lib/handleLink.ts
+++ b/src/components/Link/lib/handleLink.ts
@@ -53,7 +53,7 @@ export function handleLink({ event, dispatch, viewItem, screens, viewRegistry, p
   history.pushState({
     id,
     props: { ...props, id },
-    itemName: viewItem.meta.name,
+    viewName: viewItem.meta.name,
     contentState: content
   }, viewItem.meta.name, `${viewItem.meta.path}${toQueryString(props)}`)
 }

--- a/src/contexts/ApiProvider.tsx
+++ b/src/contexts/ApiProvider.tsx
@@ -3,34 +3,30 @@ import { HocuspocusProvider, HocuspocusProviderWebsocket } from '@hocuspocus/pro
 
 interface ApiProviderProps {
   children: React.ReactNode
-  apiUrl: URL
   websocketUrl: URL
   indexUrl: URL
 }
 
 export interface ApiProviderState {
-  apiUrl: URL
   websocketUrl: URL
   indexUrl: URL
   hocuspocusWebsocket?: HocuspocusProviderWebsocket
 }
 
 export const ApiProviderContext = createContext<ApiProviderState>({
-  apiUrl: new URL('http://localhost'),
   websocketUrl: new URL('http://localhost'),
   indexUrl: new URL('http://localhost'),
   hocuspocusWebsocket: undefined
 })
 
-export const ApiProvider = ({ children, apiUrl, websocketUrl, indexUrl }: ApiProviderProps): JSX.Element => {
+export const ApiProvider = ({ children, websocketUrl, indexUrl }: ApiProviderProps): JSX.Element => {
   const value = useMemo((): ApiProviderState => {
     return {
-      apiUrl,
       websocketUrl,
       indexUrl,
       hocuspocusWebsocket: new HocuspocusProviderWebsocket({ url: websocketUrl.href })
     }
-  }, [apiUrl, websocketUrl, indexUrl])
+  }, [websocketUrl, indexUrl])
 
   return (
     <ApiProviderContext.Provider value={value}>

--- a/src/contexts/SessionProvider.tsx
+++ b/src/contexts/SessionProvider.tsx
@@ -11,15 +11,14 @@ export const SessionProviderContext = createContext<SessionProviderState>({
   setJwt: () => { }
 })
 
-export const SessionProvider = ({ children, endpoint }: {
+export const SessionProvider = ({ children }: {
   children: React.ReactNode
-  endpoint: URL
 }): JSX.Element => {
   const [jwt, setJwt] = useState<JWT | undefined>(undefined)
 
   useEffect(() => {
     const fetchToken = async (): Promise<void> => {
-      const result = await fetchOrRefreshToken(endpoint.href)
+      const result = await fetchOrRefreshToken()
 
       if (result) {
         setJwt(JSON.parse(result))
@@ -41,7 +40,7 @@ export const SessionProvider = ({ children, endpoint }: {
     return () => {
       clearTimeout(timeoutRef)
     }
-  }, [jwt, endpoint])
+  }, [jwt])
 
   const value: SessionProviderState = {
     jwt,
@@ -61,9 +60,9 @@ export const SessionProvider = ({ children, endpoint }: {
 }
 
 
-async function fetchOrRefreshToken(endpoint: string): Promise<string | undefined> {
+async function fetchOrRefreshToken(): Promise<string | undefined> {
   try {
-    const response = await fetch(`${endpoint}`, {
+    const response = await fetch('/api/user', {
       credentials: 'include'
     })
 

--- a/src/lib/initializeNavigationState.tsx
+++ b/src/lib/initializeNavigationState.tsx
@@ -45,7 +45,8 @@ const viewRegistry = {
 
   getByPath: (path: string): ViewRegistryItem => {
     for (const [, registryItem] of registeredComponents) {
-      if (registryItem.meta.path === path) {
+      // remove trailing slashes
+      if (registryItem.meta.path === path || registryItem.meta.path === path.replace(/\/$/, '')) {
         return registryItem
       }
     }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,17 +8,15 @@ import { RegistryProvider } from './contexts/RegistryProvider.tsx'
 
 banner()
 
-const protocol = import.meta.env.VITE_PROTOCOL
 const host = import.meta.env.VITE_HOST
 const port = import.meta.env.VITE_PORT
 
-const apiUrl = new URL('/api', `${protocol}://${host}:${port}`)
 const websocketUrl = new URL('/ws', `ws://${host}:${port}`)
 const indexUrl = new URL(import.meta.env.VITE_INDEX_URL)
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <SessionProvider endpoint={new URL('/api/user', apiUrl)}>
-    <ApiProvider apiUrl={apiUrl} websocketUrl={websocketUrl} indexUrl={indexUrl}>
+  <SessionProvider>
+    <ApiProvider websocketUrl={websocketUrl} indexUrl={indexUrl}>
       <React.StrictMode>
         <RegistryProvider>
           <ThemeProvider defaultTheme='light' storageKey='ele-ui-theme' >

--- a/src/navigation/components/NavigationProvider/index.tsx
+++ b/src/navigation/components/NavigationProvider/index.tsx
@@ -34,7 +34,7 @@ export const NavigationProvider = ({ children }: PropsWithChildren): JSX.Element
     if (historyState === null) {
       history.replaceState({
         id: 'start',
-        itemName: name,
+        viewName: name,
         contentState: [{
           id: 'start',
           name,

--- a/src/navigation/lib/currentView.tsx
+++ b/src/navigation/lib/currentView.tsx
@@ -1,8 +1,13 @@
 export const currentView = (): { name: string, props: Record<string, string> } => {
   let name = ''
 
-  if (window.location.pathname !== '/') {
-    name = window.location.pathname[1]?.toUpperCase() + window.location.pathname.slice(2)
+  if (window.location.pathname !== import.meta.env.BASE_URL &&
+    window.location.pathname !== import.meta.env.BASE_URL + '/') {
+    const nameFromPath = window.location.pathname
+      .replace(import.meta.env.BASE_URL, '')
+      .replace(/\/$/, '')
+
+    name = nameFromPath[1]?.toUpperCase() + nameFromPath.slice(2)
   } else {
     name = 'PlanningOverview'
   }

--- a/src/navigation/lib/navigationReducer.tsx
+++ b/src/navigation/lib/navigationReducer.tsx
@@ -58,7 +58,7 @@ export function navigationReducer(state: NavigationState, action: NavigationActi
 
       history.replaceState({
         id: action.id,
-        itemName: current.name,
+        viewName: current.name,
         path: current.path,
         contentState: history.state.contentState
       }, current.name, `${window.location.protocol}//${window.location.host}${current.path}`)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -64,7 +64,7 @@ export interface ContentState {
 
 export interface HistoryState {
   id: string
-  itemName: string
+  viewName: string
   props: Record<string, unknown>
   path: string
   type: 'popstate' | 'pushstate' | 'replacestate'

--- a/src/views/Editor/index.tsx
+++ b/src/views/Editor/index.tsx
@@ -12,9 +12,12 @@ import { HocuspocusProvider } from '@hocuspocus/provider'
 import { useSession, useQuery } from '@/hooks'
 import { type ViewMetadata, type ViewProps } from '@/types'
 
+const BASE_URL = import.meta.env.BASE_URL
+  ? import.meta.env.BASE_URL + '/'
+  : '/'
 const meta: ViewMetadata = {
   name: 'Editor',
-  path: '/editor',
+  path: `${BASE_URL}editor`,
   widths: {
     sm: 12,
     md: 12,

--- a/src/views/Editor/index.tsx
+++ b/src/views/Editor/index.tsx
@@ -12,12 +12,9 @@ import { HocuspocusProvider } from '@hocuspocus/provider'
 import { useSession, useQuery } from '@/hooks'
 import { type ViewMetadata, type ViewProps } from '@/types'
 
-const BASE_URL = import.meta.env.BASE_URL
-  ? import.meta.env.BASE_URL + '/'
-  : '/'
 const meta: ViewMetadata = {
   name: 'Editor',
-  path: `${BASE_URL}editor`,
+  path: `${import.meta.env.BASE_URL || ''}/editor`,
   widths: {
     sm: 12,
     md: 12,

--- a/src/views/PlanningOverview/index.tsx
+++ b/src/views/PlanningOverview/index.tsx
@@ -8,10 +8,9 @@ import { Tabs, TabsContent } from '@ttab/elephant-ui'
 import { PlanningGrid } from './PlanningGrid'
 import { PlanningList } from './PlanningList'
 
-const BASE_URL = import.meta.env.BASE_URL || '/'
 const meta: ViewMetadata = {
   name: 'PlanningOverview',
-  path: `${BASE_URL}`,
+  path: import.meta.env.BASE_URL || '/',
   widths: {
     sm: 12,
     md: 12,

--- a/src/views/PlanningOverview/index.tsx
+++ b/src/views/PlanningOverview/index.tsx
@@ -8,10 +8,10 @@ import { Tabs, TabsContent } from '@ttab/elephant-ui'
 import { PlanningGrid } from './PlanningGrid'
 import { PlanningList } from './PlanningList'
 
-
+const BASE_URL = import.meta.env.BASE_URL || '/'
 const meta: ViewMetadata = {
   name: 'PlanningOverview',
-  path: '/',
+  path: `${BASE_URL}`,
   widths: {
     sm: 12,
     md: 12,

--- a/src/views/auth/Login.tsx
+++ b/src/views/auth/Login.tsx
@@ -1,11 +1,9 @@
 import { useState } from 'react'
-import { useApi } from '@/hooks/useApi'
 import { useSession } from '@/hooks'
 
 import { Input, Button } from '@ttab/elephant-ui'
 
 export const Login = (): JSX.Element => {
-  const { apiUrl } = useApi()
   const [user, setUser] = useState<string>('')
   const [password, setPassword] = useState<string>('')
   const { setJwt } = useSession()
@@ -31,12 +29,8 @@ export const Login = (): JSX.Element => {
           <Button
             onClick={(e) => {
               e.preventDefault()
-              if (!apiUrl) {
-                console.log('NO URL')
-                return
-              }
 
-              auth(apiUrl.href, user, password)
+              auth(user, password)
                 .then(async ([status, jwtToken]) => {
                   if (status === 200 && jwtToken) {
                     setJwt(jwtToken)
@@ -63,8 +57,8 @@ export const Login = (): JSX.Element => {
 }
 
 
-async function auth(api: string, user: string, password: string): Promise<[number, string | undefined]> {
-  const response = await fetch(`${api}/user`, {
+async function auth(user: string, password: string): Promise<[number, string | undefined]> {
+  const response = await fetch('/api/user', {
     method: 'post',
     mode: 'cors',
     credentials: 'include',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
       port: 5173,
       strictPort: true,
       proxy: {
-        '/api/*': {
+        '/api': {
           target: `http://${env.VITE_HOST}:${env.VITE_PORT}`,
           changeOrigin: true,
           secure: false

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ import { viteStaticCopy } from 'vite-plugin-static-copy'
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
   return {
+    base: env.BASE_URL,
     plugins: [
       react(),
       viteStaticCopy({


### PR DESCRIPTION
I think this will do.
I've simplified the envs. If we use vite's server.proxy we don't need to care about API_HOSTS and API_PORTS. This is modeled to be as the prod server is running, express serving the bundle.

:crossed_fingers: 