### PR TITLE
feat(table): add optional grouping to table rows

### DIFF
--- a/src/components/Table/GroupedRows.tsx
+++ b/src/components/Table/GroupedRows.tsx
@@ -35,7 +35,7 @@ export const GroupedRows = <TData, TValue>({ row, columns, handleOpen, rowRefs }
           key={subRow.id}
           className='flex items-center cursor-default scroll-mt-10'
           data-state={subRow.getIsSelected() && 'selected'}
-          onClick={(event: MouseEvent<HTMLTableRowElement>) => handleOpen(event, subRow) }
+          onClick={(event: MouseEvent<HTMLTableRowElement>) => handleOpen(event, subRow)}
           ref={(el) => {
             if (el) {
               rowRefs.current.set(subRow.id, el)
@@ -43,20 +43,22 @@ export const GroupedRows = <TData, TValue>({ row, columns, handleOpen, rowRefs }
               rowRefs.current.delete(subRow.id)
             }
           }}
-              >
+        >
           {subRow.getVisibleCells().map((cell) => {
-            return <TableCell
-              key={cell.id}
-              className={cn(
-                'first:pl-2 last:pr-2 sm:first:pl-6 sm:last:pr-6',
-                cell.column.columnDef.meta?.className
-              )}
-                    >
-              {flexRender(
-                cell.column.columnDef.cell,
-                cell.getContext()
-              )}
-            </TableCell>
+            return (
+              <TableCell
+                key={cell.id}
+                className={cn(
+                  'first:pl-2 last:pr-2 sm:first:pl-6 sm:last:pr-6',
+                  cell.column.columnDef.meta?.className
+                )}
+              >
+                {flexRender(
+                  cell.column.columnDef.cell,
+                  cell.getContext()
+                )}
+              </TableCell>
+            )
           })}
         </TableRow>
       ))}

--- a/src/components/Table/GroupedRows.tsx
+++ b/src/components/Table/GroupedRows.tsx
@@ -1,0 +1,65 @@
+import { type ColumnDef, flexRender, type Row } from '@tanstack/react-table'
+import { TableRow, TableCell } from '@ttab/elephant-ui'
+import { cn } from '@ttab/elephant-ui/utils'
+import React, { type MouseEvent } from 'react'
+
+export const GroupedRows = <TData, TValue>({ row, columns, handleOpen, rowRefs }: {
+  row: Row<unknown>
+  columns: Array<ColumnDef<TData, TValue>>
+  handleOpen: (event: MouseEvent<HTMLTableRowElement> | KeyboardEvent, subRow: Row<unknown>) => void
+  rowRefs: React.MutableRefObject<Map<string, HTMLTableRowElement>>
+}): JSX.Element => {
+  return (
+    <React.Fragment key={row.id}>
+      <TableRow className='sticky top-0 bg-muted'>
+        <TableCell colSpan={columns.length} className='pl-6 px-2 py-1 border-b'>
+          <div className='flex justify-between items-center flex-wrap'>
+            <div className='flex items-center space-x-2'>
+              <span className='font-thin text-muted-foreground'>Nyhetsvärde</span>
+              <span className='inline-flex items-center justify-center size-5 bg-background rounded-full ring-1 ring-gray-300'>
+                {row.groupingValue as string}
+              </span>
+            </div>
+            <div className='flex items-center space-x-2 px-6'>
+              <span className='font-thin text-muted-foreground'>Antal</span>
+              <span className='inline-flex items-center justify-center size-5 bg-background rounded-full ring-1 ring-gray-300'>
+                {row.subRows.length}
+              </span>
+            </div>
+          </div>
+        </TableCell>
+      </TableRow>
+
+      {row.subRows.map((subRow) => (
+        <TableRow
+          key={subRow.id}
+          className='flex items-center cursor-default scroll-mt-10'
+          data-state={subRow.getIsSelected() && 'selected'}
+          onClick={(event: MouseEvent<HTMLTableRowElement>) => handleOpen(event, subRow) }
+          ref={(el) => {
+            if (el) {
+              rowRefs.current.set(subRow.id, el)
+            } else {
+              rowRefs.current.delete(subRow.id)
+            }
+          }}
+              >
+          {subRow.getVisibleCells().map((cell) => {
+            return <TableCell
+              key={cell.id}
+              className={cn(
+                'first:pl-2 last:pr-2 sm:first:pl-6 sm:last:pr-6',
+                cell.column.columnDef.meta?.className
+              )}
+                    >
+              {flexRender(
+                cell.column.columnDef.cell,
+                cell.getContext()
+              )}
+            </TableCell>
+          })}
+        </TableRow>
+      ))}
+    </React.Fragment>
+  )
+}

--- a/src/components/Table/Rows.tsx
+++ b/src/components/Table/Rows.tsx
@@ -1,0 +1,39 @@
+import { type MouseEvent } from 'react'
+import { flexRender, type Row } from '@tanstack/react-table'
+import { TableRow, TableCell } from '@ttab/elephant-ui'
+import { cn } from '@ttab/elephant-ui/utils'
+
+export const Rows = ({ row, handleOpen, rowRefs }: {
+  row: Row<unknown>
+  handleOpen: (event: MouseEvent<HTMLTableRowElement>, row: Row<unknown>) => void
+  rowRefs: React.MutableRefObject<Map<string, HTMLTableRowElement>>
+}): JSX.Element => {
+  return <TableRow
+    key={row.id}
+    className='flex items-center cursor-default scroll-mt-10'
+    data-state={row.getIsSelected() && 'selected'}
+    onClick={(event: MouseEvent<HTMLTableRowElement>) => handleOpen(event, row) }
+    ref={(el) => {
+      if (el) {
+        rowRefs.current.set(row.id, el)
+      } else {
+        rowRefs.current.delete(row.id)
+      }
+    }}
+        >
+    {row.getVisibleCells().map((cell) => {
+      return <TableCell
+        key={cell.id}
+        className={cn(
+          'first:pl-2 last:pr-2 sm:first:pl-6 sm:last:pr-6',
+          cell.column.columnDef.meta?.className
+        )}
+              >
+        {flexRender(
+          cell.column.columnDef.cell,
+          cell.getContext()
+        )}
+      </TableCell>
+    })}
+  </TableRow>
+}

--- a/src/components/Table/Rows.tsx
+++ b/src/components/Table/Rows.tsx
@@ -8,32 +8,36 @@ export const Rows = ({ row, handleOpen, rowRefs }: {
   handleOpen: (event: MouseEvent<HTMLTableRowElement>, row: Row<unknown>) => void
   rowRefs: React.MutableRefObject<Map<string, HTMLTableRowElement>>
 }): JSX.Element => {
-  return <TableRow
-    key={row.id}
-    className='flex items-center cursor-default scroll-mt-10'
-    data-state={row.getIsSelected() && 'selected'}
-    onClick={(event: MouseEvent<HTMLTableRowElement>) => handleOpen(event, row) }
-    ref={(el) => {
-      if (el) {
-        rowRefs.current.set(row.id, el)
-      } else {
-        rowRefs.current.delete(row.id)
-      }
-    }}
-        >
-    {row.getVisibleCells().map((cell) => {
-      return <TableCell
-        key={cell.id}
-        className={cn(
-          'first:pl-2 last:pr-2 sm:first:pl-6 sm:last:pr-6',
-          cell.column.columnDef.meta?.className
-        )}
-              >
-        {flexRender(
-          cell.column.columnDef.cell,
-          cell.getContext()
-        )}
-      </TableCell>
-    })}
-  </TableRow>
+  return (
+    <TableRow
+      key={row.id}
+      className='flex items-center cursor-default scroll-mt-10'
+      data-state={row.getIsSelected() && 'selected'}
+      onClick={(event: MouseEvent<HTMLTableRowElement>) => handleOpen(event, row)}
+      ref={(el) => {
+        if (el) {
+          rowRefs.current.set(row.id, el)
+        } else {
+          rowRefs.current.delete(row.id)
+        }
+      }}
+    >
+      {row.getVisibleCells().map((cell) => {
+        return (
+          <TableCell
+            key={cell.id}
+            className={cn(
+              'first:pl-2 last:pr-2 sm:first:pl-6 sm:last:pr-6',
+              cell.column.columnDef.meta?.className
+            )}
+          >
+            {flexRender(
+              cell.column.columnDef.cell,
+              cell.getContext()
+            )}
+          </TableCell>
+        )
+      })}
+    </TableRow>
+  )
 }

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -27,7 +27,7 @@ import { Rows } from './Rows'
 
 interface TableProps<TData, TValue> {
   columns: Array<ColumnDef<TData, TValue>>
-  type: 'Planning' | 'Event' | 'Assignments' | 'Wires'
+  type: 'Planning' | 'Event' | 'Assignments'
   onRowSelected?: (row?: TData) => void
 }
 

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   type MouseEvent,
   useEffect,
   useCallback,
@@ -8,7 +8,6 @@ import React, {
 } from 'react'
 import {
   type ColumnDef,
-  flexRender,
   type Row
 } from '@tanstack/react-table'
 
@@ -21,13 +20,14 @@ import {
 import { Toolbar } from './Toolbar'
 import { useNavigation, useView, useTable } from '@/hooks'
 import { isEditableTarget } from '@/lib/isEditableTarget'
-import { cn } from '@ttab/elephant-ui/utils'
 import { handleLink } from '@/components/Link/lib/handleLink'
 import { NewItems } from './NewItems'
+import { GroupedRows } from './GroupedRows'
+import { Rows } from './Rows'
 
 interface TableProps<TData, TValue> {
   columns: Array<ColumnDef<TData, TValue>>
-  type: 'Planning' | 'Event' | 'Assignments'
+  type: 'Planning' | 'Event' | 'Assignments' | 'Wires'
   onRowSelected?: (row?: TData) => void
 }
 
@@ -156,65 +156,12 @@ export const Table = <TData, TValue>({
       )
     }
 
-    return deferredRows.map((row) => {
-      return (
-        <React.Fragment key={row.id}>
-          <TableRow className='sticky top-0 bg-muted'>
-            <TableCell colSpan={columns.length} className='pl-6 px-2 py-1 border-b'>
-              <div className='flex justify-between items-center flex-wrap'>
-                <div className='flex items-center space-x-2'>
-                  <span className='font-thin text-muted-foreground'>Nyhetsvärde</span>
-                  <span className='inline-flex items-center justify-center size-5 bg-background rounded-full ring-1 ring-gray-300'>
-                    {row.groupingValue as string}
-                  </span>
-                </div>
-                <div className='flex items-center space-x-2 px-6'>
-                  <span className='font-thin text-muted-foreground'>Antal</span>
-                  <span className='inline-flex items-center justify-center size-5 bg-background rounded-full ring-1 ring-gray-300'>
-                    {row.subRows.length}
-                  </span>
-                </div>
-              </div>
-            </TableCell>
-          </TableRow>
-
-          {row.subRows.map((subRow) => (
-            <TableRow
-              key={subRow.id}
-              className='flex items-center cursor-default scroll-mt-10'
-              data-state={subRow.getIsSelected() && 'selected'}
-              onClick={(event: MouseEvent<HTMLTableRowElement>) => handleOpen(event, subRow)}
-              ref={(el) => {
-                if (el) {
-                  rowRefs.current.set(subRow.id, el)
-                } else {
-                  rowRefs.current.delete(subRow.id)
-                }
-              }}
-            >
-              {subRow.getVisibleCells().map((cell) => {
-                return (
-                  <TableCell
-                    key={cell.id}
-                    className={cn(
-                      'first:pl-2 last:pr-2 sm:first:pl-6 sm:last:pr-6',
-                      cell.column.columnDef.meta?.className
-                    )}
-                  >
-                    {flexRender(
-                      cell.column.columnDef.cell,
-                      cell.getContext()
-                    )}
-                  </TableCell>
-                )
-              })}
-            </TableRow>
-          ))}
-        </React.Fragment>
-      )
-    })
-  }, [deferredRows, columns.length, deferredLoading, handleOpen])
-
+    return deferredRows.map((row, index) => (
+      table.getState().grouping.length)
+      ? <GroupedRows<TData, TValue> key={index} row={row} columns={columns} handleOpen={handleOpen} rowRefs={rowRefs} />
+      : <Rows key={index} row={row} handleOpen={handleOpen} rowRefs={rowRefs} />
+    )
+  }, [deferredRows, columns, deferredLoading, handleOpen, table])
 
   return (
     <>

--- a/src/contexts/TableProvider.tsx
+++ b/src/contexts/TableProvider.tsx
@@ -60,6 +60,7 @@ export const TableProvider = <T,>({
   const [pages, setPages] = useState<string[]>([])
   const page = pages[pages.length - 1]
   const [search, setSearch] = useState<string | undefined>()
+  const [grouping, setGrouping] = useState<string[]>([])
 
   const command = useMemo(() => ({
     pages,
@@ -77,12 +78,13 @@ export const TableProvider = <T,>({
       columnVisibility,
       rowSelection,
       columnFilters,
-      grouping: ['newsvalue']
+      grouping
     },
     enableRowSelection: true,
     enableMultiRowSelection: false,
     enableSubRowSelection: true,
     onRowSelectionChange: setRowSelection,
+    onGroupingChange: setGrouping,
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
     onColumnVisibilityChange: setColumnVisibility,

--- a/src/views/Assignments/AssignmentsList.tsx
+++ b/src/views/Assignments/AssignmentsList.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import useSWR from 'swr'
 import { useAuthors, useIndexUrl, useTable, useRegistry } from '@/hooks'
 import { useSession } from 'next-auth/react'
@@ -67,6 +67,12 @@ export const AssignmentsList = ({ startDate }: { startDate: string }): JSX.Eleme
     })
     setData(items)
   })
+
+  const { table } = useTable()
+
+  useEffect(() => {
+    table.setGrouping(['newsvalue'])
+  }, [table])
 
   return (
     <Table

--- a/src/views/EventsOverview/EventsList.tsx
+++ b/src/views/EventsOverview/EventsList.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import useSWR from 'swr'
 
-import { useSections } from '@/hooks'
+import { useSections, useTable } from '@/hooks'
 import { type Event } from '@/lib/index/schemas'
 import { eventTableColumns } from '@/views/EventsOverview/EventsListColumns'
 
@@ -13,8 +13,13 @@ export const EventsList = ({ from, to }: {
 }): JSX.Element => {
   const sections = useSections()
 
-  const { error } = useSWR(['Events', from, to, { withPlannings: true }])
+  const { error } = useSWR<Event[], Error>(['Events', from, to, { withPlannings: true }])
   const columns = useMemo(() => eventTableColumns({ sections }), [sections])
+  const { table } = useTable()
+
+  useEffect(() => {
+    table.setGrouping(['newsvalue'])
+  }, [table])
 
   const onRowSelected = useCallback((row?: Event) => {
     if (row) {

--- a/src/views/PlanningOverview/PlanningList.tsx
+++ b/src/views/PlanningOverview/PlanningList.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import useSWR from 'swr'
-import { useSections } from '@/hooks'
+import { useSections, useTable } from '@/hooks'
 import {
   type Planning
 } from '@/lib/index'
@@ -14,9 +14,14 @@ export const PlanningList = ({ from, to }: {
 }): JSX.Element => {
   const sections = useSections()
 
-
-  const { error } = useSWR(['Plannings', from, to, { withStatus: true }])
+  const { error } = useSWR<Planning[], Error>(['Plannings', from, to, { withStatus: true }])
   const columns = useMemo(() => planningTableColumns({ sections }), [sections])
+
+  const { table } = useTable()
+
+  useEffect(() => {
+    table.setGrouping(['newsvalue'])
+  }, [table])
 
   const onRowSelected = useCallback((row?: Planning) => {
     if (row) {


### PR DESCRIPTION
- Introduced `GroupedRows` and `Rows` components to handle grouped and non-grouped rows respectively.
- Updated `Table` component to use the new row components based on grouping state.
- Added `grouping` state and `onGroupingChange` handler in `TableProvider`.
- Set default grouping to 'newsvalue' in `AssignmentsList`, `EventsList`, and `PlanningList` components.