### PR TITLE
Remove flex on View root as it is unnecessary and mess with header height

### DIFF
--- a/src/components/View/Root.tsx
+++ b/src/components/View/Root.tsx
@@ -9,7 +9,7 @@ export const Root = ({ children, className, tab, onTabChange, asDialog = false }
   tab?: string
   onTabChange?: Dispatch<SetStateAction<string>>
 } & PropsWithChildren): JSX.Element => {
-  const variants = cva('flex flex-col', {
+  const variants = cva('', {
     variants: {
       asDialog: {
         true: '',


### PR DESCRIPTION
Children are not using flex attributes and it makes the header size not right sometimes.