### PR TITLE
Feature/ele 281 enable keyboard navigation in planning list view using

### DIFF
--- a/src/components/PlanningTable/index.tsx
+++ b/src/components/PlanningTable/index.tsx
@@ -16,6 +16,7 @@ import {
 import { Table, TableBody, TableCell, TableRow } from '@ttab/elephant-ui'
 import { Toolbar } from './Toolbar'
 import { useView } from '@/hooks'
+import { isEditableTarget } from '@/lib/isEditableTarget'
 
 interface PlanningTableProps<TData, TValue> {
   columns: Array<ColumnDef<TData, TValue>>
@@ -64,7 +65,7 @@ export const PlanningTable = <TData, TValue>({
     }
 
     const keyDownHandler = (evt: KeyboardEvent): void => {
-      if (!isActiveView) {
+      if (!isActiveView || isEditableTarget(evt)) {
         return
       }
 

--- a/src/lib/isEditableTarget.ts
+++ b/src/lib/isEditableTarget.ts
@@ -1,0 +1,11 @@
+export function isEditableTarget(event: KeyboardEvent): boolean {
+  const target = event?.target as HTMLElement
+
+
+  return !target ||
+    target.isContentEditable ||
+    target.nodeName === 'INPUT' ||
+    target.nodeName === 'TEXTAREA' ||
+    target.nodeName === 'SELECT' ||
+    target.nodeName === 'OPTION'
+}

--- a/src/views/PlanningOverview/PlanningHeader/Datechanger.tsx
+++ b/src/views/PlanningOverview/PlanningHeader/Datechanger.tsx
@@ -1,9 +1,12 @@
 import { ChevronLeft, ChevronRight } from '@ttab/elephant-ui/icons'
 import { DatePicker } from './Datepicker'
 import {
+  useEffect,
   type Dispatch,
   type SetStateAction
 } from 'react'
+import { useView } from '@/hooks'
+import { isEditableTarget } from '@/lib/isEditableTarget'
 
 interface DateChangerProps {
   startDate: Date
@@ -20,7 +23,27 @@ export const DateChanger = ({
   endDate,
   setEndDate
 }: DateChangerProps): JSX.Element => {
+  const { isActive } = useView()
   const steps = !!endDate && !!setEndDate ? 7 : 1
+
+  useEffect(() => {
+    const keyDownHandler = (evt: KeyboardEvent): void => {
+      if (!isActive || isEditableTarget(evt)) {
+        return
+      }
+
+      if (evt.key === 'ArrowLeft') {
+        evt.stopPropagation()
+        setStartDate(decrementDate(startDate, steps))
+      } else if (evt.key === 'ArrowRight') {
+        evt.stopPropagation()
+        setStartDate(incrementDate(startDate, steps))
+      }
+    }
+
+    document.addEventListener('keydown', keyDownHandler)
+    return () => document.removeEventListener('keydown', keyDownHandler)
+  }, [isActive, setStartDate, startDate, steps])
 
   return (
     <div className="flex items-center">


### PR DESCRIPTION
Added date selection with left/right arrow keys. Ignore arrow key navigation when editable fields are event targets (input, select, isContentEditable etc.