### PR TITLE
fix(workflow): fallback to newStatus.version for wires

### DIFF
--- a/src/hooks/useWorkflowStatus.tsx
+++ b/src/hooks/useWorkflowStatus.tsx
@@ -92,18 +92,19 @@ export const useWorkflowStatus = (uuid?: string, isWorkflow: boolean = false): [
         ? BigInt(snapshotResponse.version)
         : documentStatus?.version
 
-      if (!newVersion) {
-        toast.error('Ett fel har uppstått, aktuell status kunde inte ändras!')
-        return
-      }
-
       let payload: Status | undefined
       if (typeof newStatus !== 'string') {
         payload = {
           ...newStatus,
-          version: newVersion
+          version: newVersion || newStatus.version
         }
       } else if (typeof newStatus === 'string' && documentStatus && uuid) {
+        if (!newVersion) {
+          console.error('Unable to get current version to update status')
+          toast.error('Ett fel har uppstått, aktuell status kunde inte ändras!')
+          return
+        }
+
         payload = {
           ...documentStatus,
           uuid,


### PR DESCRIPTION
Ensure that when neither snapshotResponse.version nor documentStatus?.version is available, the hook falls back to newStatus.version. This fixes status updates for wires where previous logic failed to provide a valid version.