### PR TITLE
fix: regression in redis connection string

### DIFF
--- a/src-srv/index.ts
+++ b/src-srv/index.ts
@@ -51,7 +51,7 @@ async function runServer(): Promise<string> {
   }
 
   // Connect to Redis
-  const cache = new RedisCache(process.env.REDIS_URL || 'redis://localhost:6379')
+  const cache = new RedisCache(REDIS_URL)
 
   if (!await cache.connect()) {
     throw new Error('Failed connecting to Redis')

--- a/src-srv/utils/CollaborationServer.ts
+++ b/src-srv/utils/CollaborationServer.ts
@@ -77,7 +77,9 @@ export class CollaborationServer {
       extensions: [
         new Logger(),
         new Redis({
-          options: redisUrl
+          options: {
+            host: redisUrl
+          }
         }),
         new Database({
           fetch: async (payload) => { return await this.#fetchDocument(payload) },


### PR DESCRIPTION
Previous connection works locally since it fallbacks to localhost:6379. But doesn't work when deployed.

Trying what we had initially.