### PR TITLE
Add kc_idp_hint to authorization URL

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -1,6 +1,12 @@
 # Environment
 NODE_ENV="development"
 
+# Keycloak configuration
+AUTH_KEYCLOAK_ID=elephant
+AUTH_KEYCLOAK_SECRET="..."
+AUTH_KEYCLOAK_ISSUER="https://..."
+AUTH_KEYCLOAK_IDP_HINT=google
+
 # Google OAuth2 secrets
 GOOGLE_CLIENT_ID="12345..."
 GOOGLE_CLIENT_SECRET="GO..."


### PR DESCRIPTION
A configurable hint value makes it possible to skip the Keycloak login dialog and go directly to the Identity Provider