### PR TITLE
fix: published color

### DIFF
--- a/src/components/ui/ComboBox.tsx
+++ b/src/components/ui/ComboBox.tsx
@@ -63,7 +63,7 @@ export const ComboBox = ({
             size={size || 'sm'}
             variant={ variant || 'outline'}
             className={cn(
-              'w-[150px] text-muted-foreground font-sans font-normal whitespace-nowrap',
+              'w-9 h-9 text-muted-foreground font-sans font-normal whitespace-nowrap p-0',
               className
             )
           }>

--- a/src/defaults/documentStatuses.tsx
+++ b/src/defaults/documentStatuses.tsx
@@ -11,9 +11,9 @@ export const DocumentStatuses: DefaultValueOption[] = [
     value: 'published',
     icon: CircleCheck,
     iconProps: {
-      fill: '#4675C8',
+      fill: '#86B0F9',
       color: '#ffffff',
-      className: 'bg-[#4675C8] rounded-full',
+      className: 'bg-[#86B0F9] rounded-full',
       size: 18,
       strokeWidth: 1.75
     }


### PR DESCRIPTION
Due to the fact that lucide doesn't have filled icons we can not reproduce the filled circle published sketch (to my knowledge) using lucide. I've adjusted the color according to the sketches.