### PR TITLE
fix(useDocuments): subscribe with pagination, add abort signal support

### DIFF
--- a/shared/Index.ts
+++ b/shared/Index.ts
@@ -85,7 +85,7 @@ export class Index {
             source,
             searchAfter: [],
             loadDocument,
-            subscribe: options?.subscribe || false
+            subscribe: currentPage === 1 ? options?.subscribe : false
           }),
           meta(accessToken)
         )
@@ -150,17 +150,28 @@ export class Index {
     }
   }
 
-  async pollSubscription({ subscriptions, accessToken, maxWaitMs = 0n, batchDelayMs = 0n }: {
+  async pollSubscription({
+    subscriptions,
+    accessToken,
+    maxWaitMs = 10000n,
+    batchDelayMs = 200n,
+    abortSignal
+  }: {
     subscriptions: SubscriptionReference[]
     accessToken: string
     maxWaitMs?: bigint
     batchDelayMs?: bigint
+    abortSignal?: AbortSignal
   }) {
     const { response } = await this.#client.pollSubscription({
       subscriptions,
       maxWaitMs,
       batchDelayMs
-    }, meta(accessToken))
+    }, {
+      ...meta(accessToken),
+      abort: abortSignal
+    }
+    )
 
     return response
   }


### PR DESCRIPTION
- Only subscribe to the first page when paginating
- Updated `pollSubscription` method in `Index` class to include an optional `abortSignal` parameter for better control over polling.
- Enhanced `useDocuments` hook to use an `AbortController` for managing long polling subscriptions.
- Introduced `AbortError` class to handle abort-specific errors during polling.
- Refactored polling logic into a separate `pollSubscriptions` function for improved readability and reusability.
- Adjusted default values for `maxWaitMs` and `batchDelayMs` in `pollSubscription` method.

These changes improve the robustness and maintainability of the subscription polling mechanism.