### PR TITLE
fix(planning/event): sync end date with start date on change

### DIFF
--- a/src/views/Planning/components/PlanDate.tsx
+++ b/src/views/Planning/components/PlanDate.tsx
@@ -1,11 +1,20 @@
 import { DatePicker } from '@/components/Datepicker'
-import { useYValue } from '@/hooks'
-import { parseDate } from '@/lib/datetime'
+import { useRegistry, useYValue } from '@/hooks'
+import { newLocalDate, parseDate } from '@/lib/datetime'
 
 export const PlanDate = (): JSX.Element => {
-  const [dateString, setDateString] = useYValue<string>('meta.core/planning-item[0].data.start_date')
+  const { timeZone } = useRegistry()
 
-  const date = dateString ? parseDate(dateString) || new Date() : new Date()
+  const [startString, setStartString] = useYValue<string>('meta.core/planning-item[0].data.start_date')
+  const [, setEndString] = useYValue<string>('meta.core/planning-item[0].data.end_date')
+
+  const setDateString = (date: string) => {
+    setStartString(date)
+    setEndString(date)
+  }
+
+  const newDate = newLocalDate(timeZone)
+  const date = startString ? parseDate(startString) || newDate : newDate
 
   return (
     <div>


### PR DESCRIPTION
Update PlanDate component to set both start and end date fields when the date is changed. This ensures that the end date is always synchronized with the start date, improving consistency in planning item data. Also, use the user's time zone when creating new dates for better accuracy.