### PR TITLE
fix: add argument to swr call to prevent fetching stale data

### DIFF
--- a/src/views/Editor/components/ReadOnly.tsx
+++ b/src/views/Editor/components/ReadOnly.tsx
@@ -1,5 +1,6 @@
 import useSWR from 'swr'
 import { Label } from '@ttab/elephant-ui'
+import { toast } from 'sonner'
 import type { EleBlockGroup, EleDocumentResponse } from '@/shared/types'
 import type { ReactNode } from 'react'
 
@@ -35,12 +36,14 @@ export const ReadOnly = ({ documentId, version }: { documentId: string, version:
     const response = await fetch(url)
 
     if (!response.ok) {
-      throw new Error('Network response was not ok')
+      console.error(`Fetch metadata error for ${documentId}:`, error)
+      toast.error('Ett fel uppstod vid hämtning av metadata')
+      throw new Error('Readonly: Network response was not ok')
     }
 
     const result = await response.json() as EleDocumentResponse
 
-    if (result.document?.content.length === 0 && result?.document?.meta && result?.document?.links) {
+    if (result?.document?.content.length === 0 && result?.document?.meta && result?.document?.links) {
       return result?.document
     }
 
@@ -54,7 +57,7 @@ export const ReadOnly = ({ documentId, version }: { documentId: string, version:
   )
 
   if (error) {
-    return <div>Fel!</div>
+    return <div></div>
   }
 
   const newsvalue = data?.meta?.['core/newsvalue']?.[0]?.value

--- a/src/views/Editor/components/ReadOnly.tsx
+++ b/src/views/Editor/components/ReadOnly.tsx
@@ -30,11 +30,14 @@ const InfoBlock = ({ labelId, text, children }: { labelId: string, text: string,
 
 
 export const ReadOnly = ({ documentId, version }: { documentId: string, version: bigint | undefined }) => {
-  const fetcher = async (url: string): Promise<FetcherResult> => {
+  const fetcher = async (params: string[]): Promise<FetcherResult> => {
+    const [url] = params
     const response = await fetch(url)
+
     if (!response.ok) {
       throw new Error('Network response was not ok')
     }
+
     const result = await response.json() as EleDocumentResponse
 
     if (result.document?.content.length === 0 && result?.document?.meta && result?.document?.links) {
@@ -45,7 +48,7 @@ export const ReadOnly = ({ documentId, version }: { documentId: string, version:
   }
 
   const { data, error } = useSWR<FetcherResult, Error>(
-    `${BASE_URL}/api/documents/${documentId}${version ? `?version=${version}` : ''}`,
+    [`${BASE_URL}/api/documents/${documentId}${version ? `?version=${version}` : ''}`, documentId],
     fetcher,
     { revalidateOnFocus: false, revalidateOnReconnect: false }
   )


### PR DESCRIPTION
Steps to reproduce in stage:

1. Open up a read-only article from a Planning view.

2. Slide open the MetaSheet from the header.

3. Close the MetaSheet, as well as the article.

4. Back in the Planning view, open up the same article again.

5. 💥