### PR TITLE
fix: use BASE_URL constant for API fetch requests

### DIFF
--- a/src/components/Table/NewItems/List.tsx
+++ b/src/components/Table/NewItems/List.tsx
@@ -5,6 +5,8 @@ import { type View } from '@/types/index'
 import { CalendarDays } from '@ttab/elephant-ui/icons'
 import useSWR from 'swr'
 
+const BASE_URL = process.env.BASE_URL || ''
+
 export const List = ({ type, createdIdRef }: {
   type: View
   createdIdRef: React.MutableRefObject<string | undefined>
@@ -20,7 +22,7 @@ export const List = ({ type, createdIdRef }: {
   const { data: document, error } = useSWR(
     createdDocument || null,
     async (createdDocument): Promise<EleDocumentResponse> => {
-      const response = await fetch(`${process.env.BASE_URL}/api/documents/${createdDocument.id}`)
+      const response = await fetch(`${BASE_URL}/api/documents/${createdDocument.id}`)
       const result = await response.json()
       return result
     }

--- a/src/components/Table/NewItems/Table.tsx
+++ b/src/components/Table/NewItems/Table.tsx
@@ -14,6 +14,8 @@ import { type View } from '@/types/index'
 import { useRepositoryEvents } from '@/hooks/useRepositoryEvents'
 import { useCallback } from 'react'
 
+const BASE_URL = process.env.BASE_URL || ''
+
 export const Table = ({ type, header }: {
   type: View
   header: string
@@ -28,7 +30,7 @@ export const Table = ({ type, header }: {
     newDocuments?.length ? newDocuments : null,
     async (newDocuments): Promise<EleDocumentResponse[]> => {
       const results = await Promise.all(newDocuments.map(async (newDocument) => {
-        const response = await fetch(`${process.env.BASE_URL}/api/documents/${newDocument.id}`)
+        const response = await fetch(`${BASE_URL}/api/documents/${newDocument.id}`)
         const result = await response.json()
         return result
       }))


### PR DESCRIPTION
Use a BASE_URL constant instead of directly accessing process.env.BASE_URL in fetch requests. Make sure it doesn't return undefined.