### PR TITLE
feat(locale): implement dynamic locale handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "escape-html": "^1.0.3",
         "express": "^4.21.2",
         "express-ws": "^5.0.2",
-        "get-user-locale": "^2.3.2",
+        "get-user-locale": "^3.0.0",
         "lodash-es": "^4.17.21",
         "next-auth": "^5.0.0-beta.25",
         "node-html-parser": "^7.0.1",
@@ -5803,9 +5803,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001697",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz",
-      "integrity": "sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==",
+      "version": "1.0.30001712",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001712.tgz",
+      "integrity": "sha512-MBqPpGYYdQ7/hfKiet9SCI+nmN5/hp4ZzveOJubl5DTAMa5oggjAuoi0Z4onBpKPFI2ePGnQuQIzF3VxDjDJig==",
       "funding": [
         {
           "type": "opencollective",
@@ -5819,7 +5819,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "5.2.0",
@@ -7704,11 +7705,12 @@
       }
     },
     "node_modules/get-user-locale": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-2.3.2.tgz",
-      "integrity": "sha512-O2GWvQkhnbDoWFUJfaBlDIKUEdND8ATpBXD6KXcbhxlfktyD/d8w6mkzM/IlQEqGZAMz/PW6j6Hv53BiigKLUQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-3.0.0.tgz",
+      "integrity": "sha512-iJfHSmdYV39UUBw7Jq6GJzeJxUr4U+S03qdhVuDsR9gCEnfbqLy9gYDJFBJQL1riqolFUKQvx36mEkp2iGgJ3g==",
+      "license": "MIT",
       "dependencies": {
-        "mem": "^8.0.0"
+        "memoize": "^10.0.0"
       },
       "funding": {
         "url": "https://github.com/wojtekmaj/get-user-locale?sponsor=1"
@@ -9375,17 +9377,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "dependencies": {
-        "p-defer": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -9402,19 +9393,19 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/mem": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
-      "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
+    "node_modules/memoize": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/memoize/-/memoize-10.1.0.tgz",
+      "integrity": "sha512-MMbFhJzh4Jlg/poq1si90XRlTZRDHVqdlz2mPyGJ6kqMpyHUyVpDd5gpFAvVehW64+RA1eKE9Yt8aSLY7w2Kgg==",
+      "license": "MIT",
       "dependencies": {
-        "map-age-cleaner": "^0.1.3",
-        "mimic-fn": "^3.1.0"
+        "mimic-function": "^5.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
-        "url": "https://github.com/sindresorhus/mem?sponsor=1"
+        "url": "https://github.com/sindresorhus/memoize?sponsor=1"
       }
     },
     "node_modules/merge-descriptors": {
@@ -9494,12 +9485,16 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/mimic-fn": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -9953,14 +9948,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/p-limit": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "escape-html": "^1.0.3",
     "express": "^4.21.2",
     "express-ws": "^5.0.2",
-    "get-user-locale": "^2.3.2",
+    "get-user-locale": "^3.0.0",
     "lodash-es": "^4.17.21",
     "next-auth": "^5.0.0-beta.25",
     "node-html-parser": "^7.0.1",

--- a/shared/getLocaleData.ts
+++ b/shared/getLocaleData.ts
@@ -1,0 +1,26 @@
+import type { Locale } from 'date-fns'
+import { getUserLocale } from 'get-user-locale'
+import type { LocaleData } from '@/types'
+import { defaultLocale } from '@/defaults/locale'
+
+export { defaultLocale } from '@/defaults/locale'
+
+export const getLocaleData = async (): Promise<LocaleData> => {
+  const full = getUserLocale() || defaultLocale.code.full
+  const [short] = full.split('-')
+  const long = full.replace('-', '')
+
+  try {
+    const { default: module } = await import(
+      `../node_modules/date-fns/locale/${full}.js`
+    ) as { default: Locale }
+    return {
+      module,
+      code: { short, long, full }
+    }
+  } catch (_) {
+    console.warn(`Locale module for "${full}" not found. Falling back to default.`)
+    return defaultLocale
+  }
+}
+

--- a/shared/getLocaleData.ts
+++ b/shared/getLocaleData.ts
@@ -1,13 +1,13 @@
 import type { Locale } from 'date-fns'
-import { getUserLocale } from 'get-user-locale'
+import { getUserLocales } from 'get-user-locale'
 import type { LocaleData } from '@/types'
 import { defaultLocale } from '@/defaults/locale'
 
 export { defaultLocale } from '@/defaults/locale'
 
 export const getLocaleData = async (): Promise<LocaleData> => {
-  const full = getUserLocale() || defaultLocale.code.full
-  const [short] = full.split('-')
+  const [full, short] = getUserLocales() || defaultLocale.code.full
+  // Without -, ie enGB
   const long = full.replace('-', '')
 
   try {

--- a/src/components/AssignmentTime/ExecutionTimeMenu.tsx
+++ b/src/components/AssignmentTime/ExecutionTimeMenu.tsx
@@ -160,8 +160,8 @@ export const ExecutionTimeMenu = ({ handleOnSelect, index, startDate }: Executio
           {timePickType.icon && <timePickType.icon {...timePickType.iconProps} />}
           {
             hasEndTime
-              ? <FromToDateTimeLabel fromDate={startDateValue} toDate={endDateValue} locale={locale} timeZone={timeZone} />
-              : <FromDateTimeLabel fromDate={startDateValue} locale={locale} timeZone={timeZone} />
+              ? <FromToDateTimeLabel fromDate={startDateValue} toDate={endDateValue} locale={locale.code.full} timeZone={timeZone} />
+              : <FromDateTimeLabel fromDate={startDateValue} locale={locale.code.full} timeZone={timeZone} />
           }
         </div>
       </PopoverTrigger>
@@ -177,7 +177,7 @@ export const ExecutionTimeMenu = ({ handleOnSelect, index, startDate }: Executio
           />
           <div className='flex justify-between border-2 rounded-md border-slate-100'>
             <div className='px-3 py-2 text-sm'>
-              {startDateValue && dateToReadableDateTime(new Date(startDateValue), locale, timeZone)}
+              {startDateValue && dateToReadableDateTime(new Date(startDateValue), locale.code.full, timeZone)}
             </div>
             <div>
               <TimeInput
@@ -195,7 +195,7 @@ export const ExecutionTimeMenu = ({ handleOnSelect, index, startDate }: Executio
             </div>
             <div className='flex justify-between border-2 rounded-md border-slate-100'>
               <div className='px-3 py-2 text-sm'>
-                {(hasEndTime && endDateValue) && dateToReadableDateTime(new Date(endDateValue), locale, timeZone)}
+                {(hasEndTime && endDateValue) && dateToReadableDateTime(new Date(endDateValue), locale.code.full, timeZone)}
               </div>
               <div>
                 <TimeInput

--- a/src/components/DataItem/TimeDisplay.tsx
+++ b/src/components/DataItem/TimeDisplay.tsx
@@ -7,7 +7,7 @@ export const TimeDisplay = ({ date, className }: { date: Date, className?: strin
 
   return (
     <span className={cn('font-medium text-sm', className)}>
-      {dateToReadableTime(date, locale, timeZone) || '-'}
+      {dateToReadableTime(date, locale.code.full, timeZone) || '-'}
     </span>
   )
 }

--- a/src/components/Datepicker.tsx
+++ b/src/components/Datepicker.tsx
@@ -21,14 +21,14 @@ export const DatePicker = ({ date, changeDate, setDate, forceYear = false }: {
 }): JSX.Element => {
   const { locale, timeZone } = useRegistry()
 
-  const formattedDate = new Intl.DateTimeFormat(locale, {
+  const formattedDate = new Intl.DateTimeFormat(locale.code.full, {
     weekday: 'short',
     month: 'short',
     day: 'numeric',
     timeZone
   }).format(date)
 
-  const longFormattedDate = new Intl.DateTimeFormat(locale, {
+  const longFormattedDate = new Intl.DateTimeFormat(locale.code.full, {
     weekday: 'short',
     month: 'short',
     day: 'numeric',

--- a/src/components/Table/Items/Time.tsx
+++ b/src/components/Table/Items/Time.tsx
@@ -7,13 +7,13 @@ export const Time = ({ startTime, endTime }: { startTime?: Date | undefined, end
     if (!startTime || !endTime) {
       return <></>
     }
-    const formattedStartTime = new Intl.DateTimeFormat(locale, {
+    const formattedStartTime = new Intl.DateTimeFormat(locale.code.full, {
       hour: 'numeric',
       minute: 'numeric',
       timeZone
     }).format(startTime)
 
-    const formattedEndTime = new Intl.DateTimeFormat(locale, {
+    const formattedEndTime = new Intl.DateTimeFormat(locale.code.full, {
       hour: 'numeric',
       minute: 'numeric',
       timeZone

--- a/src/components/Version/components/index.tsx
+++ b/src/components/Version/components/index.tsx
@@ -47,14 +47,14 @@ export const Description = ({ descriptions }: { descriptions: Array<{ text: stri
 }
 
 export const Dates = ({ planningDate, eventDate }: { planningDate?: AssignmentData, eventDate?: AssignmentData }) => {
-  const { locale, timeZone }: { locale: string, timeZone: string } = useRegistry()
+  const { locale, timeZone } = useRegistry()
 
   function formatDate(dateString?: string) {
     if (!dateString || typeof dateString !== 'string') {
       return ''
     }
 
-    return new Intl.DateTimeFormat(locale, {
+    return new Intl.DateTimeFormat(locale.code.full, {
       weekday: 'short',
       month: 'short',
       day: 'numeric',

--- a/src/defaults/locale.ts
+++ b/src/defaults/locale.ts
@@ -1,0 +1,11 @@
+import { sv } from 'date-fns/locale'
+import type { LocaleData } from '@/types'
+
+export const defaultLocale: LocaleData = {
+  module: sv,
+  code: {
+    short: 'sv',
+    long: 'svSE',
+    full: 'sv-SE'
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,7 @@ import type * as views from '@/views'
 import { type RpcError } from '@protobuf-ts/runtime-rpc'
 import { type LucideIcon } from '@ttab/elephant-ui/icons'
 import type { TemplatePayload } from '@/defaults/templates'
+import type { Locale } from 'date-fns'
 
 export enum NavigationActionType {
   SET = 'set',
@@ -119,3 +120,13 @@ export type ValidateState = Record<string, {
   valid: boolean
   reason: string
 }>
+
+export type LocaleData = {
+  module: Locale
+  code: {
+    short: string
+    long: string
+    full: string
+  }
+}
+

--- a/src/views/Approvals/DoneMarkedBy.tsx
+++ b/src/views/Approvals/DoneMarkedBy.tsx
@@ -24,7 +24,7 @@ export const DoneMarkedBy = ({ doneStatus }: {
     return <></>
   }
 
-  const created = dateToReadableDateTime(new Date(doneStatus.created), locale, timeZone)
+  const created = dateToReadableDateTime(new Date(doneStatus.created), locale.code.full, timeZone)
 
   return (
     <div className='flex flex-col items-start justify-start'>

--- a/src/views/Assignments/AssignmentColumns.tsx
+++ b/src/views/Assignments/AssignmentColumns.tsx
@@ -12,6 +12,7 @@ import { AssignmentTitles } from '@/components/Table/Items/AssignmentTitles'
 import { Actions } from '@/components/Table/Items/Actions'
 import { dateInTimestampOrShortMonthDayTimestamp } from '@/lib/datetime'
 import { type ColumnDef } from '@tanstack/react-table'
+import type { LocaleData } from '@/types/index'
 import { type DefaultValueOption } from '@/types/index'
 import type { IDBSection, IDBAuthor } from 'src/datastore/types'
 import type {
@@ -26,7 +27,7 @@ import { SectionBadge } from '@/components/DataItem/SectionBadge'
 export function assignmentColumns({ authors = [], locale, timeZone, sections = [] }: {
   authors?: IDBAuthor[]
   sections?: IDBSection[]
-  locale: string
+  locale: LocaleData
   timeZone: string
 }): Array<ColumnDef<AssignmentMetaExtended>> {
   return [
@@ -60,7 +61,7 @@ export function assignmentColumns({ authors = [], locale, timeZone, sections = [
         if (date.toDateString() === new Date().toDateString()) {
           return data ? date?.getHours() : undefined
         } else {
-          return `${date.getHours()} ${date.toLocaleString(locale, { weekday: 'long', hourCycle: 'h23' })}`
+          return `${date.getHours()} ${date.toLocaleString(locale.code.full, { weekday: 'long', hourCycle: 'h23' })}`
         }
       },
       enableGrouping: true,
@@ -189,7 +190,7 @@ export function assignmentColumns({ authors = [], locale, timeZone, sections = [
         const [start, fullDay, publishSlot, publishTime] = row.getValue<string[]>('assignment_time')
         const isFullday = fullDay === 'true'
         const types: string[] = row.getValue<DefaultValueOption[]>('assignmentType')?.map((t) => t.value)
-        const formattedStart = dateInTimestampOrShortMonthDayTimestamp(start, locale, timeZone)
+        const formattedStart = dateInTimestampOrShortMonthDayTimestamp(start, locale.code.full, timeZone)
 
         /* Assignment type: text | video | graphic
           Order of returned information for non-picture assignments:
@@ -207,7 +208,7 @@ export function assignmentColumns({ authors = [], locale, timeZone, sections = [
             return <div>{slotFormatted}</div>
           }
           if (publishTime) {
-            const formattedPublishTime = dateInTimestampOrShortMonthDayTimestamp(publishTime, locale, timeZone)
+            const formattedPublishTime = dateInTimestampOrShortMonthDayTimestamp(publishTime, locale.code.full, timeZone)
             return <Time time={formattedPublishTime} type='publish' tooltip='Publiceringstid' />
           }
 

--- a/src/views/Event/components/EventTime.tsx
+++ b/src/views/Event/components/EventTime.tsx
@@ -232,13 +232,13 @@ export const EventTimeMenu = (): JSX.Element => {
       fromDate: eventData?.start,
       toDate: eventData?.end,
       timeZone,
-      locale
+      locale: locale.code.full
     })
     : dateTimeLabel({
       fromDate: eventData?.start,
       toDate: eventData?.end,
       timeZone,
-      locale
+      locale: locale.code.full
     })
 
   return (
@@ -270,7 +270,7 @@ export const EventTimeMenu = (): JSX.Element => {
 
           <div className='flex justify-between border-2 rounded-md border-slate-100'>
             <div className='px-3 py-2 text-sm'>
-              {startDateValue && dateToReadableDay(new Date(startDateValue), locale, timeZone)}
+              {startDateValue && dateToReadableDay(new Date(startDateValue), locale.code.full, timeZone)}
             </div>
             <div>
               <TimeInput
@@ -284,7 +284,7 @@ export const EventTimeMenu = (): JSX.Element => {
           </div>
           <div className='flex justify-between border-2 rounded-md border-slate-100 mt-2'>
             <div className='px-3 py-2 text-sm'>
-              {endDateValue && dateToReadableDay(new Date(endDateValue), locale, timeZone)}
+              {endDateValue && dateToReadableDay(new Date(endDateValue), locale.code.full, timeZone)}
             </div>
             <div>
               <TimeInput

--- a/src/views/EventsOverview/EventsGridColumn.tsx
+++ b/src/views/EventsOverview/EventsGridColumn.tsx
@@ -42,7 +42,7 @@ export const EventsGridColumn = ({ date, items }: EventsGridColumnProps): JSX.El
 
   const { locale, timeZone } = useRegistry()
 
-  const [weekday, day] = new Intl.DateTimeFormat(locale, {
+  const [weekday, day] = new Intl.DateTimeFormat(locale.code.full, {
     weekday: 'short',
     day: 'numeric',
     timeZone

--- a/src/views/EventsOverview/EventsListColumns.tsx
+++ b/src/views/EventsOverview/EventsListColumns.tsx
@@ -24,11 +24,12 @@ import { SectionBadge } from '@/components/DataItem/SectionBadge'
 import { type IDBOrganiser, type IDBSection } from 'src/datastore/types'
 import { FacetedFilter } from '@/components/Commands/FacetedFilter'
 import { Tooltip } from '@ttab/elephant-ui'
+import type { LocaleData } from '@/types/index'
 
-export function eventTableColumns({ sections = [], organisers = [], locale = 'sv-SE' }: {
+export function eventTableColumns({ sections = [], organisers = [], locale }: {
   sections?: IDBSection[]
   organisers?: IDBOrganiser[]
-  locale?: string
+  locale: LocaleData
 }): Array<ColumnDef<Event>> {
   return [
     {
@@ -65,7 +66,7 @@ export function eventTableColumns({ sections = [], organisers = [], locale = 'sv
         if (startTime.toDateString() === new Date().toDateString()) {
           return startTime.getHours()
         } else {
-          return `${startTime.getHours()} ${startTime.toLocaleString(locale, { weekday: 'long', hourCycle: 'h23' })}`
+          return `${startTime.getHours()} ${startTime.toLocaleString(locale.code.full, { weekday: 'long', hourCycle: 'h23' })}`
         }
       },
       cell: () => {

--- a/src/views/EventsOverview/index.tsx
+++ b/src/views/EventsOverview/index.tsx
@@ -17,6 +17,7 @@ import { useQuery } from '@/hooks/useQuery'
 import { type EventSearchParams } from '@/lib/events/search'
 import { useOrganisers } from '@/hooks/useOrganisers'
 import { loadFilters } from '@/lib/loadFilters'
+import { useRegistry } from '@/hooks/useRegistry'
 
 const meta: ViewMetadata = {
   name: 'Events',
@@ -45,8 +46,9 @@ export const Events = (): JSX.Element => {
   [query.from])
 
   const organisers = useOrganisers()
+  const { locale } = useRegistry()
   const columns = useMemo(() =>
-    eventTableColumns({ sections, organisers }), [sections, organisers])
+    eventTableColumns({ sections, organisers, locale }), [sections, organisers, locale])
   const columnFilters = loadFilters<Event>(query, columns)
 
   return (

--- a/src/views/Factboxes/FactboxColumns.tsx
+++ b/src/views/Factboxes/FactboxColumns.tsx
@@ -1,6 +1,7 @@
 import { Title } from '@/components/Table/Items/Title'
 import type { Factbox } from '@/hooks/index/lib/factboxes'
 import { dateToReadableDateTime } from '@/lib/datetime'
+import type { LocaleData } from '@/types/index'
 import type { ColumnDef, Row } from '@tanstack/react-table'
 import { Boxes } from '@ttab/elephant-ui/icons'
 
@@ -12,7 +13,7 @@ interface FactboxData {
   version: string
 }
 
-export function factboxColumns({ locale, timeZone }: { locale: string, timeZone: string }): Array<ColumnDef<Factbox>> {
+export function factboxColumns({ locale, timeZone }: { locale: LocaleData, timeZone: string }): Array<ColumnDef<Factbox>> {
   const handleDragStart = (event: React.DragEvent<HTMLDivElement>, row: Row<Factbox>) => {
     const factboxData: FactboxData = {
       title: row.getValue<string>('title'),
@@ -82,7 +83,7 @@ export function factboxColumns({ locale, timeZone }: { locale: string, timeZone:
       accessorFn: (data) => data.fields.modified.values[0],
       cell: ({ row }) => {
         const edited = row.getValue<string>('edited')
-        const readableDateTime = edited ? dateToReadableDateTime(new Date(edited), locale, timeZone, true) : '-'
+        const readableDateTime = edited ? dateToReadableDateTime(new Date(edited), locale.code.full, timeZone, true) : '-'
         return (
           <div className='truncate space-x-2 justify-start items-center'>
             <span className='font-thin text-xs text-muted-foreground'>

--- a/src/views/Latest/index.tsx
+++ b/src/views/Latest/index.tsx
@@ -1,12 +1,12 @@
 import { useAssignments } from '@/hooks/index/useAssignments'
 import { useSections } from '@/hooks/useSections'
+import type { LocaleData } from '@/types/index'
 import { type ViewMetadata } from '@/types/index'
 import { type Document } from '@ttab/elephant-api/newsdoc'
 import { Separator } from '@ttab/elephant-ui'
 import { useMemo } from 'react'
 import { format } from 'date-fns'
 import { useRegistry } from '@/hooks/useRegistry'
-import * as locales from 'date-fns/locale'
 import { handleLink } from '@/components/Link/lib/handleLink'
 import { useHistory, useNavigation, useView } from '@/hooks/index'
 
@@ -74,21 +74,18 @@ export const Latest = () => {
   return <Content documents={documents} locale={locale} />
 }
 
-const Content = ({ documents, locale }: { documents: Document[], locale: string }): JSX.Element => {
+const Content = ({ documents, locale }: { documents: Document[], locale: LocaleData }): JSX.Element => {
   const { state, dispatch } = useNavigation()
   const history = useHistory()
   const { viewId } = useView()
 
-  function getLocalizedDate(date: Date, localeCode: string): string | undefined {
-    const [code] = localeCode.split('-')
-    const _locale = locales[code.toLocaleLowerCase() as keyof typeof locales]
-
-    if (!_locale) {
-      console.warn(`Locale ${localeCode} not supported.`)
+  function getLocalizedDate(date: Date, locale: LocaleData): string | undefined {
+    if (!locale.module) {
+      console.warn(`Locale ${locale.code.full} not supported.`)
       return format(date, 'dd MMM yyyy – HH.mm')
     }
 
-    return format(date, 'dd MMM yyyy – HH.mm', { locale: _locale })
+    return format(date, 'dd MMM yyyy – HH.mm', { locale: locale.module })
   }
 
   return (

--- a/src/views/PlanningOverview/PlanningGridColumn.tsx
+++ b/src/views/PlanningOverview/PlanningGridColumn.tsx
@@ -43,7 +43,7 @@ export const PlanningGridColumn = ({ date, items }: PlanningGridColumnProps): JS
 
   const { locale, timeZone } = useRegistry()
 
-  const [weekday, day] = new Intl.DateTimeFormat(locale, {
+  const [weekday, day] = new Intl.DateTimeFormat(locale.code.full, {
     weekday: 'short',
     day: 'numeric',
     timeZone

--- a/src/views/SearchOverview/SearchColumns.tsx
+++ b/src/views/SearchOverview/SearchColumns.tsx
@@ -15,9 +15,10 @@ import { type Planning } from '@/lib/index/schemas/planning'
 import { type Article } from '@/lib/index'
 import { type Event } from '@/lib/index'
 import { type AssignmentMetaExtended } from '../Assignments/types'
+import type { LocaleData } from '@/types'
 
 export function searchWideColumns({ locale, timeZone, sections }: {
-  locale: string
+  locale: LocaleData
   timeZone: string
   sections: IDBSection[]
 }): Array<ColumnDef<Planning | Event | AssignmentMetaExtended | Article>> {
@@ -166,7 +167,7 @@ export function searchWideColumns({ locale, timeZone, sections }: {
         const dateValue: string = row.getValue('date')
         if (dateValue) {
           const d = new Date(dateValue)
-          const day = dateToReadableShort(d, locale, timeZone)
+          const day = dateToReadableShort(d, locale.code.full, timeZone)
           return <div>{day}</div>
         }
         return <></>


### PR DESCRIPTION
Introduce dynamic locale handling by integrating `getLocaleData` and refactoring components to use `locale.code.full`. Added `LocaleData` type and default locale configuration. Updated `RegistryProvider` to initialize locale dynamically.

BREAKING CHANGE: Locale is now an object with `code` and `module` properties instead of a string.

Initial bundle size
```
Before:
3,123.01 kB │ gzip: 811.84 kB
After:
2,512.68 kB │ gzip: 694.25 kB

Reduction: 
-19.54%     | -14.48%
```