### PR TITLE
feat: add createdDocumentIdRef to CreateDocumentDialog

### DIFF
--- a/src/components/View/ViewHeader/CreateDocumentDialog.tsx
+++ b/src/components/View/ViewHeader/CreateDocumentDialog.tsx
@@ -14,9 +14,10 @@ import { type TemplatePayload } from '@/lib/createYItem'
 
 export type Template = keyof typeof Templates
 
-export const CreateDocumentDialog = ({ type, payload, children }: PropsWithChildren<{
+export const CreateDocumentDialog = ({ type, payload, createdDocumentIdRef, children }: PropsWithChildren<{
   type: View
   payload?: TemplatePayload
+  createdDocumentIdRef?: React.MutableRefObject<string | undefined>
 }>): JSX.Element | null => {
   const [document, setDocument] = useState<[string | undefined, Y.Doc | undefined]>([undefined, undefined])
 
@@ -42,7 +43,8 @@ export const CreateDocumentDialog = ({ type, payload, children }: PropsWithChild
                   createDocument(
                     getTemplate(type),
                     true,
-                    payload
+                    payload,
+                    createdDocumentIdRef
                   )
                 )
               }

--- a/src/lib/createYItem.ts
+++ b/src/lib/createYItem.ts
@@ -21,9 +21,16 @@ export function createDocument<T>(
     payload?: T
   ) => Document,
   inProgress?: boolean,
-  payload?: T
+  payload?: T,
+  createdDocumentIdRef?: React.MutableRefObject<string | undefined>
 ): [string, Y.Doc] {
   const documentId = crypto.randomUUID()
+
+  // Set generated documentId to ref so that it can be
+  // accessed from creating component
+  if (createdDocumentIdRef) {
+    createdDocumentIdRef.current = documentId
+  }
 
   const yDoc = new Y.Doc()
 

--- a/src/views/Event/components/PlanningTable.tsx
+++ b/src/views/Event/components/PlanningTable.tsx
@@ -58,6 +58,7 @@ export const PlanningTable = ({ eventId, eventTitle }: {
         <CreateDocumentDialog
           type='Planning'
           payload={{ eventId, eventTitle, createdDocumentIdRef }}
+          createdDocumentIdRef={createdDocumentIdRef}
         >
           <a
             href='#'


### PR DESCRIPTION
- Added `createdDocumentIdRef` prop to `CreateDocumentDialog` component.
- Updated `createDocument` function to set `documentId` to the ref.
- Modified `PlanningTable` to pass `createdDocumentIdRef` to the dialog.