### PR TITLE
fix(Wire): dont hide slug component when empty

### DIFF
--- a/src/views/Wire/WireViewContent.tsx
+++ b/src/views/Wire/WireViewContent.tsx
@@ -174,12 +174,12 @@ export const WireViewContent = (props: ViewProps & {
               />
             </Form.Group>
             <Form.Group icon={Tag}>
-              {slugline && selectedPlanning && (
+              {selectedPlanning && (
                 <SluglineEditable
                   key={selectedPlanning?.value}
                   compareValues={[
                     ...(selectedPlanning?.payload?.sluglines || []),
-                    slugline.toString()
+                    slugline?.toString()
                   ]}
                   path='meta.tt/slugline[0].value'
                 />


### PR DESCRIPTION
When deleting the slug, the field is removed. Only when a planning is selected.