### PR TITLE
fix(wires): recreate editor on new wire preview

### DIFF
--- a/src/components/PlainEditor.tsx
+++ b/src/components/PlainEditor.tsx
@@ -10,17 +10,21 @@ const BASE_URL = import.meta.env.BASE_URL || ''
 
 const plugins = [Text, UnorderedList, OrderedList, Bold, Italic, Link, TTVisual, Factbox, Table]
 
-export const Editor = ({ id }: { id: string }): JSX.Element => {
-  const fetcher = async (): Promise<EleDocumentResponse> => {
-    const response = await fetch(`${BASE_URL}/api/documents/${id}`)
-    if (!response.ok) {
-      throw new Error('Network response was not ok')
-    }
-    const result = await response.json() as EleDocumentResponse
-    return result
+const fetcher = async (url: string): Promise<TBElement[] | undefined> => {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error('Network response was not ok')
   }
+  const result = await response.json() as EleDocumentResponse
+  return result.document?.content
+}
 
-  const { data: document, error } = useSWR<EleDocumentResponse, Error>(id, fetcher)
+export const Editor = ({ id }: { id: string }): JSX.Element => {
+  const { data: content, error } = useSWR<TBElement[] | undefined, Error>(
+    `${BASE_URL}/api/documents/${id}`,
+    fetcher,
+    { revalidateOnFocus: false, revalidateOnReconnect: false }
+  )
 
   if (error) return <div>Failed to load</div>
   if (!document) return (
@@ -33,8 +37,9 @@ export const Editor = ({ id }: { id: string }): JSX.Element => {
     <div className='flex-grow overflow-auto max-w-screen-lg mx-auto'>
       <Textbit.Root plugins={plugins.map((initPlugin) => initPlugin())}>
         <Textbit.Editable
+          key={id}
           readOnly
-          value={document.document?.content as TBElement[]}
+          value={content}
           className='outline-none pb-6 max-h-[30vh] overflow-y-scroll dark:text-slate-100 px-2'
         />
       </Textbit.Root>


### PR DESCRIPTION
This solves the problem, but I suspect that there's something that should be handled in `Textbit`. :thinking: 
There's some `caching` `memoization` taking place.