### PR TITLE
Slugline tab order, improved documentStatus handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@tanstack/react-table": "^8.20.5",
         "@ttab/api-client": "^2.9.1",
         "@ttab/elephant-ui": "^0.2.20",
-        "@ttab/textbit": "^0.14.5",
+        "@ttab/textbit": "^0.14.6",
         "@ttab/textbit-plugins": "^0.3.1",
         "class-variance-authority": "^0.7.0",
         "cookie-parser": "^1.4.6",
@@ -3379,9 +3379,9 @@
       }
     },
     "node_modules/@ttab/textbit": {
-      "version": "0.14.5",
-      "resolved": "https://npm.pkg.github.com/download/@ttab/textbit/0.14.5/8eb3c6806d260f8be3cfd0a2ecf383fb20035cbb",
-      "integrity": "sha512-TjrNAmVyr301h7bqoyEXNmGqg4revvDuACXxqcTrVKTCu3Edc/J9LNUuCdwiVn2x5oOiew/rBe76NOOp3oS+xg==",
+      "version": "0.14.6",
+      "resolved": "https://npm.pkg.github.com/download/@ttab/textbit/0.14.6/293d58faa932a1b25527edec5db7f33042a87270",
+      "integrity": "sha512-U4rxlO6ISqLXeFHs/dDhb4dCF0hxj3zaYLTIkQmChLH4KoFeufbBYNbm/DcLN0yiatqiD0qmbUBE8bnsPxZVSg==",
       "license": "MIT",
       "dependencies": {
         "@slate-yjs/react": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@tanstack/react-table": "^8.20.5",
     "@ttab/api-client": "^2.9.1",
     "@ttab/elephant-ui": "^0.2.20",
-    "@ttab/textbit": "^0.14.5",
+    "@ttab/textbit": "^0.14.6",
     "@ttab/textbit-plugins": "^0.3.1",
     "class-variance-authority": "^0.7.0",
     "cookie-parser": "^1.4.6",

--- a/src/components/DataItem/SluglineEditable.tsx
+++ b/src/components/DataItem/SluglineEditable.tsx
@@ -1,16 +1,17 @@
 import { useState, useRef, useCallback } from 'react'
 import { Awareness } from '@/components'
 import { TextBox } from '../ui'
-import { SluglineButton } from './Slugline'
 import { useYValue } from '@/hooks/useYValue'
 import type * as Y from 'yjs'
+import { SluglineButton } from './Slugline'
 
-export const SluglineEditable = ({ path }: {
+export const SluglineEditable = ({ path, documentStatus }: {
   path: string
+  documentStatus?: string
 }): JSX.Element => {
   const [active, setActive] = useState(false)
   const setFocused = useRef<(value: boolean) => void>(null)
-
+  const [slugLine] = useYValue<Y.XmlText | undefined>(path)
   const setAwareness = useCallback((active: boolean) => {
     if (setFocused?.current) {
       setFocused.current(active)
@@ -18,36 +19,33 @@ export const SluglineEditable = ({ path }: {
     }
   }, [setActive, setFocused])
 
-  return (
-    <Awareness name={`PlanSlugline-${path}`} ref={setFocused}>
-      {active
-        ? <SluglineInput path={path} setActive={setAwareness} />
-        : <div className="pt-1.5"><SluglineButton path={path} setActive={setAwareness} /></div>}
-    </Awareness>
-  )
-}
-
-const SluglineInput = ({ path, setActive }: {
-  path: string
-  setActive: ((value: boolean) => void)
-}): JSX.Element => {
-  const [slugLine] = useYValue<Y.XmlText | undefined>(path)
-
-
   if (typeof slugLine === 'undefined') {
     return <></>
   }
 
-  return <TextBox
-    path={path}
-    placeholder='Lägg till slugg'
-    autoFocus={true}
-    singleLine={true}
-    onBlur={() => {
-      if (setActive) {
-        setActive(false)
+  return (
+    <Awareness name={`PlanSlugline-${path}`} ref={setFocused}>
+      {documentStatus !== 'usable'
+        ? <div className={!active ? 'relative h-6 mt-1.5 ring-1 ring-gray-300 rounded transition-colors hover:bg-gray-100 hover:cursor-pointer' : 'mt-0.5'}>
+          <div className={!active ? 'absolute -top-1 w-full' : ''}>
+            <TextBox
+              path={path}
+              placeholder='Lägg till slugg'
+              singleLine={true}
+              onBlur={() => {
+                setAwareness(false)
+              }}
+              onFocus={() => {
+                setAwareness(true)
+              }}
+              className='pl-2 h-6 font-normal text-sm whitespace-nowrap'
+            />
+          </div>
+        </div>
+        : <div>
+          <SluglineButton path={path} setActive={setAwareness} />
+        </div>
       }
-    }}
-    className="h-7 w-44 p-1.5 font-normal text-sm whitespace-nowrap"
-  />
+    </Awareness>
+  )
 }

--- a/src/components/ui/TextBox.tsx
+++ b/src/components/ui/TextBox.tsx
@@ -10,7 +10,7 @@ import type * as Y from 'yjs'
 import { Text } from '@ttab/textbit-plugins'
 import { useYValue } from '@/hooks/useYValue'
 
-export const TextBox = ({ icon, placeholder, path, className, singleLine = false, autoFocus = false, onBlur }: {
+export const TextBox = ({ icon, placeholder, path, className, singleLine = false, autoFocus = false, onBlur, onFocus }: {
   path: string
   icon?: React.ReactNode
   placeholder?: string
@@ -18,6 +18,7 @@ export const TextBox = ({ icon, placeholder, path, className, singleLine = false
   singleLine?: boolean
   autoFocus?: boolean
   onBlur?: React.FocusEventHandler<HTMLDivElement>
+  onFocus?: React.FocusEventHandler<HTMLDivElement>
 }): JSX.Element => {
   const { provider, user } = useCollaboration()
   const [content] = useYValue<Y.XmlText>(path, { observe: false })
@@ -30,6 +31,7 @@ export const TextBox = ({ icon, placeholder, path, className, singleLine = false
           debounce={0}
           autoFocus={autoFocus}
           onBlur={onBlur}
+          onFocus={onFocus}
           placeholder={placeholder}
           plugins={[Text({
             singleLine,
@@ -97,7 +99,7 @@ const TextboxEditable = ({ provider, user, icon, content }: {
         : <div>
           <Textbit.Editable
             yjsEditor={yjsEditor}
-            className='p-1 py-1.5 -ms-2 ps-2 rounded-sm outline-none ring-offset-background data-[state="focused"]:ring-1 ring-gray-300 data-[state="focused"]:dark:ring-gray-600'
+            className='p-1 py-1.5 -ms-2 ps-2 rounded-sm outline-none ring-offset-background data-[state="focused"]:ring-1 ring-gray-300 data-[state="focused"]:dark:ring-gray-600 whitespace-nowrap'
           />
         </div>
       }

--- a/src/hooks/useDocumentStatus.tsx
+++ b/src/hooks/useDocumentStatus.tsx
@@ -1,0 +1,63 @@
+import { useSession } from 'next-auth/react'
+import useSWR, { mutate as globalMutate } from 'swr'
+import { useCallback } from 'react'
+import { Repository } from '@/lib/repository'
+import { type MetaHead } from '@/lib/repository/metaSearch'
+import { useRegistry } from '@/hooks'
+
+interface Status {
+  name: string
+  version: number
+  documentId: string
+}
+
+type UseDocumentStatusReturn = [Status | undefined, (newStatusName: string) => Promise<void>]
+
+export const useDocumentStatus = (documentId?: string): UseDocumentStatusReturn => {
+  const { server: { repositoryUrl } } = useRegistry()
+  const { data: session } = useSession()
+
+  const { data: documentStatus, mutate } = useSWR(
+    documentId ? [`status/${documentId}`] : null,
+    async () => {
+      if (!session || !repositoryUrl || !documentId) return undefined
+
+      const _meta = await Repository.metaSearch({ session, documentId, repositoryUrl })
+      const version = _meta.meta.current_version
+      const heads: MetaHead = _meta?.meta?.heads
+      const headsEntries = Object.entries(heads)
+      const currentStatus = headsEntries.sort((a, b) => a[1].created > b[1].created ? -1 : 0)[0][0]
+
+      return {
+        version: +version,
+        name: currentStatus,
+        documentId
+      }
+    }
+  )
+
+  const setDocumentStatus = useCallback(
+    async (newStatusName: string) => {
+      if (!session || !documentId || !documentStatus) return
+
+      const newStatus = {
+        ...documentStatus,
+        name: newStatusName
+      }
+
+      // Optimistically update the SWR cache before performing the actual API call
+      await mutate(newStatus, false)
+
+      try {
+        await Repository.update({ session, status: newStatus })
+        // Revalidate after the mutation completes
+        await globalMutate([`status/${documentId}`])
+      } catch (error) {
+        console.error('Failed to update status', error)
+      }
+    },
+    [session, documentId, documentStatus, mutate]
+  )
+
+  return [documentStatus, setDocumentStatus]
+}

--- a/src/views/Planning/components/PlanDocumentStatus.tsx
+++ b/src/views/Planning/components/PlanDocumentStatus.tsx
@@ -1,54 +1,19 @@
 import { Awareness } from '@/components'
 import { ComboBox } from '@/components/ui'
 import { DocumentStatuses } from '@/defaults'
-import { useSession } from 'next-auth/react'
 import { useRef } from 'react'
-import { type DefaultValueOption } from '@/types'
-import { Repository } from '@/lib/repository'
-import useSWR from 'swr'
-import { type MetaHead } from '@/lib/repository/metaSearch'
-import { useRegistry } from '@/hooks'
-
 interface Status {
   name: string
   version: number
   documentId: string
 }
 
-export const PlanDocumentStatus = ({ documentId }: { documentId: string }): JSX.Element => {
-  const { server: { repositoryUrl } } = useRegistry()
-  const { data: documentStatus, mutate } = useSWR([`status/${documentId}`], async () => {
-    const _meta = await Repository.metaSearch({ session, documentId, repositoryUrl })
-    const version = _meta.meta.current_version
-    const heads: MetaHead = _meta?.meta?.heads
-    const headsEntries = Object.entries(heads)
-    const currentStatus = headsEntries.sort((a, b) => a[1].created > b[1].created ? -1 : 0)[0][0]
-    const status = {
-      version: +version,
-      name: currentStatus,
-      documentId
-    }
-    return status
-  })
-  const { data: session } = useSession()
+export const PlanDocumentStatus = ({ status, setStatus }: {
+  status?: Status
+  setStatus: (newStatusName: string) => Promise<void>
+}): JSX.Element => {
   const setFocused = useRef<(value: boolean) => void>(null)
-
-  const selectedOption = DocumentStatuses.find(type => type.value === (documentStatus?.name || 'draft'))
-
-  const handleOnSelect = (option: DefaultValueOption, currentStatus?: Status): void => {
-    (async () => {
-      if (currentStatus?.version) {
-        const selectedStatusName = option.value
-        const newStatus = {
-          name: selectedStatusName,
-          version: currentStatus.version,
-          documentId: currentStatus.documentId
-        }
-        await Repository.update({ session, status: newStatus })
-        await mutate(newStatus, { optimisticData: newStatus, revalidate: false })
-      }
-    })().catch(error => console.error(error))
-  }
+  const selectedOption = DocumentStatuses.find(type => type.value === (status?.name || 'draft'))
 
   return (
     <Awareness name='PlanDocumentStatus' ref={setFocused}>
@@ -57,7 +22,12 @@ export const PlanDocumentStatus = ({ documentId }: { documentId: string }): JSX.
         options={DocumentStatuses}
         variant={'ghost'}
         selectedOption={selectedOption}
-        onSelect={(option) => handleOnSelect(option, documentStatus)}
+        onSelect={(option) => {
+          console.log('setting to ', option.value)
+          if (status?.version) {
+            void setStatus(option.value)
+          }
+        }}
         hideInput
       >
         {selectedOption?.icon

--- a/src/views/Planning/components/PlanDocumentStatus.tsx
+++ b/src/views/Planning/components/PlanDocumentStatus.tsx
@@ -23,7 +23,6 @@ export const PlanDocumentStatus = ({ status, setStatus }: {
         variant={'ghost'}
         selectedOption={selectedOption}
         onSelect={(option) => {
-          console.log('setting to ', option.value)
           if (status?.version) {
             void setStatus(option.value)
           }

--- a/src/views/Planning/index.tsx
+++ b/src/views/Planning/index.tsx
@@ -20,6 +20,7 @@ import { cva } from 'class-variance-authority'
 import { cn } from '@ttab/elephant-ui/utils'
 import { createStateless, StatelessType } from '@/shared/stateless'
 import { useSession } from 'next-auth/react'
+import { useDocumentStatus } from '@/hooks/useDocumentStatus'
 
 const meta: ViewMetadata = {
   name: 'Planning',
@@ -57,6 +58,7 @@ export const Planning = (props: ViewProps & { document?: Y.Doc }): JSX.Element =
 const PlanningViewContent = (props: ViewProps & { documentId: string }): JSX.Element | undefined => {
   const { provider } = useCollaboration()
   const { data, status } = useSession()
+  const [documentStatus, setDocumentStatus] = useDocumentStatus(props.documentId)
 
   const viewVariants = cva('flex flex-col', {
     variants: {
@@ -86,7 +88,7 @@ const PlanningViewContent = (props: ViewProps & { documentId: string }): JSX.Ele
 
           <ViewHeader.Content>
             <div className='flex w-full h-full items-center space-x-2'>
-              <PlanDocumentStatus documentId={props.documentId} />
+              <PlanDocumentStatus status={documentStatus} setStatus={setDocumentStatus} />
               <PlanStatus />
               <PlanNewsvalue />
             </div>
@@ -105,7 +107,12 @@ const PlanningViewContent = (props: ViewProps & { documentId: string }): JSX.Ele
           <div className='flex flex-col gap-2 pl-0.5'>
             <div className='flex space-x-2 items-start'>
               <PlanTitle autoFocus={props.asCreateDialog} />
-              <SluglineEditable path='meta.tt/slugline[0].value' />
+              <div className='min-w-32'>
+                <SluglineEditable
+                  path='meta.tt/slugline[0].value'
+                  documentStatus={documentStatus?.name}
+                />
+              </div>
             </div>
 
             <PlanDescription role="public" />


### PR DESCRIPTION
Tab order for slugline in planning was not working when switching between button and text input. Removed the button and restyled the context of the input to mimick previous behaviour. We should not allow changing slugline on usable planning.

Also added useDocumentStatus() hook that allows both getting and setting the document status much easier.