### PR TITLE
fix(WorkflowStatus): do snapshot before setting status

### DIFF
--- a/src-srv/routes.ts
+++ b/src-srv/routes.ts
@@ -24,7 +24,7 @@ interface RouteContext extends RouteInitContext {
   res: Response
 }
 
-interface RouteContentResponse {
+export interface RouteContentResponse {
   payload: unknown
   statusCode?: number
 }

--- a/src/lib/snapshot.ts
+++ b/src/lib/snapshot.ts
@@ -2,13 +2,16 @@ import { toast } from 'sonner'
 
 const BASE_URL = import.meta.env.BASE_URL
 
-export async function snapshot(uuid: string): Promise<{ statusCode: number, statusMessage: string } | undefined> {
+type SnapshotResponse = Promise<{ statusCode: number, statusMessage: string } | { version: string, uuid: string } | undefined>
+
+export async function snapshot(uuid: string, force?: true): SnapshotResponse {
   if (!uuid) {
     throw new Error('UUID is required')
   }
 
   try {
-    const response = await fetch(`${BASE_URL}/api/snapshot/${uuid}`)
+    const url = `${BASE_URL}/api/snapshot/${uuid}${force === true ? '?force=true' : ''}`
+    const response = await fetch(url)
 
     if (response.status === 404) {
       return
@@ -18,9 +21,8 @@ export async function snapshot(uuid: string): Promise<{ statusCode: number, stat
       throw new Error(`Error fetching snapshot: ${response.statusText}`)
     }
 
-    console.log('Snapshot response:', response)
 
-    const data = await response.json() as { statusCode: number, statusMessage: string }
+    const data = await response.json() as SnapshotResponse
     return data
   } catch (ex) {
     if (ex instanceof Error) {

--- a/src/views/Editor/index.tsx
+++ b/src/views/Editor/index.tsx
@@ -70,7 +70,9 @@ const Editor = (props: ViewProps): JSX.Element => {
 
   // If published or specific version has be specified
   if (workflowStatus?.name === 'usable' || props.version) {
-    const bigIntVersion = !props.version ? 0n : BigInt(props.version)
+    const bigIntVersion = workflowStatus?.name === 'usable'
+      ? workflowStatus?.version
+      : BigInt(props.version ?? 0)
 
     return (
       <View.Root>


### PR DESCRIPTION
- Introduced a `force` query parameter to the snapshot API to allow forced snapshots even when no changes are detected.
- Updated `snapshotDocument` method in `CollaborationServer` to handle `force` parameter and ensure proper hash usage.
- Enhanced `useWorkflowStatus` hook to utilize the new snapshot response for version updates.
- Refactored `snapshot` utility to support the `force` parameter and return detailed response data.
- Adjusted `Editor` view to correctly handle version logic based on workflow status.

These changes improve snapshot functionality and ensure accurate versioning in workflows.
```