### PR TITLE
fix(editor): add button to open latest version from read-only

### DIFF
--- a/src/views/Editor/EditorHeader.tsx
+++ b/src/views/Editor/EditorHeader.tsx
@@ -1,4 +1,4 @@
-import { useHistory, useNavigation, useView, useWorkflowStatus, useYValue } from '@/hooks'
+import { useHistory, useLink, useNavigation, useView, useWorkflowStatus, useYValue } from '@/hooks'
 import { Newsvalue } from '@/components/Newsvalue'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { MetaSheet } from './components/MetaSheet'
@@ -11,6 +11,7 @@ import { getValueByYPath, setValueByYPath } from '@/lib/yUtils'
 import type { EleBlock } from '@/shared/types'
 import { toast } from 'sonner'
 import { handleLink } from '@/components/Link/lib/handleLink'
+import { Button } from '@ttab/elephant-ui'
 
 export const EditorHeader = ({ documentId, readOnly, readOnlyVersion }: { documentId: string, readOnly?: boolean, readOnlyVersion?: bigint }): JSX.Element => {
   const { viewId } = useView()
@@ -21,6 +22,8 @@ export const EditorHeader = ({ documentId, readOnly, readOnlyVersion }: { docume
   const [publishTime, setPublishTime] = useState<string | null>(null)
   const [workflowStatus] = useWorkflowStatus(documentId, true)
   const [documentType] = useYValue<string>('root.type')
+
+  const openLatestVersion = useLink('Editor')
 
   useEffect(() => {
     containerRef.current = (document.getElementById(viewId))
@@ -103,6 +106,9 @@ export const EditorHeader = ({ documentId, readOnly, readOnlyVersion }: { docume
   }, [deliverablePlanning, dispatch, documentId, history, state.viewRegistry, viewId, workflowStatus])
 
   const title = documentType === 'core/editorial-info' ? 'Till red' : 'Artikel'
+
+  const isReadOnlyAndUpdated = workflowStatus?.name !== 'usable' && readOnly
+
   return (
     <ViewHeader.Root>
       <ViewHeader.Title name='Editor' title={title} icon={readOnly ? PenOff : PenBoxIcon} />
@@ -120,8 +126,21 @@ export const EditorHeader = ({ documentId, readOnly, readOnlyVersion }: { docume
             {!!documentId && (
               <>
                 {!readOnly && <ViewHeader.RemoteUsers documentId={documentId} />}
-
-                {!!deliverablePlanning && (
+                {isReadOnlyAndUpdated && (
+                  <Button
+                    variant='secondary'
+                    onClick={(event) => {
+                      openLatestVersion(event, {
+                        id: documentId
+                      },
+                      'self'
+                      )
+                    }}
+                  >
+                    Gå till senaste versionen
+                  </Button>
+                )}
+                {!!deliverablePlanning && !isReadOnlyAndUpdated && (
                   <StatusMenu
                     documentId={documentId}
                     type={documentType || 'core/article'}

--- a/src/views/Editor/EditorHeader.tsx
+++ b/src/views/Editor/EditorHeader.tsx
@@ -107,7 +107,7 @@ export const EditorHeader = ({ documentId, readOnly, readOnlyVersion }: { docume
 
   const title = documentType === 'core/editorial-info' ? 'Till red' : 'Artikel'
 
-  const isReadOnlyAndUpdated = workflowStatus?.name !== 'usable' && readOnly
+  const isReadOnlyAndUpdated = workflowStatus && workflowStatus?.name !== 'usable' && readOnly
 
   return (
     <ViewHeader.Root>

--- a/src/views/Editor/index.tsx
+++ b/src/views/Editor/index.tsx
@@ -78,7 +78,7 @@ const Editor = (props: ViewProps): JSX.Element => {
       <View.Root>
         <EditorHeader documentId={documentId} readOnly readOnlyVersion={bigIntVersion} />
         <View.Content className='flex flex-col max-w-[1000px] px-4 h-full'>
-          <PlainEditor id={documentId} version={bigIntVersion} />
+          <PlainEditor key={props.version} id={documentId} version={bigIntVersion} />
         </View.Content>
       </View.Root>
     )


### PR DESCRIPTION
When in readOnly mode and displayed version isn't the latest, instead of StatusMenu show button to go-to-latest.

Problem apparent with: https://github.com/ttab/elephant-chrome/pull/1379 