### PR TITLE
feat(user): add abort signal support for message polling

### DIFF
--- a/shared/types/errors.ts
+++ b/shared/types/errors.ts
@@ -1,0 +1,2 @@
+export class AbortError extends Error {}
+


### PR DESCRIPTION
- Introduced `AbortSignal` to `pollMessages` method in `User` class to allow cancellation of polling requests.
- Created a new `AbortError` class to handle aborted requests gracefully.
- Updated `UserMessagesReceiver` to use `AbortController` for managing polling lifecycle and cleanup.
- Added event listener for `beforeunload` to abort polling on page unload.
- Enhanced error handling to differentiate between abort errors and other exceptions.