### PR TITLE
feat: add validateStateRef prop to form components

### DIFF
--- a/src/components/Byline.tsx
+++ b/src/components/Byline.tsx
@@ -4,9 +4,11 @@ import { useAuthors, useYValue } from '@/hooks'
 import { Block } from '@ttab/elephant-api/newsdoc'
 import { useRef } from 'react'
 import { Validation } from './Validation'
+import { type ValidateState } from '../types'
 
-export const Byline = ({ onValidation, name }: {
+export const Byline = ({ onValidation, validateStateRef, name }: {
   onValidation?: (block: string, label: string, value: string | undefined, reason: string) => boolean
+  validateStateRef: React.MutableRefObject<ValidateState>
   name?: string
 }): JSX.Element => {
   const allAuthors = useAuthors().map((_) => {
@@ -58,6 +60,7 @@ export const Byline = ({ onValidation, name }: {
           path={path}
           block='core/author'
           onValidation={onValidation}
+          validateStateRef={validateStateRef}
         />
       }
     </Awareness>

--- a/src/components/Byline.tsx
+++ b/src/components/Byline.tsx
@@ -8,7 +8,7 @@ import { type ValidateState } from '../types'
 
 export const Byline = ({ onValidation, validateStateRef, name }: {
   onValidation?: (block: string, label: string, value: string | undefined, reason: string) => boolean
-  validateStateRef: React.MutableRefObject<ValidateState>
+  validateStateRef?: React.MutableRefObject<ValidateState>
   name?: string
 }): JSX.Element => {
   const allAuthors = useAuthors().map((_) => {
@@ -28,41 +28,40 @@ export const Byline = ({ onValidation, validateStateRef, name }: {
 
   return (
     <Awareness name={name || 'Byline'} ref={setFocused} className='flex flex-col gap-2'>
-      <ComboBox
-        size='xs'
-        sortOrder='label'
-        options={allAuthors}
-        selectedOptions={selectedOptions}
-        placeholder={'Lägg till byline'}
-        onOpenChange={(isOpen: boolean) => {
-          if (setFocused?.current) {
-            setFocused.current(isOpen)
-          }
-        }}
-        onSelect={(option) => {
-          if ((authors || [])?.some((a) => a.uuid === option.value)) {
-            setAuthors(authors?.filter((a: Block) => {
-              return a.uuid !== option.value
-            }))
-          } else {
-            setAuthors([...(authors || []), Block.create({
-              type: 'core/author',
-              rel: 'author',
-              uuid: option.value,
-              title: option.label
-            })])
-          }
-        }}
+      <Validation
+        label='Byline'
+        path={path}
+        block='core/author'
+        onValidation={onValidation}
+        validateStateRef={validateStateRef}
+        >
+        <ComboBox
+          size='xs'
+          sortOrder='label'
+          options={allAuthors}
+          selectedOptions={selectedOptions}
+          placeholder={'Lägg till byline'}
+          onOpenChange={(isOpen: boolean) => {
+            if (setFocused?.current) {
+              setFocused.current(isOpen)
+            }
+          }}
+          onSelect={(option) => {
+            if ((authors || [])?.some((a) => a.uuid === option.value)) {
+              setAuthors(authors?.filter((a: Block) => {
+                return a.uuid !== option.value
+              }))
+            } else {
+              setAuthors([...(authors || []), Block.create({
+                type: 'core/author',
+                rel: 'author',
+                uuid: option.value,
+                title: option.label
+              })])
+            }
+          }}
       />
-      {onValidation &&
-        <Validation
-          label='Byline'
-          path={path}
-          block='core/author'
-          onValidation={onValidation}
-          validateStateRef={validateStateRef}
-        />
-      }
+      </Validation>
     </Awareness>
   )
 }

--- a/src/components/DataItem/SluglineEditable.tsx
+++ b/src/components/DataItem/SluglineEditable.tsx
@@ -5,12 +5,13 @@ import { useYValue } from '@/hooks/useYValue'
 import type * as Y from 'yjs'
 import { Validation } from '../Validation'
 import { SluglineButton } from './Slugline'
+import { type FormProps } from '../Form/Root'
 
-export const SluglineEditable = ({ path, documentStatus, onValidation }: {
+export const SluglineEditable = ({ path, documentStatus, onValidation, validateStateRef }: {
   path: string
   documentStatus?: string
   onValidation?: (label: string, block: string, value: string | undefined, reason: string) => boolean
-}): JSX.Element => {
+} & FormProps): JSX.Element => {
   const setFocused = useRef<(value: boolean) => void>(null)
   const [slugLine] = useYValue<Y.XmlText | undefined>(path)
 
@@ -31,6 +32,7 @@ export const SluglineEditable = ({ path, documentStatus, onValidation }: {
               block='tt/slugline'
               path={path}
               onValidation={onValidation}
+              validateStateRef={validateStateRef}
             >
               <TextBox
                 path={path}

--- a/src/components/Form/Content.tsx
+++ b/src/components/Form/Content.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { type FormProps } from './Root'
 import { cva } from 'class-variance-authority'
 
-export const Content = ({ children, asDialog, onValidation }: FormProps): JSX.Element => {
+export const Content = ({ children, asDialog, onValidation, validateStateRef }: FormProps): JSX.Element => {
   const variants = cva('flex flex-col gap-4 items-start',
     {
       variants: {
@@ -19,7 +19,8 @@ export const Content = ({ children, asDialog, onValidation }: FormProps): JSX.El
         React.isValidElement<FormProps>(child)
           ? React.cloneElement(child, {
             asDialog,
-            onValidation
+            onValidation,
+            validateStateRef
           })
           : child
       )}

--- a/src/components/Form/Group.tsx
+++ b/src/components/Form/Group.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { type LucideIcon } from '@ttab/elephant-ui/icons'
 import { type FormProps } from './Root'
 
-export const Group = ({ children, icon: Icon, asDialog, onValidation }: FormProps & {
+export const Group = ({ children, icon: Icon, asDialog, onValidation, validateStateRef }: FormProps & {
   icon?: LucideIcon
 }): JSX.Element => (
 
@@ -29,7 +29,8 @@ export const Group = ({ children, icon: Icon, asDialog, onValidation }: FormProp
         React.isValidElement<FormProps>(child)
           ? React.cloneElement(child, {
             asDialog,
-            onValidation
+            onValidation,
+            validateStateRef
           })
           : child
       )}

--- a/src/components/Form/Root.tsx
+++ b/src/components/Form/Root.tsx
@@ -42,7 +42,6 @@ export const Root = ({ children, asDialog = false, className }: PropsWithChildre
   }
 
   return (
-
     <section>
       <ValidationAlert validateStateRef={validateStateRef} />
       <div className={cn(formRootStyle, className)}>

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -6,7 +6,7 @@ import { useRef } from 'react'
 import { Validation } from './Validation'
 import { type FormProps } from './Form/Root'
 
-export const Section = ({ onValidation }: FormProps): JSX.Element => {
+export const Section = ({ onValidation, validateStateRef }: FormProps): JSX.Element => {
   const allSections = useSections().map((_) => {
     return {
       value: _.id,
@@ -27,6 +27,7 @@ export const Section = ({ onValidation }: FormProps): JSX.Element => {
         path={path}
         block='core/section[0]'
         onValidation={onValidation}
+        validateStateRef={validateStateRef}
       >
         <ComboBox
           max={1}

--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -3,7 +3,7 @@ import { Validation } from './Validation'
 import { type FormProps } from './Form/Root'
 
 
-export const Title = ({ autoFocus, placeholder, path, className, onValidation }: FormProps & {
+export const Title = ({ autoFocus, placeholder, path, className, onValidation, validateStateRef }: FormProps & {
   autoFocus?: boolean
   placeholder: string
   path?: string
@@ -14,6 +14,7 @@ export const Title = ({ autoFocus, placeholder, path, className, onValidation }:
     path={path || 'root.title'}
     block='title'
     onValidation={onValidation}
+    validateStateRef={validateStateRef}
   >
     <TextBox
       path={path || 'root.title'}

--- a/src/components/Validation.tsx
+++ b/src/components/Validation.tsx
@@ -1,13 +1,14 @@
 import { useCollaboration, useYValue } from '@/hooks'
 import { TriangleAlert } from '@ttab/elephant-ui/icons'
-import { type PropsWithChildren, useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
+import { type FormProps } from './Form/Root'
 
-export const Validation = ({ children, path, label, block, onValidation }: PropsWithChildren<{
+export const Validation = ({ children, path, label, block, onValidation, validateStateRef }: {
   path: string
   label: string
   block: string
   onValidation?: (block: string, label: string, value: string | undefined, reason: string) => boolean
-}>): JSX.Element | null => {
+} & FormProps): JSX.Element | null => {
   const [value] = useYValue<string | undefined>(path)
   const { synced } = useCollaboration()
 
@@ -16,6 +17,18 @@ export const Validation = ({ children, path, label, block, onValidation }: Props
       ? onValidation(block, label, value, 'cannot be empty')
       : true
   }, [value, onValidation, label, block])
+
+  useEffect(() => {
+    return () => {
+      if (validateStateRef?.current[block]) {
+        validateStateRef.current = Object.fromEntries(
+          Object.entries(validateStateRef.current)
+            .filter(([key]) => key !== block)
+        )
+      }
+    }
+  }, [block, validateStateRef])
+
 
   return synced && !isValid
     ? <div className="relative flex items-center">

--- a/src/views/Flash/FlashViewContent.tsx
+++ b/src/views/Flash/FlashViewContent.tsx
@@ -232,7 +232,7 @@ export const FlashViewContent = (props: ViewProps & {
                 <TagsIcon size={18} strokeWidth={1.75} className='text-muted-foreground' />
               </div>
 
-              <Byline name='FlashByline' onValidation={handleValidation} />
+              <Byline name='FlashByline' onValidation={handleValidation} validateStateRef={validateStateRef} />
 
               {!selectedPlanning &&
                 <Section onValidation={handleValidation} />


### PR DESCRIPTION
Added validateStateRef prop to various form components to manage validation state references. This change ensures that validation states are properly tracked and cleaned up when components unmount.