### PR TITLE
feat(api): add snapshot endpoint for document snapshots

### DIFF
--- a/__tests__/stateless.test.ts
+++ b/__tests__/stateless.test.ts
@@ -22,6 +22,7 @@ describe('stateless', () => {
       state: false,
       id: 'abce123',
       context: {
+        agent: 'server',
         accessToken: 'secrettoken',
         user: {
           id: 'abce123',

--- a/shared/stateless.ts
+++ b/shared/stateless.ts
@@ -20,6 +20,7 @@ const inProgressMessageSchema = z.object({
   status: z.string().optional(),
   id: z.string(),
   context: z.object({
+    agent: z.string(),
     accessToken: z.string(),
     user: z.object({
       name: z.string(),

--- a/src-srv/api/documents/[id]/index.ts
+++ b/src-srv/api/documents/[id]/index.ts
@@ -41,7 +41,7 @@ export const GET: RouteHandler = async (req: Request, { cache, repository, res }
     // Fetch content fron repository
     const doc = await repository.getDocument({
       uuid,
-      accessToken: session?.accessToken,
+      accessToken: (session as { accessToken: string })?.accessToken,
       version
     }).catch((ex) => {
       throw new Error('get document from repository', { cause: ex })

--- a/src-srv/api/snapshot/[id]/index.ts
+++ b/src-srv/api/snapshot/[id]/index.ts
@@ -1,0 +1,91 @@
+import logger from '../../../lib/logger.js'
+import type { Request } from 'express'
+import type { RouteHandler, RouteStatusResponse } from '../../../routes.js'
+import { assertContext } from '../../../lib/assertContext.js'
+
+export const GET: RouteHandler = async (req: Request, { collaborationServer, cache, res }) => {
+  const uuid = req.params.id
+  const locals = res.locals as Record<string, unknown> | undefined
+  const session = locals?.session as { accessToken?: string, user?: unknown } | undefined
+
+  if (!session) {
+    return {
+      statusCode: 401,
+      statusMessage: 'Unauthorized: Session not found, can not snapshot document'
+    }
+  }
+
+  const context: unknown = {
+    accessToken: session.accessToken,
+    user: session.user,
+    agent: 'server'
+  }
+
+  let snapshotResponse: RouteStatusResponse = {
+    statusCode: 500,
+    statusMessage: 'Unknown error'
+  }
+
+
+  try {
+    // Check if document exists in cache
+    const state = await cache.get(uuid)
+    if (!state) {
+      return {
+        statusCode: 404,
+        statusMessage: 'Document not found'
+      }
+    }
+
+
+    const connection = await collaborationServer.server.openDirectConnection(uuid, context)
+
+    await new Promise<void>((resolve, reject) => {
+      connection.transact((document) => {
+        if (!assertContext(context)) {
+          throw new Error('Invalid context provided')
+        }
+
+        collaborationServer.snapshotDocument({
+          documentName: uuid,
+          document,
+          context
+        }).then((response) => {
+          if (!response) {
+            snapshotResponse = {
+              statusCode: 200,
+              statusMessage: 'Snapshot not deemed necessary'
+            }
+          } else if (response.status.code === 'OK') {
+            snapshotResponse = {
+              statusCode: 200,
+              statusMessage: 'Snapshot taken'
+            }
+          } else {
+            logger.error(`Error while taking snapshot: ${response.status.code}`)
+          }
+
+          // Resolve the promise after snapshotDocument completes
+          resolve()
+        }).catch((ex: Error) => {
+          logger.error('Snapshot Error:', ex instanceof Error ? ex.message : ex)
+          reject(ex) // Reject the promise on error
+        })
+
+        return undefined
+      })
+        .catch((ex: Error) => {
+          logger.error('Error during transaction', ex)
+          reject(ex)
+        })
+    })
+  } catch (ex) {
+    logger.error('Error while taking snapshot', { error: ex })
+    return {
+      statusCode: 500,
+      statusMessage: 'Internal server error'
+    }
+  }
+
+  return snapshotResponse
+}

--- a/src-srv/lib/assertContext.ts
+++ b/src-srv/lib/assertContext.ts
@@ -1,0 +1,31 @@
+import type { User as DefaultUser } from '@auth/express'
+
+interface User extends DefaultUser {
+  sub: string
+}
+
+export interface Context {
+  agent: string
+  accessToken: string
+  user: User
+}
+
+export function assertContext(context: unknown): context is Context {
+  return (
+    typeof context === 'object'
+    && context !== null
+
+    && 'agent' in context
+    && (context.agent === 'server' || context.agent === 'user')
+
+    && 'accessToken' in context
+    && typeof context.accessToken === 'string'
+
+    && 'user' in context
+    && typeof context.user === 'object'
+    && context.user !== null
+
+    && 'sub' in context.user
+    && typeof context.user.sub === 'string'
+  )
+}

--- a/src-srv/lib/errorHandler.ts
+++ b/src-srv/lib/errorHandler.ts
@@ -1,4 +1,13 @@
-import type { Hocuspocus, Extension, fetchPayload, storePayload, onStoreDocumentPayload, connectedPayload, onDisconnectPayload, onStatelessPayload } from '@hocuspocus/server'
+import type {
+  Hocuspocus,
+  Extension,
+  fetchPayload,
+  storePayload,
+  onStoreDocumentPayload,
+  connectedPayload,
+  onDisconnectPayload,
+  onStatelessPayload
+} from '@hocuspocus/server'
 import logger from './logger.js'
 import { RpcError } from '@protobuf-ts/runtime-rpc'
 import { isValidUUID } from '../utils/isValidUUID.js'

--- a/src-srv/routes.ts
+++ b/src-srv/routes.ts
@@ -29,7 +29,7 @@ interface RouteContentResponse {
   statusCode?: number
 }
 
-interface RouteStatusResponse {
+export interface RouteStatusResponse {
   statusCode: number
   statusMessage: string
 }

--- a/src-srv/utils/CollaborationServer.ts
+++ b/src-srv/utils/CollaborationServer.ts
@@ -29,7 +29,11 @@ import { fromGroupedNewsDoc, toGroupedNewsDoc } from '@/shared/transformations/g
 import { fromYjsNewsDoc, toYjsNewsDoc } from '@/shared/transformations/yjsNewsDoc.js'
 import CollaborationServerErrorHandler, { getErrorContext, withErrorHandler } from '../lib/errorHandler.js'
 import logger from '../lib/logger.js'
+import type { UpdateRequest, UpdateResponse } from '@ttab/elephant-api/repository'
 import { type GetDocumentResponse } from '@ttab/elephant-api/repository'
+import type { FinishedUnaryCall } from '@protobuf-ts/runtime-rpc'
+import type { Context } from '../lib/assertContext.js'
+import { assertContext } from '../lib/assertContext.js'
 
 interface CollaborationServerOptions {
   name: string
@@ -46,7 +50,7 @@ export class CollaborationServer {
   readonly #port: number
   readonly #quiet: boolean
   readonly #expressServer: Application
-  readonly #server: Hocuspocus
+  readonly server: Hocuspocus
   readonly #repository: Repository
   readonly #redisCache: RedisCache
   readonly #errorHandler: CollaborationServerErrorHandler
@@ -78,7 +82,7 @@ export class CollaborationServer {
 
     this.#quiet = process.env.LOG_LEVEL !== 'info' && process.env.LOG_LEVEL !== 'debug'
 
-    this.#server = Server.configure({
+    this.server = Server.configure({
       port: this.#port,
       timeout: 30000,
       debounce: 5000,
@@ -119,14 +123,18 @@ export class CollaborationServer {
         }),
         new Snapshot({
           debounce: 120000,
-          snapshot: (payload: onStoreDocumentPayload) => {
+          snapshot: ({ context, ...rest }: onStoreDocumentPayload) => {
             return async () => {
-              await this.#snapshotDocument(payload).catch((ex) => {
-                const ctx = getErrorContext(payload)
+              if (!assertContext(context)) {
+                throw new Error('Invalid context provided')
+              }
+
+              await this.snapshotDocument({ context, ...rest }).catch((ex) => {
+                const ctx = getErrorContext({ context, ...rest })
 
                 this.#errorHandler.error(ex, {
-                  id: payload.documentName,
-                  accessToken: payload.context.accessToken,
+                  id: rest.documentName,
+                  accessToken: context.accessToken,
                   ...ctx
                 })
               })
@@ -153,7 +161,7 @@ export class CollaborationServer {
    * Start listening for websocket connections on all specified paths
    */
   async listen(paths: string[]): Promise<boolean> {
-    if (!this.#server || !this.#expressServer) {
+    if (!this.server || !this.#expressServer) {
       return false
     }
 
@@ -163,12 +171,12 @@ export class CollaborationServer {
     }
 
     // Apply the server to errorHandler
-    this.#errorHandler.setServer(this.#server)
+    this.#errorHandler.setServer(this.server)
 
     try {
       paths.forEach((path) => {
         this.#expressServer.ws(path, (websocket, request) => {
-          this.#server.handleConnection(websocket, request)
+          this.server.handleConnection(websocket, request)
         })
       })
     } catch (ex) {
@@ -185,12 +193,12 @@ export class CollaborationServer {
    * This allows the server to reinitialize itself.
    */
   async close(): Promise<void> {
-    if (!this.#server || !this.#openForBusiness) {
+    if (!this.server || !this.#openForBusiness) {
       return
     }
 
     try {
-      await this.#server.destroy()
+      await this.server.destroy()
     } catch (ex) {
       this.#errorHandler.error(ex)
     } finally {
@@ -203,7 +211,7 @@ export class CollaborationServer {
     const msg = parseStateless(payload.payload)
 
     if (msg.type === StatelessType.IN_PROGRESS && !msg.message.state) {
-      const userTrackerConnection = await this.#server.openDirectConnection(
+      const userTrackerConnection = await this.server.openDirectConnection(
         msg.message.context.user.sub
           .replace('core://user/', ''),
         { ...msg.message.context, agent: 'server' }
@@ -211,7 +219,7 @@ export class CollaborationServer {
         throw new Error('acquire connection', { cause: ex })
       })
 
-      const connection = await this.#server.openDirectConnection(
+      const connection = await this.server.openDirectConnection(
         msg.message.id, { ...msg.message.context, agent: 'server' }
       ).catch((ex) => {
         throw new Error('acquire connection', { cause: ex })
@@ -266,6 +274,10 @@ export class CollaborationServer {
    * Fetch document from redis if already in cache, otherwise from repository
    */
   async #fetchDocument({ documentName: uuid, document: yDoc, context }: fetchPayload): Promise<Uint8Array | null> {
+    if (!assertContext(context)) {
+      throw new Error('Invalid context provided')
+    }
+
     // Fetch from Redis if exists
     const state = await this.#redisCache.get(uuid).catch((ex) => {
       throw new Error('get cached document', { cause: ex })
@@ -284,7 +296,7 @@ export class CollaborationServer {
     // Fetch content
     const newsDoc = await this.#repository.getDocument({
       uuid,
-      accessToken: (context as { accessToken: string }).accessToken
+      accessToken: context.accessToken
     }).catch((ex) => {
       throw new Error('get document from repository', { cause: ex })
     })
@@ -302,36 +314,35 @@ export class CollaborationServer {
     return Y.encodeStateAsUpdate(yDoc)
   }
 
-  async #snapshotDocument({ documentName, document: yDoc, context }: onStoreDocumentPayload): Promise<void> {
-    // Ignore tracker document
-    if (this.#openDocuments.isTrackerDocument(documentName)) {
-      return
-    }
-
+  async snapshotDocument({ documentName, document: yDoc, context }: {
+    documentName: string
+    document: Y.Doc
+    context: Context
+  }): Promise<FinishedUnaryCall<UpdateRequest, UpdateResponse> | null> {
     // Ignore __inProgress documents
     if ((yDoc.getMap('ele')
       .get('root') as Y.Map<unknown>)
       .get('__inProgress') as boolean) {
       logger.debug('::: Snapshot document: Document is in progress, not saving')
-      return
+      return null
     }
 
     // Ignore userTracker documents
-    if ((context as { user: { sub: string } }).user.sub?.endsWith(documentName)) {
-      return
+    if (context.user.sub?.endsWith(documentName)) {
+      return null
     }
 
     const { documentResponse, updatedHash } = fromYjsNewsDoc(yDoc)
     if (!updatedHash) {
       logger.debug('::: saveDocument: No changes in document')
-      return
+      return null
     }
 
-    await this.#storeDocumentInRepository(
+    return await this.#storeDocumentInRepository(
       documentName,
       fromGroupedNewsDoc(documentResponse),
       updatedHash,
-      (context as { accessToken: string }).accessToken,
+      context.accessToken,
       context
     )
   }
@@ -341,9 +352,9 @@ export class CollaborationServer {
     documentResponse: GetDocumentResponse,
     updatedHash: number,
     accessToken: string,
-    context: unknown,
+    context: Context,
     status?: string
-  ): Promise<void> {
+  ): Promise<FinishedUnaryCall<UpdateRequest, UpdateResponse>> {
     const { document, version } = documentResponse
     if (!document) {
       throw new Error(`Store document ${documentName} failed, no document in GetDocumentResponse parameter`)
@@ -363,8 +374,8 @@ export class CollaborationServer {
       throw new Error('Save snapshot document to repository failed', { cause: result })
     }
 
-    const connection = await this.#server.openDirectConnection(documentName, {
-      ...context as Record<string, unknown> || {},
+    const connection = await this.server.openDirectConnection(documentName, {
+      ...context || {},
       agent: 'server'
     }).catch((ex) => {
       throw new Error('Open hocuspocus connection failed', { cause: ex })
@@ -381,6 +392,7 @@ export class CollaborationServer {
     })
 
     logger.debug(`::: Document saved to repository: ${document.uuid}, version: ${result.response.version} 'new hash:' ${updatedHash}`)
+    return result
   }
 
   /**
@@ -396,14 +408,14 @@ export class CollaborationServer {
    * Number of HocusPocus provider connections (not number of websocket connections)
    */
   getConnectionsCount(): number {
-    return this.#server ? this.#server.getConnectionsCount() : 0
+    return this.server ? this.server.getConnectionsCount() : 0
   }
 
   /**
    * Number of open documents
    */
   getDocumentsCount(): number {
-    return this.#server ? this.#server.getDocumentsCount() : 0
+    return this.server ? this.server.getDocumentsCount() : 0
   }
 
   /**

--- a/src-srv/utils/extensions/Auth.ts
+++ b/src-srv/utils/extensions/Auth.ts
@@ -10,6 +10,7 @@ import { type JWT } from '@auth/core/jwt'
 
 export class Auth implements Extension {
   async onAuthenticate({ token: accessToken }: onAuthenticatePayload): Promise<{
+    agent: string
     accessToken: string
     user: JWT
   }> {
@@ -17,6 +18,7 @@ export class Auth implements Extension {
 
     if (isValidAccessToken) {
       return {
+        agent: 'user',
         accessToken,
         user: { ...decodeJwt(accessToken) }
       }

--- a/src-srv/utils/extensions/Snapshot.ts
+++ b/src-srv/utils/extensions/Snapshot.ts
@@ -28,7 +28,6 @@ export class Snapshot implements Extension {
 
   async onStoreDocument(payload: onStoreDocumentPayload): Promise<void> {
     const { documentName, context } = payload as { documentName: string, context: { agent?: string, user: { sub: string } } }
-
     // Ignore document-tracker, server actions, and userTracker
     if (documentName !== 'document-tracker' && context.agent !== 'server' && documentName !== context.user.sub) {
       // Clear previous debounce

--- a/src/components/Duplicate/index.tsx
+++ b/src/components/Duplicate/index.tsx
@@ -71,6 +71,7 @@ export const Duplicate = ({ provider, title, session, status, type }: {
                     state: false,
                     id: duplicateId,
                     context: {
+                      agent: 'server',
                       accessToken: session.accessToken,
                       user: session.user,
                       type: capitalized

--- a/src/components/Move/Prompt.tsx
+++ b/src/components/Move/Prompt.tsx
@@ -78,6 +78,7 @@ export const MovePrompt = ({
           state: false,
           id: planningId,
           context: {
+            agent: 'server',
             accessToken: session.accessToken,
             user: session.user,
             type: 'Planning'

--- a/src/views/Event/index.tsx
+++ b/src/views/Event/index.tsx
@@ -101,6 +101,7 @@ const EventViewContent = (props: ViewProps & { documentId: string }): JSX.Elemen
           state: false,
           id: props.documentId,
           context: {
+            agent: 'server',
             accessToken: data.accessToken,
             user: data.user,
             type: 'Event'

--- a/src/views/Factbox/index.tsx
+++ b/src/views/Factbox/index.tsx
@@ -150,6 +150,7 @@ const FactboxContainer = ({
           state: false,
           id: documentId,
           context: {
+            agent: 'server',
             accessToken: session.accessToken,
             user: session.user,
             type: 'Factbox'

--- a/src/views/Flash/lib/createFlash.tsx
+++ b/src/views/Flash/lib/createFlash.tsx
@@ -45,6 +45,7 @@ export function createFlash({
             status: documentStatus,
             id: documentId,
             context: {
+              agent: 'server',
               accessToken: session.accessToken,
               user: session.user,
               type: 'Flash'
@@ -96,6 +97,7 @@ export function createFlash({
             state: false,
             id: planning.id,
             context: {
+              agent: 'user',
               accessToken: session.accessToken,
               user: session.user,
               type: 'Planning'

--- a/src/views/Planning/index.tsx
+++ b/src/views/Planning/index.tsx
@@ -100,6 +100,7 @@ const PlanningViewContent = (props: ViewProps & { documentId: string }): JSX.Ele
           state: false,
           id: props.documentId,
           context: {
+            agent: 'server',
             accessToken: data.accessToken,
             user: data.user,
             type: 'Planning'

--- a/src/views/Wire/lib/createArticle.tsx
+++ b/src/views/Wire/lib/createArticle.tsx
@@ -77,6 +77,7 @@ export function createArticle({
             state: false,
             id: planning.id,
             context: {
+              agent: 'server',
               accessToken: session.accessToken,
               user: session.user,
               type: 'Planning'
@@ -90,6 +91,7 @@ export function createArticle({
             state: false,
             id: documentId,
             context: {
+              agent: 'server',
               accessToken: session.accessToken,
               user: session.user,
               type: 'Article'


### PR DESCRIPTION
Introduced a new `GET` endpoint at `/api/snapshot/[id]` to handle document snapshots. The endpoint validates session context, checks document existence in the cache, and interacts with the collaboration server to create snapshots. Added robust error handling and context validation to ensure reliability.

BREAKING CHANGE: Requires `agent` property in context for snapshot operations.