### PR TITLE
fix(navigation): onDocumentCreated handling

### DIFF
--- a/src/components/Link/lib/handleLink.ts
+++ b/src/components/Link/lib/handleLink.ts
@@ -63,6 +63,20 @@ export function handleLink({
     content.splice(currentIndex + 1, Infinity, newContent)
   }
 
+  // Listen for when the change has been done and then add onDocumentCreated callback
+  // to the navigation state as we can't store functions in history state.
+  window.addEventListener('popstate', () => {
+    const currentIndex = content.findIndex((c) => c.viewId === viewId)
+    content[currentIndex].props = { ...content[currentIndex].props, onDocumentCreated }
+
+    dispatch({
+      viewId,
+      content,
+      type: NavigationActionType.ON_DOC_CREATED,
+      callback: onDocumentCreated
+    })
+  }, { once: true })
+
   // Push new history state
   history.pushState(`${viewItem.meta.path}${toQueryString(props)}`, {
     viewId,
@@ -72,17 +86,4 @@ export function handleLink({
   if (!onDocumentCreated) {
     return
   }
-
-  // Listen for when the change has been done and then add onDocumentCreated callback
-  // to the navigation state as we can't store functions in history state.
-  window.addEventListener('popstate', () => {
-    const currentIndex = content.findIndex((c) => c.viewId === viewId)
-    content[currentIndex].props = { ...content[currentIndex].props, onDocumentCreated }
-
-    dispatch({
-      viewId,
-      type: NavigationActionType.ON_DOC_CREATED,
-      callback: onDocumentCreated
-    })
-  }, { once: true })
 }

--- a/src/navigation/lib/navigationReducer.tsx
+++ b/src/navigation/lib/navigationReducer.tsx
@@ -7,7 +7,6 @@ import {
 export function navigationReducer(prevState: NavigationState, action: NavigationAction): NavigationState {
   switch (action.type) {
     case NavigationActionType.SET: {
-      console.log('NAVIGATION.SET')
       if (action.content === undefined) {
         throw new Error('Content is undefined')
       }

--- a/src/navigation/lib/navigationReducer.tsx
+++ b/src/navigation/lib/navigationReducer.tsx
@@ -7,6 +7,7 @@ import {
 export function navigationReducer(prevState: NavigationState, action: NavigationAction): NavigationState {
   switch (action.type) {
     case NavigationActionType.SET: {
+      console.log('NAVIGATION.SET')
       if (action.content === undefined) {
         throw new Error('Content is undefined')
       }
@@ -42,19 +43,9 @@ export function navigationReducer(prevState: NavigationState, action: Navigation
     }
 
     case NavigationActionType.ON_DOC_CREATED: {
-      const nextState = { ...prevState }
-      nextState.content.forEach((content) => {
-        if (content.viewId === action.viewId) {
-          const props = content.props || {}
-          content.props = {
-            ...props,
-            onDocumentCreated: action.callback
-          }
-        }
-      })
-
       return {
         ...prevState,
+        content: action.content || prevState.content,
         active: action.viewId
       }
     }


### PR DESCRIPTION
Fixed the handling of onDocumentCreated callback in handleLink and navigationReducer. Moved the history.pushState call to the end of the handleLink function and updated the navigationReducer to set the content and active viewId directly.