### PR TITLE
feat(editorial-info): add support for new deliverable type

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -8,7 +8,7 @@ import { useMemo } from 'react'
 import { useModal } from '../Modal/useModal'
 import * as Views from '@/views'
 import { createDocument } from '@/lib/createYItem'
-import { getTemplate } from '@/defaults/templates/lib/getTemplate'
+import { getTemplateFromView } from '@/defaults/templates/lib/getTemplateFromView'
 
 export const Header = ({ assigneeUserName, type }: {
   type: View
@@ -34,7 +34,7 @@ export const Header = ({ assigneeUserName, type }: {
           className='h-8 pr-4'
           onClick={() => {
             const initialDocument = createDocument({
-              template: getTemplate(type),
+              template: getTemplateFromView(type),
               inProgress: true
             })
             showModal(

--- a/src/defaults/assignmentTypes.tsx
+++ b/src/defaults/assignmentTypes.tsx
@@ -29,7 +29,7 @@ export const AssignmentTypes: DefaultValueOption[] = [
     iconProps
   },
   {
-    label: 'Tillred',
+    label: 'Till red',
     value: 'editorial-info',
     icon: FileWarning,
     iconProps

--- a/src/defaults/assignmentTypes.tsx
+++ b/src/defaults/assignmentTypes.tsx
@@ -5,7 +5,8 @@ import {
   Camera,
   Video,
   Aperture,
-  ZapIcon
+  ZapIcon,
+  FileWarning
 } from '@ttab/elephant-ui/icons'
 
 const iconProps = {
@@ -16,7 +17,7 @@ const iconProps = {
 
 export const AssignmentTypes: DefaultValueOption[] = [
   {
-    label: 'Text',
+    label: 'Artikel',
     value: 'text',
     icon: FileText,
     iconProps
@@ -25,6 +26,12 @@ export const AssignmentTypes: DefaultValueOption[] = [
     label: 'Flash',
     value: 'flash',
     icon: ZapIcon,
+    iconProps
+  },
+  {
+    label: 'Tillred',
+    value: 'editorial-info',
+    icon: FileWarning,
     iconProps
   },
   {

--- a/src/defaults/templates/editorialInfoDocumentTemplate.ts
+++ b/src/defaults/templates/editorialInfoDocumentTemplate.ts
@@ -1,0 +1,47 @@
+import { Document } from '@ttab/elephant-api/newsdoc'
+import type { TemplatePayload } from '.'
+
+/**
+ * Generates a document template for type editorial-info
+ *
+ * @param {string} id - The unique identifier for the article.
+ * @param {TemplatePayload} [payload] - Optional payload containing additional template data.
+ * @returns {Document} - The generated document template.
+ */
+export function editorialInfoDocumentTemplate(id: string, payload?: TemplatePayload): Document {
+  return Document.create({
+    uuid: id,
+    type: 'core/editorial-info',
+    uri: `core://editorial-info/${id}`, // Migrated documents have core://article/...
+    language: 'sv-se',
+    title: payload?.title,
+    content: [
+      {
+        type: 'core/text',
+        data: {
+          text: ''
+        },
+        role: 'heading-1'
+      },
+      {
+        type: 'core/text',
+        data: {
+          text: ''
+        }
+      }
+    ],
+    meta: [
+      {
+        type: 'core/note',
+        data: {
+          text: 'Obs! Detta meddelande är inte avsett för publicering.'
+        },
+        role: 'public'
+      },
+      ...payload?.meta?.['tt/slugline'] || []
+    ],
+    links: [
+      ...payload?.links?.['core/section'] || []
+    ]
+  })
+}

--- a/src/defaults/templates/index.ts
+++ b/src/defaults/templates/index.ts
@@ -6,6 +6,7 @@ export { factboxDocumentTemplate as factbox } from './factboxDocumentTemplate'
 export { assignmentPlanningTemplate as assignment } from './assignmentPlanningTemplate'
 export { planningDocumentTemplate as planning } from './planningDocumentTemplate'
 export { eventDocumentTemplate as event } from './eventDocumentTemplate'
+export { editorialInfoDocumentTemplate as editorialInfo } from './editorialInfoDocumentTemplate'
 
 export interface TemplatePayload {
   title?: string
@@ -19,6 +20,6 @@ export interface TemplatePayload {
     'core/section'?: Block[]
     'core/story'?: Block[]
     'tt/wire'?: Block[]
-    'core/event'?: Block[] // FIXME: Is this correct?
+    'core/event'?: Block[]
   }
 }

--- a/src/defaults/templates/lib/getDeliverableType.ts
+++ b/src/defaults/templates/lib/getDeliverableType.ts
@@ -1,0 +1,14 @@
+export function getDeliverableType(type: string | undefined): DeliverableType {
+  switch (type) {
+    case 'text':
+      return 'article'
+    case 'flash':
+      return 'flash'
+    case 'editorial-info':
+      return 'editorial-info'
+    default:
+      return 'article'
+  }
+}
+
+export type DeliverableType = 'article' | 'flash' | 'editorial-info'

--- a/src/defaults/templates/lib/getTemplateFromDeliverable.ts
+++ b/src/defaults/templates/lib/getTemplateFromDeliverable.ts
@@ -1,0 +1,17 @@
+import * as Templates from '@/defaults/templates'
+import type { TemplatePayload } from '@/defaults/templates'
+import type { DeliverableType } from './getDeliverableType'
+import type { Document } from '@ttab/elephant-api/newsdoc'
+
+export function getTemplateFromDeliverable(type: DeliverableType): (id: string, payload: TemplatePayload) => Document {
+  switch (type) {
+    case 'article':
+      return Templates.article
+    case 'flash':
+      return Templates.flash
+    case 'editorial-info':
+      return Templates.editorialInfo
+    default:
+      return Templates.article
+  }
+}

--- a/src/defaults/templates/lib/getTemplateFromView.ts
+++ b/src/defaults/templates/lib/getTemplateFromView.ts
@@ -2,7 +2,7 @@ import { type View } from '@/types/index'
 import type { Document } from '@ttab/elephant-api/newsdoc'
 import * as Templates from '@/defaults/templates'
 
-export function getTemplate(type: View): (id: string, payload?: Templates.TemplatePayload) => Document {
+export function getTemplateFromView(type: View): (id: string, payload?: Templates.TemplatePayload) => Document {
   switch (type) {
     case 'Planning':
       return Templates.planning

--- a/src/defaults/workflowSpecification.tsx
+++ b/src/defaults/workflowSpecification.tsx
@@ -336,5 +336,78 @@ export const WorkflowSpecifications: Record<string, WorkflowSpecification> = {
         }
       }
     }
+  },
+  'core/editorial-info': {
+    draft: {
+      title: 'Utkast',
+      description: 'Du jobbar på ett utkast av detta till red',
+      transitions: {
+        done: {
+          default: true,
+          title: 'Klarmarkera',
+          description: 'Markera till red som klar'
+        },
+        approved: {
+          title: 'Godkänn',
+          description: 'Godkänn till red för intern användning'
+        },
+        usable: {
+          verify: true,
+          title: 'Publicera',
+          description: 'Publicera till red externt synlig'
+        }
+      }
+    },
+    done: {
+      title: 'Klar',
+      description: 'Till red är klar och väntar på godkännande',
+      transitions: {
+        approved: {
+          default: true,
+          title: 'Godkänn',
+          description: 'Godkänn till red för intern användning'
+        },
+        usable: {
+          verify: true,
+          title: 'Publicera',
+          description: 'Publicera till red externt synlig'
+        },
+        draft: {
+          title: 'Till utkast',
+          description: 'Gör om till red till ett utkast igen'
+        }
+      }
+    },
+    approved: {
+      title: 'Intern',
+      description: 'Till red är internt publicerad och går att publicera externt',
+      transitions: {
+        usable: {
+          default: true,
+          verify: true,
+          title: 'Publicera',
+          description: 'Publicera till red externt synlig'
+        },
+        draft: {
+          title: 'Till utkast',
+          description: 'Gör om till red till ett utkast igen'
+        }
+      }
+    },
+    usable: {
+      title: 'Publicerad',
+      description: 'Till red är publicerad',
+      transitions: {
+        draft: {
+          default: true,
+          title: 'Till utkast',
+          description: 'Gör om till red till ett utkast igen'
+        },
+        cancelled: {
+          title: 'Dra tillbaka',
+          description: 'Avbryt publiceringen och arkivera till red'
+        }
+      }
+    }
   }
 }

--- a/src/lib/createYItem.ts
+++ b/src/lib/createYItem.ts
@@ -6,6 +6,7 @@ import { toGroupedNewsDoc, group } from '@/shared/transformations/groupedNewsDoc
 import { toYjsNewsDoc } from '@/shared/transformations/yjsNewsDoc'
 import type { Wire } from '@/hooks/index/lib/wires'
 import type { IDBAuthor } from 'src/datastore/types'
+import type { DeliverableType } from '@/defaults/templates/lib/getDeliverableType'
 
 /**
 * General function to create a new document as Y.Doc from a template
@@ -138,7 +139,7 @@ export function appendDocumentToAssignment({ document, id, index, slug, type }: 
   id: string
   index: number
   slug?: string
-  type: 'flash' | 'article'
+  type: DeliverableType
 }): void {
   // Get meta yMap
   const meta = document.getMap('ele').get('meta') as Y.Map<unknown>
@@ -149,29 +150,29 @@ export function appendDocumentToAssignment({ document, id, index, slug, type }: 
     .get(index) as Y.Map<unknown>)
     .get('links') as Y.Map<unknown>
 
-  // Check if 'core/article' exists
-  if (!assignmentLinks.has('core/article')) {
-    assignmentLinks.set('core/article', new Y.Array())
+  // Check if deliverableType exists
+  if (!assignmentLinks.has(`core/${type}`)) {
+    assignmentLinks.set(`core/${type}`, new Y.Array())
   }
   // Get existing articles
-  const yArticles = assignmentLinks.get('core/article') as Y.Array<unknown>
+  const yDeliverables = assignmentLinks.get(`core/${type}`) as Y.Array<unknown>
 
-  // Create new article from template
-  const article = Block.create({
+  // Create new deliverable from template
+  const deliverable = Block.create({
     type: `core/${type}`,
     uuid: id,
     rel: 'deliverable',
     title: slug
   })
 
-  // Group article
-  const [groupedArticle] = group([article], 'type')[`core/${type}`]
+  // Group deliverable
+  const [groupedDeliverable] = group([deliverable], 'type')[`core/${type}`]
 
   // Convert to YMap
-  const yArticle = toYMap(
-    groupedArticle as unknown as Record<string, unknown>,
+  const yDeliverable = toYMap(
+    groupedDeliverable as unknown as Record<string, unknown>,
     new Y.Map()
   )
   // Push to existing articles
-  yArticles.push([yArticle])
+  yDeliverables.push([yDeliverable])
 }

--- a/src/views/Editor/EditorHeader.tsx
+++ b/src/views/Editor/EditorHeader.tsx
@@ -1,4 +1,4 @@
-import { useView } from '@/hooks'
+import { useView, useYValue } from '@/hooks'
 import { Newsvalue } from '@/components/Newsvalue'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { MetaSheet } from './components/MetaSheet'
@@ -16,6 +16,8 @@ export const EditorHeader = ({ documentId }: { documentId: string }): JSX.Elemen
   const deliverablePlanning = useDeliverablePlanning(documentId)
   const containerRef = useRef<HTMLElement | null>(null)
   const [publishTime, setPublishTime] = useState<string | null>(null)
+  const [documentType] = useYValue<string>('root.type')
+
 
   useEffect(() => {
     containerRef.current = (document.getElementById(viewId))
@@ -59,15 +61,16 @@ export const EditorHeader = ({ documentId }: { documentId: string }): JSX.Elemen
     return true
   }, [deliverablePlanning])
 
+  const title = documentType === 'core/editorial-info' ? 'Till red' : 'Artikel'
   return (
     <ViewHeader.Root>
-      <ViewHeader.Title name='Editor' title='Artikel' icon={PenBoxIcon} />
+      <ViewHeader.Title name='Editor' title={title} icon={PenBoxIcon} />
 
       <ViewHeader.Content className='justify-start'>
         <div className='max-w-[810px] mx-auto flex flex-row gap-2 justify-between items-center w-full'>
           <div className='flex flex-row gap-1 justify-start items-center @7xl/view:-ml-20'>
             <div className='hidden flex-row gap-2 justify-start items-center @lg/view:flex'>
-              <Newsvalue />
+              {documentType !== 'core/editorial-info' && <Newsvalue />}
               <AddNote />
             </div>
           </div>
@@ -80,7 +83,7 @@ export const EditorHeader = ({ documentId }: { documentId: string }): JSX.Elemen
                 {!!deliverablePlanning && (
                   <StatusMenu
                     documentId={documentId}
-                    type='core/article'
+                    type={documentType || 'core/article'}
                     publishTime={publishTime ? new Date(publishTime) : undefined}
                     onBeforeStatusChange={onBeforeStatusChange}
                   />

--- a/src/views/Planning/components/Assignment.tsx
+++ b/src/views/Planning/components/Assignment.tsx
@@ -67,7 +67,7 @@ export const Assignment = ({ index, onAbort, onClose }: {
             )}
           />
 
-          {assignmentType === 'text'
+          {(assignmentType === 'text' || assignmentType === 'editorial-info')
           && (
             <Form.Group icon={Tags}>
               <SluglineEditable

--- a/src/views/Planning/components/AssignmentRow.tsx
+++ b/src/views/Planning/components/AssignmentRow.tsx
@@ -21,6 +21,8 @@ import { createPayload } from '@/defaults/templates/lib/createPayload'
 import { Move } from '@/components/Move/'
 import { useModal } from '@/components/Modal/useModal'
 import type * as Y from 'yjs'
+import { getDeliverableType } from '@/defaults/templates/lib/getDeliverableType'
+import { AssignmentTypes } from '@/defaults/assignmentTypes'
 
 export const AssignmentRow = ({ index, onSelect, isFocused = false, asDialog }: {
   index: number
@@ -54,9 +56,12 @@ export const AssignmentRow = ({ index, onSelect, isFocused = false, asDialog }: 
   const [planningId] = getValueByYPath<string | undefined>(yRoot, 'root.uuid')
 
   const documentId = articleId || flashId
-  const isDocument = assignmentType === 'flash' || assignmentType === 'text'
-  const documentLabel = assignmentType === 'text' ? 'artikel' : assignmentType
-  const openDocument = assignmentType === 'text' ? openArticle : openFlash
+  const isDocument = assignmentType === 'flash' || assignmentType === 'text' || assignmentType === 'editorial-info'
+  const documentLabel = assignmentType
+    ? AssignmentTypes.find((a) => a.value === assignmentType)?.label?.toLowerCase()
+    : 'okänt'
+
+  const openDocument = assignmentType === 'flash' ? openFlash : openArticle
   const { showModal, hideModal } = useModal()
 
   const assTime = useMemo(() => {
@@ -71,7 +76,7 @@ export const AssignmentRow = ({ index, onSelect, isFocused = false, asDialog }: 
         : undefined
   }, [publishTime, assignmentType, startTime])
 
-  // Open a deliverable (e.g. article or flash) callback helper.
+  // Open a deliverable (e.g. article, flash, editorial-info) callback helper.
   const onOpenEvent = useCallback(<T extends HTMLElement>(event: MouseEvent<T> | KeyboardEvent) => {
     event.preventDefault()
     event.stopPropagation()
@@ -119,6 +124,7 @@ export const AssignmentRow = ({ index, onSelect, isFocused = false, asDialog }: 
       icon: Edit,
       item: <T extends HTMLElement>(event: MouseEvent<T>) => {
         event.stopPropagation()
+        event.preventDefault()
         onSelect()
       }
     },
@@ -127,6 +133,7 @@ export const AssignmentRow = ({ index, onSelect, isFocused = false, asDialog }: 
       icon: Delete,
       item: <T extends HTMLElement>(event: MouseEvent<T>) => {
         event.stopPropagation()
+        event.preventDefault()
         setShowVerifyDialog(true)
       }
     },
@@ -135,6 +142,7 @@ export const AssignmentRow = ({ index, onSelect, isFocused = false, asDialog }: 
       icon: MoveRight,
       item: <T extends HTMLElement>(event: MouseEvent<T>) => {
         event.stopPropagation()
+        event.preventDefault()
         showModal(
           <Move
             asDialog
@@ -279,7 +287,7 @@ export const AssignmentRow = ({ index, onSelect, isFocused = false, asDialog }: 
       {showCreateDialogPayload && provider?.document && (slugline || assignmentType === 'flash') && (
         <CreateDeliverablePrompt
           payload={createPayload(provider.document, index, assignmentType) || {}}
-          deliverableType={assignmentType === 'flash' ? 'flash' : 'article'}
+          deliverableType={getDeliverableType(assignmentType)}
           title={title || ''}
           documentLabel={documentLabel || ''}
           onClose={(event, id) => {
@@ -293,7 +301,7 @@ export const AssignmentRow = ({ index, onSelect, isFocused = false, asDialog }: 
                 id,
                 index,
                 slug: '',
-                type: assignmentType === 'flash' ? 'flash' : 'article'
+                type: getDeliverableType(assignmentType)
               })
               const openDocument = assignmentType === 'flash' ? openFlash : openArticle
               openDocument(event, { id }, 'blank')

--- a/src/views/Planning/components/AssignmentRow.tsx
+++ b/src/views/Planning/components/AssignmentRow.tsx
@@ -41,6 +41,7 @@ export const AssignmentRow = ({ index, onSelect, isFocused = false, asDialog }: 
   const [inProgress] = useYValue(`${base}.__inProgress`)
   const [articleId] = useYValue<string>(`${base}.links.core/article[0].uuid`)
   const [flashId] = useYValue<string>(`${base}.links.core/flash[0].uuid`)
+  const [editorialInfoId] = useYValue<string>(`${base}.links.core/editorial-info[0].uuid`)
   const [assignmentType] = useYValue<string>(`${base}.meta.core/assignment-type[0].value`)
   const [assignmentId] = useYValue<string>(`${base}.id`)
   const [title] = useYValue<string>(`${base}.title`)
@@ -55,7 +56,7 @@ export const AssignmentRow = ({ index, onSelect, isFocused = false, asDialog }: 
   const yRoot = provider?.document.getMap('ele')
   const [planningId] = getValueByYPath<string | undefined>(yRoot, 'root.uuid')
 
-  const documentId = articleId || flashId
+  const documentId = articleId || flashId || editorialInfoId
   const isDocument = assignmentType === 'flash' || assignmentType === 'text' || assignmentType === 'editorial-info'
   const documentLabel = assignmentType
     ? AssignmentTypes.find((a) => a.value === assignmentType)?.label?.toLowerCase()

--- a/src/views/Planning/components/AssignmentTable.tsx
+++ b/src/views/Planning/components/AssignmentTable.tsx
@@ -124,7 +124,7 @@ export const AssignmentTable = ({ asDialog = false }: {
             const [assignmentType] = getValueByYPath(yRoot,
               `${currentAssigmentPath}.meta.core/assignment-type[0].value`)
 
-            if (assignmentType !== 'text') {
+            if (assignmentType !== 'text' && assignmentType !== 'editorial-info') {
               deleteByYPath(yRoot, `${currentAssigmentPath}.meta.[tt/slugline]`)
             }
 

--- a/src/views/Planning/components/CreateDeliverablePrompt.tsx
+++ b/src/views/Planning/components/CreateDeliverablePrompt.tsx
@@ -2,19 +2,18 @@ import { type MouseEvent } from 'react'
 import { Prompt } from '@/components'
 import { useCollaboration } from '@/hooks/useCollaboration'
 import {
-  article as articleTpl,
-  flash as flashTpl,
   type TemplatePayload
 } from '@/defaults/templates/'
 import { useSession } from 'next-auth/react'
 import { useRegistry } from '@/hooks/useRegistry'
 import { toast } from 'sonner'
+import { getTemplateFromDeliverable } from '@/defaults/templates/lib/getTemplateFromDeliverable'
 
 /**
  * Deliverable document creation dialog, responsible for creating articles and flashes in the repository.
  */
 export function CreateDeliverablePrompt({ deliverableType, payload, onClose, title, documentLabel }: {
-  deliverableType: 'article' | 'flash'
+  deliverableType: 'article' | 'flash' | 'editorial-info'
   payload: TemplatePayload
   title: string
   documentLabel: string
@@ -33,8 +32,9 @@ export function CreateDeliverablePrompt({ deliverableType, payload, onClose, tit
 
   const onCreateDocument = async () => {
     const id = crypto.randomUUID()
+    const template = getTemplateFromDeliverable(deliverableType)
     await repository.saveDocument(
-      (deliverableType === 'flash') ? flashTpl(id, payload) : articleTpl(id, payload),
+      template(id, payload),
       session.accessToken,
       BigInt(-1)
     )


### PR DESCRIPTION
- Introduced `editorial-info` as a new deliverable type.
- Added `editorialInfoDocumentTemplate` for generating templates.
- Updated workflow specifications for `editorial-info`.
- Enhanced `Assignment` and `AssignmentRow` components to handle `editorial-info`.
- Modified `CreateDeliverablePrompt` to support `editorial-info`.
- Renamed `getTemplate` to `getTemplateFromView` for clarity.
- Added `getDeliverableType` and `getTemplateFromDeliverable` utilities.