### PR TITLE
Feature/ele 1310 scheduled articles should appear in approvals view

### DIFF
--- a/src/hooks/index/lib/assignments/fetchAssignments.ts
+++ b/src/hooks/index/lib/assignments/fetchAssignments.ts
@@ -183,6 +183,7 @@ function constructQuery(
   timeZone: string
 ): QueryV1 {
   const { from, to } = getUTCDateRange(date, timeZone)
+  // CAVEAT: This is in reality a local date but with zero time and a faulty Z in it.
   const formattedDate = format(date, 'yyyy-MM-dd\'T00:00:000Z\'')
 
   if (dateType === 'publish') {

--- a/src/hooks/index/lib/assignments/fetchAssignments.ts
+++ b/src/hooks/index/lib/assignments/fetchAssignments.ts
@@ -183,8 +183,8 @@ function constructQuery(
   timeZone: string
 ): QueryV1 {
   const { from, to } = getUTCDateRange(date, timeZone)
-  // CAVEAT: This is in reality a local date but with zero time and a faulty Z in it.
-  const formattedDate = format(date, 'yyyy-MM-dd\'T00:00:000Z\'')
+  // CAVEAT: This is in reality a local date but with zero time and a misleading Z in it.
+  const formattedDate = format(date, 'yyyy-MM-dd\'T00:00:00:000Z\'')
 
   if (dateType === 'publish') {
     return QueryV1.create({

--- a/src/hooks/index/lib/assignments/fetchAssignments.ts
+++ b/src/hooks/index/lib/assignments/fetchAssignments.ts
@@ -54,7 +54,6 @@ export async function fetchAssignments({ index, repository, type, requireDeliver
 
   do {
     const query = constructQuery(date, dateType, timeZone)
-    console.log(JSON.stringify(query, null, 2))
 
     const { ok, hits, errorMessage } = await index.query({
       accessToken: session.accessToken,

--- a/src/hooks/index/useAssignments.tsx
+++ b/src/hooks/index/useAssignments.tsx
@@ -18,8 +18,9 @@ const defaultStatuses = ['draft', 'done', 'approved', 'withheld']
  * Fetch all assignments in specific date as Block[] extended with some planning level data.
  * Allows optional filtering by type and optional sorting into buckets.
  */
-export const useAssignments = ({ date, type, slots, status, requireDeliverable = false, requireMetrics = null }: {
-  date: Date | string
+export const useAssignments = ({ date, type, dateType = 'start-date', slots, status, requireDeliverable = false, requireMetrics = null }: {
+  date: Date
+  dateType?: 'start-date' | 'publish'
   type?: string | string[]
   requireDeliverable?: boolean
   requireMetrics?: string[] | null
@@ -38,7 +39,7 @@ export const useAssignments = ({ date, type, slots, status, requireDeliverable =
 
   const { data, mutate, error } = useSWR<AssignmentInterface[] | undefined, Error>(
     key,
-    (): Promise<AssignmentInterface[] | undefined> => fetchAssignments({ index, repository, session, date, requireDeliverable, requireMetrics, type })
+    (): Promise<AssignmentInterface[] | undefined> => fetchAssignments({ index, repository, session, date, dateType, timeZone, requireDeliverable, requireMetrics, type })
   )
 
   if (error) {

--- a/src/lib/datetime.ts
+++ b/src/lib/datetime.ts
@@ -328,16 +328,25 @@ export function getUTCDateRange(date: Date, timeZone: string): {
  * in the systems (the elephants) configured timezone. This ensures
  * users in other timezones also get a date in the "home timezone".
  *
+ * If given a specific local date string it will treat it as midnight that day.
+ *
  * Specify a string format to get it as string in iso format.
  *
  * @param timeZone Timezone supported by date-fns
  * @param as Optional string format specifier
  * @returns Date | string
  */
-export function newLocalDate(timeZone: string, as?: 'datetime' | 'date') {
-  const date = toZonedTime(new Date(), timeZone)
+export function newLocalDate(timeZone: string, options?: {
+  as?: 'datetime' | 'date'
+  date?: string // In yyyy-MM-dd format
+}) {
+  const inputDate = options?.date
+    ? fromZonedTime(`${options.date}T00:00:00`, timeZone)
+    : new Date()
 
-  switch (as) {
+  const date = toZonedTime(inputDate, timeZone)
+
+  switch (options?.as) {
     case 'datetime':
       return format(date, 'yyyy-MM-dd\'T\'HH:mm:ss')
 

--- a/src/lib/datetime.ts
+++ b/src/lib/datetime.ts
@@ -336,10 +336,37 @@ export function getUTCDateRange(date: Date, timeZone: string): {
  * @param as Optional string format specifier
  * @returns Date | string
  */
-export function newLocalDate(timeZone: string, options?: {
-  as?: 'datetime' | 'date'
-  date?: string // In yyyy-MM-dd format
-}) {
+export function newLocalDate(
+  timeZone: string,
+  options: {
+    as: 'datetime'
+    date?: string
+  }
+): string
+
+export function newLocalDate(
+  timeZone: string,
+  options: {
+    as: 'date'
+    date?: string
+  }
+): Date
+
+export function newLocalDate(
+  timeZone: string,
+  options?: {
+    as?: 'datetime' | 'date'
+    date?: string
+  }
+): Date
+
+export function newLocalDate(
+  timeZone: string,
+  options?: {
+    as?: 'datetime' | 'date'
+    date?: string // In yyyy-MM-dd format
+  }
+) {
   const inputDate = options?.date
     ? fromZonedTime(`${options.date}T00:00:00`, timeZone)
     : new Date()

--- a/src/views/Approvals/index.tsx
+++ b/src/views/Approvals/index.tsx
@@ -49,8 +49,8 @@ export const ApprovalsView = (): JSX.Element => {
 
   const date = useMemo(() => {
     return (typeof query.from === 'string')
-      ? query.from
-      : newLocalDate(timeZone) // Current date in elephant timeZone!
+      ? newLocalDate(timeZone, { date: query.from }) as Date
+      : newLocalDate(timeZone) as Date
   }, [query.from, timeZone])
 
   const [data, facets] = useAssignments({

--- a/src/views/Approvals/index.tsx
+++ b/src/views/Approvals/index.tsx
@@ -49,8 +49,8 @@ export const ApprovalsView = (): JSX.Element => {
 
   const date = useMemo(() => {
     return (typeof query.from === 'string')
-      ? newLocalDate(timeZone, { date: query.from }) as Date
-      : newLocalDate(timeZone) as Date
+      ? newLocalDate(timeZone, { date: query.from })
+      : newLocalDate(timeZone)
   }, [query.from, timeZone])
 
   const [data, facets] = useAssignments({

--- a/src/views/Approvals/index.tsx
+++ b/src/views/Approvals/index.tsx
@@ -4,9 +4,9 @@ import { timesSlots as Slots } from '@/defaults/assignmentTimeslots'
 import { TimeSlot } from './TimeSlot'
 import { useAssignments } from '@/hooks/index/useAssignments'
 import { useEffect, useMemo, useState } from 'react'
-import { useQuery, useNavigationKeys, useOpenDocuments } from '@/hooks'
+import { useQuery, useNavigationKeys, useOpenDocuments, useRegistry } from '@/hooks'
 import { Header } from '@/components/Header'
-import { getDateTimeBoundariesUTC } from '@/lib/datetime'
+import { newLocalDate } from '@/lib/datetime'
 import { ApprovalsCard } from './ApprovalsCard'
 import { Toolbar } from './Toolbar.tsx'
 import { StatusSpecifications } from '@/defaults/workflowSpecification'
@@ -36,6 +36,8 @@ export const Approvals = (): JSX.Element => {
 }
 
 export const ApprovalsView = (): JSX.Element => {
+  const { timeZone } = useRegistry()
+
   const slots = Object.keys(Slots).map((key) => {
     return {
       key,
@@ -45,18 +47,18 @@ export const ApprovalsView = (): JSX.Element => {
   })
   const [query] = useQuery()
 
-  const { from } = useMemo(() =>
-    getDateTimeBoundariesUTC(typeof query.from === 'string'
-      ? new Date(`${query.from}T00:00:00.000Z`)
-      : new Date()
-    ), [query.from])
-
+  const date = useMemo(() => {
+    return (typeof query.from === 'string')
+      ? query.from
+      : newLocalDate(timeZone) // Current date in elephant timeZone!
+  }, [query.from, timeZone])
 
   const [data, facets] = useAssignments({
     type: ['flash', 'text'],
     requireDeliverable: true,
     requireMetrics: ['charcount'],
-    date: from ? new Date(from) : new Date(),
+    date,
+    dateType: 'publish',
     slots
   })
 


### PR DESCRIPTION
* Correctly fetch text assignment texts based on publish time in Approvals view.
* Fix faulty utc from/to span.
* Added functions that should deprecate other time/date functions including using new Date() which won't give you the local datetime in the systems configured timeZone if using the system in another timezone.