### PR TITLE
feat: add subscription support to document fetching

### DIFF
--- a/src/hooks/index/useDocuments/lib/fetch.ts
+++ b/src/hooks/index/useDocuments/lib/fetch.ts
@@ -1,11 +1,23 @@
 import type { Index } from '@/shared/Index'
 import type { Session } from 'next-auth'
-import type { HitV1, QueryV1, SortingV1 } from '@ttab/elephant-api/index'
+import type { HitV1, QueryV1, SortingV1, SubscriptionReference } from '@ttab/elephant-api/index'
 import { withStatus } from './withStatus'
 import { withPlannings } from './withPlannings'
 import type { useDocumentsFetchOptions } from '../'
+import type { Dispatch, SetStateAction } from 'react'
 
-export async function fetch<T extends HitV1, F>({ index, session, query, page = 1, size = 100, documentType, fields, sort, options }: {
+export async function fetch<T extends HitV1, F>({
+  index,
+  session,
+  query,
+  page = 1,
+  size = 100,
+  documentType,
+  fields,
+  sort,
+  setSubscriptions,
+  options
+}: {
   index: Index | undefined
   session: Session | null
   query?: QueryV1
@@ -14,13 +26,14 @@ export async function fetch<T extends HitV1, F>({ index, session, query, page = 
   documentType: string
   fields?: F
   sort?: SortingV1[]
+  setSubscriptions?: Dispatch<SetStateAction<SubscriptionReference[] | undefined>>
   options?: useDocumentsFetchOptions
 }): Promise<T[]> {
   if (!index || !session?.accessToken) {
     throw new Error('Index or access token is missing')
   }
 
-  const { ok, hits, errorMessage } = await index.query<T, F>({
+  const { ok, hits, errorMessage, subscriptions } = await index.query<T, F>({
     documentType,
     fields,
     accessToken: session.accessToken,
@@ -33,6 +46,10 @@ export async function fetch<T extends HitV1, F>({ index, session, query, page = 
 
   if (!ok) {
     throw new Error(errorMessage || 'Unknown error while fetching data')
+  }
+
+  if (subscriptions && subscriptions.length) {
+    setSubscriptions?.(subscriptions)
   }
 
   let result = hits

--- a/src/hooks/index/useDocuments/schemas/factbox.ts
+++ b/src/hooks/index/useDocuments/schemas/factbox.ts
@@ -4,7 +4,7 @@ import type { FieldValuesV1, HitV1 } from '@ttab/elephant-api/index'
 /**
  * List of fields used in the schema.
  */
-export const fields = [
+export const _fields = [
   'modified',
   'document.title',
   'current_version',
@@ -19,10 +19,10 @@ export const fields = [
 /**
  * Create a schema based on fields array.
  */
-const schemaShape = fields.reduce((acc, field) => {
+const schemaShape = _fields.reduce((acc, field) => {
   acc[field] = z.any()
   return acc
-}, {} as Record<(typeof fields)[number], z.ZodType<FieldValuesV1>>)
+}, {} as Record<(typeof _fields)[number], z.ZodType<FieldValuesV1>>)
 
 /**
  * Zod schema for factboxes.
@@ -32,11 +32,21 @@ const _schema = z.object(schemaShape)
 /**
  * Type inferred from the factboxesSchema.
  */
-type FactboxFields = z.infer<typeof _schema>
+type FactboxFieldsObject = z.infer<typeof _schema>
+
+/**
+ * Type inferred from fields
+ */
+export type FactboxFields = Array<keyof typeof _fields>
 
 /**
  * Interface extending HitV1 with a fields property of type FactboxSchema.
  */
 export interface Factbox extends HitV1 {
-  fields: FactboxFields
+  fields: FactboxFieldsObject
 }
+
+/**
+ * Export fields and cast it as FactboxFields
+ */
+export const fields = _fields as unknown as FactboxFields

--- a/src/views/Event/components/DuplicatesTable.tsx
+++ b/src/views/Event/components/DuplicatesTable.tsx
@@ -35,7 +35,10 @@ export const DuplicatesTable = ({ documentId }: {
     }),
     sort: [
       SortingV1.create({ field: 'modified', desc: true })
-    ]
+    ],
+    options: {
+      subscribe: true
+    }
   })
 
   useRepositoryEvents('core/event', (event) => {

--- a/src/views/EventsOverview/EventsList.tsx
+++ b/src/views/EventsOverview/EventsList.tsx
@@ -37,7 +37,8 @@ export const EventsList = (): JSX.Element => {
       aggregatePages: true,
       setTableData: true,
       withStatus: true,
-      withPlannings: true
+      withPlannings: true,
+      subscribe: true
     }
 
   })

--- a/src/views/Factboxes/FactboxList.tsx
+++ b/src/views/Factboxes/FactboxList.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@/hooks'
 
 import { Table } from '@/components/Table'
 import type { ColumnDef } from '@tanstack/react-table'
-import type { Factbox } from '@/hooks/index/useDocuments/schemas/factbox'
+import type { Factbox, FactboxFields } from '@/hooks/index/useDocuments/schemas/factbox'
 import { Toolbar } from './Toolbar'
 import { useDocuments } from '@/hooks/index/useDocuments'
 import { constructQuery } from '@/hooks/index/useDocuments/queries/views/factboxes'
@@ -16,7 +16,7 @@ export const FactboxList = ({ columns }: {
   const [{ page }] = useQuery()
   const [filter] = useQuery(['query'])
 
-  useDocuments({
+  useDocuments<Factbox, FactboxFields>({
     documentType: 'core/factbox',
     fields,
     query: constructQuery(filter),
@@ -25,6 +25,7 @@ export const FactboxList = ({ columns }: {
       ? parseInt(page)
       : undefined,
     options: {
+      subscribe: true,
       setTableData: true
     }
   })

--- a/src/views/PlanningOverview/PlanningList.tsx
+++ b/src/views/PlanningOverview/PlanningList.tsx
@@ -34,7 +34,8 @@ export const PlanningList = ({ columns }: {
     options: {
       aggregatePages: true,
       withStatus: true,
-      setTableData: true
+      setTableData: true,
+      subscribe: true
     }
   })
 

--- a/src/views/PrintArticles/PrintFlows.tsx
+++ b/src/views/PrintArticles/PrintFlows.tsx
@@ -7,7 +7,7 @@ import { toast } from 'sonner'
 /**
  * PrintFlows component.
  *
- * This component fetches and displays a list of print flows. It uses the `useFetchPrintFlows` hook
+ * This component fetches and displays a list of print flows. It uses the `useDocuments` hook
  * to retrieve the data from the server and displays each flow with its title and content names.
  * A button is provided for each flow, but its functionality is not yet implemented.
  *

--- a/src/views/Wires/WiresList.tsx
+++ b/src/views/Wires/WiresList.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useRef } from 'react'
-import { useQuery, useRegistry, useRepositoryEvents } from '@/hooks'
+import { useCallback } from 'react'
+import { useQuery } from '@/hooks'
 
 import { Table } from '@/components/Table'
 import type { WireFields } from '@/hooks/index/useDocuments/schemas/wire'
@@ -9,19 +9,14 @@ import { Toolbar } from './Toolbar'
 import { useDocuments } from '@/hooks/index/useDocuments'
 import { constructQuery } from '@/hooks/index/useDocuments/queries/views/wires'
 import { SortingV1 } from '@ttab/elephant-api/index'
-import * as handlers from './lib/handlers'
-import { useSession } from 'next-auth/react'
 
 export const WireList = ({ columns }: {
   columns: ColumnDef<Wire, unknown>[]
 }): JSX.Element => {
   const [{ page }] = useQuery()
   const [filter] = useQuery(['section', 'source', 'query', 'newsvalue'])
-  const { data: session } = useSession()
-  const { repository } = useRegistry()
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null)
 
-  const { data, mutate } = useDocuments<Wire, WireFields>({
+  useDocuments<Wire, WireFields>({
     documentType: 'tt/wire',
     size: 40,
     query: constructQuery(filter),
@@ -33,36 +28,8 @@ export const WireList = ({ columns }: {
       SortingV1.create({ field: 'modified', desc: true })
     ],
     options: {
-      setTableData: true
-    }
-  })
-
-  useRepositoryEvents(['tt/wire', 'tt/wire+meta'], (event) => {
-    if (event.event !== 'document' && event.event !== 'status' && event.event !== 'delete_document') {
-      return
-    }
-
-    // Optimistic update and eventually revalidation of new documents
-    if (event.event === 'document') {
-      void handlers.handleDocumentEvent({
-        event,
-        session,
-        repository,
-        source: filter?.source,
-        data,
-        mutate,
-        timeoutRef
-      })
-    }
-
-    // Optimistic update and eventually revalidation of statuses
-    if (event.event === 'status') {
-      void handlers.handleStatusEvent({
-        event,
-        data,
-        mutate,
-        timeoutRef
-      })
+      setTableData: true,
+      subscribe: true
     }
   })
 


### PR DESCRIPTION
- Introduced `subscribe` option in `useDocumentsFetchOptions` to enable subscription-based updates.
- Updated `Index` class to handle subscriptions and polling for updates.
- Modified `useDocuments` hook to manage subscriptions and poll for updates when enabled.
- Enhanced `fetch` function to set subscriptions from the server response.
- Updated various views to enable subscription support where applicable.
- Refactored `factbox` schema to improve type safety and export fields.
- Improved error handling and added user notifications for fetch and polling failures.