### PR TITLE
feat(form): propagate onChange for unsaved changes tracking

### DIFF
--- a/src/components/Assignees.tsx
+++ b/src/components/Assignees.tsx
@@ -10,7 +10,7 @@ import { YBlock } from '@/shared/YBlock'
 import type { EleBlock } from '@/shared/types'
 import { type FormProps } from './Form/Root'
 
-export const Assignees = ({ path, placeholder, asDialog }: {
+export const Assignees = ({ path, placeholder, asDialog, onChange }: {
   placeholder: string
   path: string
 } & FormProps): JSX.Element | undefined => {
@@ -44,6 +44,8 @@ export const Assignees = ({ path, placeholder, asDialog }: {
             setFocused.current(true, isOpen ? path : '')
           }}
           onSelect={(option) => {
+            onChange?.(true)
+
             const selectedAssignee = selectedOptions.findIndex((sa) => sa.value === option.value)
 
             if (selectedAssignee > -1) {

--- a/src/components/AssignmentTime/index.tsx
+++ b/src/components/AssignmentTime/index.tsx
@@ -5,6 +5,7 @@ import { TimeDeliveryMenu } from './TimeDeliveryMenu'
 import { type AssignmentValueOption, type AssignmentData } from './types'
 import { ExecutionTimeMenu } from './ExecutionTimeMenu'
 import { timeSlotTypes, timePickTypes } from '../../defaults/assignmentTimeConstants'
+import type { FormProps } from '../Form/Root'
 
 const getTimeSlot = (timeSlot: string): AssignmentValueOption | undefined => {
   return timeSlotTypes.find((type) => type.slots?.includes(timeSlot))
@@ -21,9 +22,9 @@ const getMidnightISOString = (endDate: string | undefined): string => {
   return endDateIsoString
 }
 
-export const AssignmentTime = ({ index }: {
+export const AssignmentTime = ({ index, onChange }: {
   index: number
-}): JSX.Element => {
+} & FormProps): JSX.Element => {
   const [assignmentType] = useYValue<string>(`meta.core/assignment[${index}].meta.core/assignment-type[0].value`)
   const [data, setData] = useYValue<AssignmentData>(`meta.core/assignment[${index}].data`)
   const { full_day: fullDay, end, publish_slot: publishSlot, end_date: endDate, start_date: startDate } = data || {}
@@ -59,6 +60,8 @@ export const AssignmentTime = ({ index }: {
   const handleOnSelect = ({ value, selectValue }: { value: string, selectValue: string }): void => {
     switch (value) {
       case 'fullday':
+        onChange?.(true)
+
         setData(Block.create({
           data: {
             end_date: data?.end_date,
@@ -74,6 +77,8 @@ export const AssignmentTime = ({ index }: {
       case 'forenoon':
       case 'afternoon':
       case 'evening': {
+        onChange?.(true)
+
         setData(Block.create({
           data: {
             end_date: data?.end_date,
@@ -92,6 +97,9 @@ export const AssignmentTime = ({ index }: {
 
       case 'endexecution': {
         const endValue = new Date(`${endDate}T${selectValue}`).toISOString()
+
+        onChange?.(true)
+
         setData(Block.create({
           data: {
             end_date: data?.end_date,

--- a/src/components/DataItem/AssignmentType.tsx
+++ b/src/components/DataItem/AssignmentType.tsx
@@ -5,13 +5,14 @@ import { Block } from '@ttab/elephant-api/newsdoc'
 import { useYValue } from '@/hooks/useYValue'
 import { FilePen, FilePlus2 } from '@ttab/elephant-ui/icons'
 import type { DefaultValueOption } from '@/types/index'
+import type { FormProps } from '../Form/Root'
 
-export const AssignmentType = ({ path, editable = false, readOnly = false, className }: {
+export const AssignmentType = ({ path, editable = false, readOnly = false, className, onChange }: {
   path: string
   className?: string
   editable?: boolean
   readOnly?: boolean
-}): JSX.Element => {
+} & FormProps): JSX.Element => {
   const [assignmentType, setAssignmentType] = useYValue<Block[]>(path + '.meta.core/assignment-type')
   const [, setAssignmentVisibility] = useYValue<string>(path + 'data.public')
 
@@ -47,6 +48,8 @@ export const AssignmentType = ({ path, editable = false, readOnly = false, class
       disabled={!editable}
       value={selectedOptions[0]?.value}
       onValueChange={(value) => {
+        onChange?.(true)
+
         switch (value) {
           case 'picture/video':
             setAssignmentType([Block.create({

--- a/src/components/DataItem/AssignmentVisibility.tsx
+++ b/src/components/DataItem/AssignmentVisibility.tsx
@@ -3,18 +3,21 @@ import { Tooltip, Select, SelectTrigger, SelectContent, SelectItem } from '@ttab
 import { Building, Globe } from '@ttab/elephant-ui/icons'
 import { cn } from '@ttab/elephant-ui/utils'
 import { useCallback, useMemo } from 'react'
+import type { FormProps } from '../Form/Root'
 
-export const AssignmentVisibility = ({ path, editable, disabled, className = '' }: {
+export const AssignmentVisibility = ({ path, editable, disabled, className = '', onChange }: {
   path: string
   editable: boolean
   disabled: boolean
   className?: string
-}): JSX.Element => {
+} & FormProps): JSX.Element => {
   const [visibilityStatus, setAssignmentVisibility] = useYValue<string>(path)
 
   const onValueChange = useCallback(
-    (value: string) => setAssignmentVisibility(value),
-    [setAssignmentVisibility]
+    (value: string) => {
+      setAssignmentVisibility(value)
+      onChange?.(true)
+    }, [setAssignmentVisibility, onChange]
   )
 
   const tooltipContent = useMemo(

--- a/src/components/DataItem/SluglineEditable.tsx
+++ b/src/components/DataItem/SluglineEditable.tsx
@@ -7,13 +7,14 @@ import { Validation } from '../Validation'
 import { SluglineButton } from './Slugline'
 import { type FormProps } from '../Form/Root'
 import type { Block } from '@ttab/elephant-api/newsdoc'
+import type { TBElement } from '@ttab/textbit'
 
-export const SluglineEditable = ({ path, documentStatus, onValidation, validateStateRef, compareValues, disabled }: {
+export const SluglineEditable = ({ path, documentStatus, onValidation, validateStateRef, compareValues, disabled, onChange }: {
   disabled?: boolean
   path: string
   compareValues?: string[]
   documentStatus?: string
-  onValidation?: (label: string, block: string, value: string | undefined, reason: string) => boolean
+  onChange?: (value: TBElement[]) => void
 } & FormProps): JSX.Element => {
   const setFocused = useRef<(value: boolean) => void>(null)
   const [slugLine] = useYValue<Y.XmlText>(path)
@@ -59,6 +60,7 @@ export const SluglineEditable = ({ path, documentStatus, onValidation, validateS
                   singleLine={true}
                   className='h-6 font-normal text-sm whitespace-nowrap mb-1'
                   spellcheck={false}
+                  onChange={onChange}
                 />
               </Validation>
             </Awareness>

--- a/src/components/Description.tsx
+++ b/src/components/Description.tsx
@@ -1,12 +1,14 @@
+import React from 'react'
 import { MessageCircleMore, Text } from '@ttab/elephant-ui/icons'
 import { TextBox } from '@/components/ui'
 import { type Block } from '@ttab/elephant-api/newsdoc'
 import { useYValue } from '@/hooks/useYValue'
+import type { FormProps } from './Form/Root'
 
-
-export const Description = ({ role }: {
+export const Description = React.memo(function Description({ role, onChange }: {
   role: 'internal' | 'public'
-}): JSX.Element => {
+} & FormProps): JSX.Element | null {
+  // FIXME: The use of statuDescriptions is causing rerenders on _every_ change
   const [stateDescriptions] = useYValue<Block[]>('meta.core/description')
 
   const index = findIndex(stateDescriptions, role)
@@ -16,6 +18,7 @@ export const Description = ({ role }: {
     <div className='flex w-full'>
       <TextBox
         path={path}
+        onChange={onChange}
         icon={role === 'internal'
           ? <MessageCircleMore size={18} strokeWidth={1.75} className='text-muted-foreground mr-4' />
           : <Text size={18} strokeWidth={1.75} className='text-muted-foreground mr-4' />}
@@ -24,7 +27,7 @@ export const Description = ({ role }: {
       />
     </div>
   )
-}
+})
 
 function findIndex(stateDescriptions: Block[] | undefined, role: 'internal' | 'public'): number {
   // If no descriptions, assign indices based on role
@@ -36,3 +39,4 @@ function findIndex(stateDescriptions: Block[] | undefined, role: 'internal' | 'p
   const foundIndex = stateDescriptions.findIndex((description) => description.role === role)
   return foundIndex === -1 ? stateDescriptions.length : foundIndex
 }
+

--- a/src/components/DocumentStatus/StatusButton.tsx
+++ b/src/components/DocumentStatus/StatusButton.tsx
@@ -1,0 +1,52 @@
+import type { StatusSpecification, WorkflowSpecification } from '@/defaults/workflowSpecification'
+import type { Status } from '@/shared/Repository'
+import { Button } from '@ttab/elephant-ui'
+import { ChevronDown } from '@ttab/elephant-ui/icons'
+import { forwardRef } from 'react'
+
+export const StatusButton = forwardRef<HTMLButtonElement, {
+  asSave: boolean
+  documentStatus: Status
+  workflow: WorkflowSpecification
+  currentStatusName: string
+  currentStatusDef: StatusSpecification
+}>((props, ref) => {
+  const {
+    asSave,
+    documentStatus,
+    workflow,
+    currentStatusName,
+    currentStatusDef,
+    ...rest
+  } = props
+  const CurrentIcon = currentStatusDef.icon
+
+  return (
+    <Button
+      ref={ref}
+      size='sm'
+      variant='outline'
+      className='flex items-center h-8 px-3'
+      title={workflow[props.currentStatusName]?.description}
+      {...rest}
+    >
+      <div className='pe-2'>
+        <CurrentIcon
+          size={18}
+          strokeWidth={1.75}
+          className={currentStatusDef?.className}
+        />
+      </div>
+      <div className='pe-1'>
+        {asSave ? 'Opublicerade ändringar' : workflow[currentStatusName]?.title}
+      </div>
+      <div className='ps-1'>
+        <ChevronDown size={16} />
+      </div>
+
+    </Button>
+  )
+}
+)
+
+StatusButton.displayName = 'StatusButton'

--- a/src/components/DocumentStatus/StatusMenu.tsx
+++ b/src/components/DocumentStatus/StatusMenu.tsx
@@ -1,5 +1,4 @@
-import { Button, DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@ttab/elephant-ui'
-import { ChevronDown } from '@ttab/elephant-ui/icons'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@ttab/elephant-ui'
 import { useRef, useState, useEffect, useCallback } from 'react'
 import { useWorkflow } from '@/hooks/index/useWorkflow'
 import type { WorkflowTransition } from '@/defaults/workflowSpecification'
@@ -8,8 +7,10 @@ import { StatusOptions } from './StatusOptions'
 import { StatusMenuHeader } from './StatusMenuHeader'
 import { PromptDefault } from './PromptDefault'
 import { PromptSchedule } from './PromptSchedule'
+import { StatusMenuOption } from './StatusMenuOption'
+import { StatusButton } from './StatusButton'
 
-export const StatusMenu = ({ documentId, type, publishTime, onBeforeStatusChange }: {
+export const StatusMenu = ({ documentId, type, publishTime, onBeforeStatusChange, isChanged }: {
   documentId: string
   type: string
   publishTime?: Date
@@ -17,6 +18,7 @@ export const StatusMenu = ({ documentId, type, publishTime, onBeforeStatusChange
     status: string,
     data?: Record<string, unknown>
   ) => Promise<boolean>
+  isChanged?: boolean
 }) => {
   const [documentStatus, setDocumentStatus] = useWorkflowStatus(documentId, type === 'core/article')
   const containerRef = useRef<HTMLDivElement>(null)
@@ -57,29 +59,20 @@ export const StatusMenu = ({ documentId, type, publishTime, onBeforeStatusChange
     return null
   }
 
-  const CurrentIcon = currentStatusDef.icon
-
   return (
     <>
       <div className='flex items-center' ref={containerRef}>
 
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button size='sm' variant='outline' className='flex items-center h-8 px-3' title={workflow[currentStatusName]?.description}>
-              <div className='pe-2'>
-                <CurrentIcon
-                  size={18}
-                  strokeWidth={1.75}
-                  className={currentStatusDef?.className}
-                />
-              </div>
-              <div className='pe-1'>
-                {workflow[currentStatusName]?.title}
-              </div>
-              <div className='ps-1'>
-                <ChevronDown size={16} />
-              </div>
-            </Button>
+            <StatusButton
+              documentStatus={documentStatus}
+              workflow={workflow}
+              currentStatusName={currentStatusName}
+              currentStatusDef={currentStatusDef}
+              asSave={!!(isChanged && documentStatus.name !== 'draft')}
+
+            />
           </DropdownMenuTrigger>
 
           <DropdownMenuContent
@@ -94,12 +87,26 @@ export const StatusMenu = ({ documentId, type, publishTime, onBeforeStatusChange
               title={workflow[currentStatusName]?.title}
               description={workflow[currentStatusName]?.description}
             />
-
             <StatusOptions
               transitions={transitions}
               statuses={statuses}
               onSelect={showPrompt}
-            />
+            >
+              {isChanged && documentStatus.name !== 'draft' && (
+                <StatusMenuOption
+                  key='save'
+                  status={documentStatus.name}
+                  state={{
+                    verify: true,
+                    title: `Spara ändringar - ${workflow[currentStatusName]?.title}`,
+                    description: 'Spara ändringar'
+                  }}
+                  onSelect={showPrompt}
+                  statusDef={currentStatusDef}
+                />
+
+              )}
+            </StatusOptions>
 
           </DropdownMenuContent>
         </DropdownMenu>
@@ -131,4 +138,3 @@ export const StatusMenu = ({ documentId, type, publishTime, onBeforeStatusChange
     </>
   )
 }
-

--- a/src/components/DocumentStatus/StatusOptions.tsx
+++ b/src/components/DocumentStatus/StatusOptions.tsx
@@ -1,13 +1,15 @@
 import type { StatusSpecification, WorkflowTransition } from '@/defaults/workflowSpecification'
 import { StatusMenuOption } from './StatusMenuOption'
+import type { PropsWithChildren } from 'react'
 
-export const StatusOptions = ({ transitions, statuses, onSelect }: {
+export const StatusOptions = ({ transitions, statuses, onSelect, children }: {
   transitions: Record<string, WorkflowTransition>
   statuses: Record<string, StatusSpecification>
   onSelect: (state: { status: string } & WorkflowTransition) => void
-}) => {
+} & PropsWithChildren) => {
   return (
     <div className='p-2'>
+      {children}
       {Object.entries(transitions)
         .filter(([status]) => {
           // Filter out configured transitions not allowed according to

--- a/src/components/Form/Content.tsx
+++ b/src/components/Form/Content.tsx
@@ -2,28 +2,33 @@ import React from 'react'
 import { type FormProps } from './Root'
 import { cva } from 'class-variance-authority'
 
-export const Content = ({ children, asDialog, onValidation, validateStateRef }: FormProps): JSX.Element => {
-  const variants = cva('flex flex-col gap-4 items-start',
-    {
-      variants: {
-        asDialog: {
-          false: 'px-10',
-          true: 'py-5 px-6'
+export const Content = React.memo(
+  ({ children, asDialog, onValidation, validateStateRef, onChange }: FormProps): JSX.Element => {
+    const variants = cva('flex flex-col gap-4 items-start',
+      {
+        variants: {
+          asDialog: {
+            false: 'px-10',
+            true: 'py-5 px-6'
+          }
         }
-      }
-    })
+      })
 
-  return (
-    <div className={variants({ asDialog })}>
-      {React.Children.map(children, (child: React.ReactNode): React.ReactNode =>
-        React.isValidElement<FormProps>(child)
-          ? React.cloneElement(child, {
-            asDialog,
-            onValidation,
-            validateStateRef
-          })
-          : child
-      )}
-    </div>
-  )
-}
+    return (
+      <div className={variants({ asDialog })}>
+        {React.Children.map(children, (child: React.ReactNode): React.ReactNode =>
+          React.isValidElement<FormProps>(child)
+            ? React.cloneElement(child, {
+              asDialog,
+              onChange,
+              onValidation,
+              validateStateRef
+            })
+            : child
+        )}
+      </div>
+    )
+  }
+)
+
+Content.displayName = 'Content'

--- a/src/components/Form/Group.tsx
+++ b/src/components/Form/Group.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { type LucideIcon } from '@ttab/elephant-ui/icons'
 import { type FormProps } from './Root'
 
-export const Group = ({ children, icon: Icon, asDialog, onValidation, validateStateRef }: FormProps & {
+export const Group = ({ children, icon: Icon, asDialog, onValidation, validateStateRef, onChange }: FormProps & {
   icon?: LucideIcon
 }): JSX.Element => (
 
@@ -29,6 +29,7 @@ export const Group = ({ children, icon: Icon, asDialog, onValidation, validateSt
           ? React.cloneElement(child, {
             asDialog,
             onValidation,
+            onChange,
             validateStateRef
           })
           : child

--- a/src/components/Form/Title.tsx
+++ b/src/components/Form/Title.tsx
@@ -3,7 +3,7 @@ import { cn } from '@ttab/elephant-ui/utils'
 import { cva } from 'class-variance-authority'
 import { type FormProps } from './Root'
 
-export const Title = ({ children, asDialog, onValidation }: FormProps): JSX.Element => {
+export const Title = ({ children, asDialog, onValidation, onChange }: FormProps): JSX.Element => {
   const titleVariants = cva(`
     w-full
     [&_[role="textbox"]:has([data-slate-placeholder="true"])]:!ring-0
@@ -30,6 +30,7 @@ export const Title = ({ children, asDialog, onValidation }: FormProps): JSX.Elem
         React.isValidElement<FormProps>(child)
           ? React.cloneElement(child, {
             asDialog,
+            onChange,
             onValidation
           })
           : child

--- a/src/components/Move/index.tsx
+++ b/src/components/Move/index.tsx
@@ -28,6 +28,7 @@ export const Move = (props: ViewProps & {
     assignment: Y.Map<unknown> | undefined
     planningId: string | undefined
   }
+  onChange?: (arg: boolean) => void
 }): JSX.Element => {
   const [selectedPlanning, setSelectedPlanning] = useState<DefaultValueOption | undefined>(undefined)
   const [showVerifyDialog, setShowVerifyDialog] = useState(false)
@@ -119,6 +120,8 @@ export const Move = (props: ViewProps & {
 
       // Remove from old planning
       deleteByYPath(yRootOriginal, `meta.core/assignment[${originalAssignmentIndex}]`)
+
+      props.onChange?.(true)
 
       const newPlanningUUID = getValueByYPath<string>(newEle, 'root.uuid')?.[0]
       toast.success('Uppdraget har flyttats', {

--- a/src/components/Newsvalue.tsx
+++ b/src/components/Newsvalue.tsx
@@ -6,7 +6,8 @@ import { Awareness } from '@/components'
 import { Validation } from './Validation'
 import type { FormProps } from './Form/Root'
 
-export const Newsvalue = ({ onValidation, validateStateRef }: FormProps): JSX.Element => {
+export const Newsvalue = ({ onValidation, validateStateRef, onChange }:
+FormProps): JSX.Element => {
   const path = 'meta.core/newsvalue[0].value'
   const [newsvalue, setNewsvalue] = useYValue<string | undefined>(path)
   const setFocused = useRef<(value: boolean, path: string) => void>(() => { })
@@ -39,6 +40,8 @@ export const Newsvalue = ({ onValidation, validateStateRef }: FormProps): JSX.El
             setFocused.current(true, isOpen ? path : '')
           }}
           onSelect={(option) => {
+            onChange?.(true)
+
             if (newsvalue === option.value) {
               setNewsvalue(undefined)
             } else {

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -6,7 +6,8 @@ import { useRef } from 'react'
 import { Validation } from './Validation'
 import { type FormProps } from './Form/Root'
 
-export const Section = ({ onValidation, validateStateRef }: FormProps): JSX.Element => {
+export const Section = ({ onValidation, validateStateRef, onChange }:
+FormProps): JSX.Element => {
   const allSections = useSections().map((_) => {
     return {
       value: _.id,
@@ -42,6 +43,8 @@ export const Section = ({ onValidation, validateStateRef }: FormProps): JSX.Elem
             }
           }}
           onSelect={(option) => {
+            onChange?.(true)
+
             if (section?.title === option.label) {
               setSection(undefined)
             } else {

--- a/src/components/Story.tsx
+++ b/src/components/Story.tsx
@@ -3,8 +3,9 @@ import { useStories, useYValue } from '@/hooks'
 import { Block } from '@ttab/elephant-api/newsdoc'
 import { ComboBox } from '@ttab/elephant-ui'
 import { useRef } from 'react'
+import type { FormProps } from './Form/Root'
 
-export const Story = (): JSX.Element => {
+export const Story = ({ onChange }: FormProps): JSX.Element => {
   const allStories = useStories().map((_) => {
     return {
       value: _.id,
@@ -31,6 +32,7 @@ export const Story = (): JSX.Element => {
           setFocused.current(true, isOpen ? path : '')
         }}
         onSelect={(option) => {
+          onChange?.(true)
           setStory(story?.title === option.label
             ? undefined
             : Block.create({

--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -1,14 +1,24 @@
-import { TextBox } from '@/components/ui'
+import React from 'react'
+import type { FormProps } from './Form/Root'
+import { TextBox } from './ui'
 import { Validation } from './Validation'
-import { type FormProps } from './Form/Root'
 
-export const Title = ({ autoFocus, placeholder, path, className, onValidation, validateStateRef, countCharacters }: FormProps & {
+export const Title = React.memo(({
+  autoFocus,
+  placeholder,
+  path,
+  className,
+  onValidation,
+  validateStateRef,
+  countCharacters,
+  onChange
+}: {
   autoFocus?: boolean
   placeholder: string
   path?: string
   className?: string
   countCharacters?: boolean
-}): JSX.Element => (
+} & FormProps): JSX.Element => (
   <Validation
     label='Titel'
     path={path || 'root.title'}
@@ -23,6 +33,10 @@ export const Title = ({ autoFocus, placeholder, path, className, onValidation, v
       autoFocus={!!autoFocus}
       singleLine={true}
       countCharacters={countCharacters}
+      onChange={onChange}
     />
   </Validation>
 )
+)
+
+Title.displayName = 'Title'

--- a/src/components/ui/TextBox.tsx
+++ b/src/components/ui/TextBox.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useRef } from 'react'
 import { Awareness } from '../Awareness'
 import { TextboxRoot } from './Textbox/TextboxRoot'
 
-export const TextBox = ({ icon: Icon, path, ...props }: {
+export const TextBox = ({ icon: Icon, path, onChange, ...props }: {
   disabled?: boolean
   path: string
   icon?: React.ReactNode
@@ -14,6 +14,7 @@ export const TextBox = ({ icon: Icon, path, ...props }: {
   spellcheck?: boolean
   onBlur?: React.FocusEventHandler<HTMLDivElement>
   onFocus?: React.FocusEventHandler<HTMLDivElement>
+  onChange?: (arg: boolean) => void
 }): JSX.Element => {
   const setFocused = useRef<(value: boolean, key: string) => void>(() => { })
   const { onFocus, onBlur } = props
@@ -41,7 +42,7 @@ export const TextBox = ({ icon: Icon, path, ...props }: {
           </div>
         )}
 
-        <TextboxRoot {...props} path={path} onBlur={handleOnBlur} onFocus={handleOnFocus} />
+        <TextboxRoot {...props} path={path} onBlur={handleOnBlur} onFocus={handleOnFocus} onChange={onChange} />
       </div>
     </Awareness>
   )

--- a/src/components/ui/Textbox/TextboxEditable.tsx
+++ b/src/components/ui/Textbox/TextboxEditable.tsx
@@ -10,7 +10,7 @@ import { ContextMenu } from '../../Editor/ContextMenu'
 import { useOnSpellcheck } from '@/hooks/useOnSpellcheck'
 import { getValueByYPath } from '@/shared/yUtils'
 
-export const TextboxEditable = ({ provider, path, user, content, singleLine, spellcheck, disabled = false }: {
+export const TextboxEditable = ({ provider, path, user, content, singleLine, spellcheck, disabled = false, onChange }: {
   disabled?: boolean
   provider: HocuspocusProvider
   path: string
@@ -18,6 +18,7 @@ export const TextboxEditable = ({ provider, path, user, content, singleLine, spe
   user: AwarenessUserData
   content: Y.XmlText
   spellcheck?: boolean
+  onChange?: (arg: boolean) => void
 }): JSX.Element | undefined => {
   const [documentLanguage] = getValueByYPath<string>(provider.document.getMap('ele'), 'root.language')
   const onSpellcheck = useOnSpellcheck(documentLanguage)
@@ -49,6 +50,11 @@ export const TextboxEditable = ({ provider, path, user, content, singleLine, spe
 
   return (
     <Textbit.Editable
+      onChange={() => {
+        if (provider.hasUnsyncedChanges) {
+          onChange?.(true)
+        }
+      }}
       readOnly={disabled}
       yjsEditor={yjsEditor}
       lang={documentLanguage}

--- a/src/components/ui/Textbox/TextboxRoot.tsx
+++ b/src/components/ui/Textbox/TextboxRoot.tsx
@@ -14,7 +14,8 @@ export const TextboxRoot = ({
   autoFocus = false,
   spellcheck = true,
   onBlur,
-  onFocus
+  onFocus,
+  onChange
 }: {
   disabled?: boolean
   path: string
@@ -25,6 +26,7 @@ export const TextboxRoot = ({
   spellcheck?: boolean
   onBlur: React.FocusEventHandler<HTMLDivElement>
   onFocus: React.FocusEventHandler<HTMLDivElement>
+  onChange?: (arg: boolean) => void
 }): JSX.Element => {
   const { provider, user } = useCollaboration()
   // FIXME: We need to check that the path exists. If not we need to create the missing Block
@@ -66,6 +68,7 @@ export const TextboxRoot = ({
             singleLine={singleLine}
             user={user}
             spellcheck={spellcheck}
+            onChange={onChange}
           />
         </Textbit.Root>
       )}

--- a/src/hooks/useWorkflowStatus.tsx
+++ b/src/hooks/useWorkflowStatus.tsx
@@ -1,7 +1,7 @@
 import { useSession } from 'next-auth/react'
 import useSWR, { mutate as globalMutate } from 'swr'
 import { useCallback } from 'react'
-import { useRegistry } from '@/hooks'
+import { useRegistry, useYValue } from '@/hooks'
 import { toast } from 'sonner'
 import type { Status } from '@/shared/Repository'
 import { snapshot } from '@/lib/snapshot'
@@ -13,6 +13,7 @@ export const useWorkflowStatus = (uuid?: string, isWorkflow: boolean = false): [
 ] => {
   const { repository } = useRegistry()
   const { data: session } = useSession()
+  const [, setChanged] = useYValue('root.changed')
 
   /**
    * SWR callback that fetches current workflow status
@@ -117,6 +118,9 @@ export const useWorkflowStatus = (uuid?: string, isWorkflow: boolean = false): [
           isWorkflow
         })
 
+        // Reset unsaved changes state
+        setChanged(undefined)
+
         // Revalidate after the mutation completes
         await globalMutate([`status/${uuid || payload.uuid}`])
       } catch (error) {
@@ -126,10 +130,8 @@ export const useWorkflowStatus = (uuid?: string, isWorkflow: boolean = false): [
         await mutate(currentStatus, false)
       }
     },
-    [session, uuid, documentStatus, mutate, repository, isWorkflow]
+    [session, uuid, documentStatus, mutate, repository, isWorkflow, setChanged]
   )
 
   return [documentStatus, setDocumentStatus]
 }
-
-

--- a/src/hooks/useYValue.tsx
+++ b/src/hooks/useYValue.tsx
@@ -1,5 +1,5 @@
 import { isEqualDeep } from '@/lib/isEqualDeep'
-import { useRef, useSyncExternalStore } from 'react'
+import { useCallback, useRef, useSyncExternalStore } from 'react'
 import { getValueByYPath, setValueByYPath, stringToYPath } from '@/shared/yUtils'
 import { useCollaboration } from './useCollaboration'
 import type { HocuspocusProvider } from '@hocuspocus/provider'
@@ -53,9 +53,9 @@ export function useYValue<T>(path: string, raw: boolean = false, externalProvide
   )
 
   // Setter function to update the value at the path
-  const setData = (newValue: T): void => {
+  const setData = useCallback((newValue: T): void => {
     setValueByYPath(yRoot, yPath, newValue)
-  }
+  }, [yRoot, yPath])
 
   return [
     data as T,

--- a/src/views/Planning/components/Assignment.tsx
+++ b/src/views/Planning/components/Assignment.tsx
@@ -12,7 +12,7 @@ import { type FormProps } from '@/components/Form/Root'
 import { useEffect, useRef } from 'react'
 import { AssignmentVisibility } from '@/components/DataItem/AssignmentVisibility'
 
-export const Assignment = ({ index, onAbort, onClose }: {
+export const Assignment = ({ index, onAbort, onClose, onChange }: {
   index: number
   onClose: () => void
   onAbort?: () => void
@@ -50,7 +50,7 @@ export const Assignment = ({ index, onAbort, onClose }: {
 
   return (
     <div className='flex flex-col rounded-md border shadow-xl -mx-1 -my-1 z-10 bg-background' ref={formRef}>
-      <Form.Root asDialog={true}>
+      <Form.Root asDialog={true} onChange={onChange}>
         <Form.Content>
           <Form.Title>
             <Title

--- a/src/views/Planning/components/AssignmentRow.tsx
+++ b/src/views/Planning/components/AssignmentRow.tsx
@@ -31,11 +31,12 @@ import { CreatePrintArticle } from '@/components/CreatePrintArticle'
 import { snapshot } from '@/lib/snapshot'
 import { AssignmentVisibility } from '@/components/DataItem/AssignmentVisibility'
 
-export const AssignmentRow = ({ index, onSelect, isFocused = false, asDialog }: {
+export const AssignmentRow = ({ index, onSelect, isFocused = false, asDialog, onChange }: {
   index: number
   onSelect: () => void
   isFocused?: boolean
   asDialog?: boolean
+  onChange?: (arg: boolean) => void
 }): JSX.Element => {
   const { provider } = useCollaboration()
   const openArticle = useLink('Editor')
@@ -175,6 +176,7 @@ export const AssignmentRow = ({ index, onSelect, isFocused = false, asDialog }: 
         showModal(
           <Move
             asDialog
+            onChange={onChange}
             onDialogClose={hideModal}
             original={{
               document: provider?.document,
@@ -301,6 +303,8 @@ export const AssignmentRow = ({ index, onSelect, isFocused = false, asDialog }: 
               provider?.document.getMap('ele'),
               `meta.core/assignment[${index}]`
             )
+
+            onChange?.(true)
           }}
           onSecondary={() => {
             setShowVerifyDialog(false)

--- a/src/views/Planning/components/AssignmentTable.tsx
+++ b/src/views/Planning/components/AssignmentTable.tsx
@@ -13,8 +13,9 @@ import { cva } from 'class-variance-authority'
 import { Button } from '@ttab/elephant-ui'
 import { useActiveAuthor } from '@/hooks/useActiveAuthor'
 
-export const AssignmentTable = ({ asDialog = false }: {
+export const AssignmentTable = ({ asDialog = false, onChange }: {
   asDialog?: boolean
+  onChange?: (arg: boolean) => void
 }): JSX.Element => {
   const { provider } = useCollaboration()
   const [assignments] = useYValue<EleBlock[]>('meta.core/assignment')
@@ -129,6 +130,9 @@ export const AssignmentTable = ({ asDialog = false }: {
             }
 
             deleteByYPath(yRoot, `${currentAssigmentPath}.__inProgress`)
+
+            // Set document as changed once we abort the new assignment
+            onChange?.(true)
           }}
           className='mb-6'
         />
@@ -141,6 +145,7 @@ export const AssignmentTable = ({ asDialog = false }: {
               {selectedAssignment === index
                 ? (
                     <Assignment
+                      onChange={onChange}
                       index={index}
                       onClose={() => {
                         setSelectedAssignment(undefined)
@@ -153,6 +158,7 @@ export const AssignmentTable = ({ asDialog = false }: {
                       index={index}
                       isFocused={index === focusedRowIndex}
                       asDialog={asDialog}
+                      onChange={onChange}
                       onSelect={() => {
                         if (!newAssigment) {
                           setSelectedAssignment(index)

--- a/src/views/Planning/components/PlanDate.tsx
+++ b/src/views/Planning/components/PlanDate.tsx
@@ -1,14 +1,17 @@
 import { DatePicker } from '@/components/Datepicker'
+import type { FormProps } from '@/components/Form/Root'
 import { useRegistry, useYValue } from '@/hooks'
 import { newLocalDate, parseDate } from '@/lib/datetime'
 
-export const PlanDate = (): JSX.Element => {
+export const PlanDate = ({ onChange }: FormProps): JSX.Element => {
   const { timeZone } = useRegistry()
 
   const [startString, setStartString] = useYValue<string>('meta.core/planning-item[0].data.start_date')
   const [, setEndString] = useYValue<string>('meta.core/planning-item[0].data.end_date')
 
   const setDateString = (date: string) => {
+    onChange?.(true)
+
     setStartString(date)
     setEndString(date)
   }

--- a/src/views/Planning/components/PlanningHeader.tsx
+++ b/src/views/Planning/components/PlanningHeader.tsx
@@ -5,10 +5,11 @@ import { ViewHeader } from '@/components/View'
 import { GanttChartSquare } from '@ttab/elephant-ui/icons'
 import { MetaSheet } from '@/views/Editor/components/MetaSheet'
 
-export const PlanningHeader = ({ documentId, asDialog, onDialogClose }: {
+export const PlanningHeader = ({ documentId, asDialog, onDialogClose, isChanged }: {
   documentId: string
   asDialog: boolean
   onDialogClose?: () => void
+  isChanged?: boolean
 }): JSX.Element => {
   const { viewId } = useView()
   const containerRef = useRef<HTMLElement | null>(null)
@@ -33,7 +34,11 @@ export const PlanningHeader = ({ documentId, asDialog, onDialogClose }: {
 
           <div className='flex flex-row gap-2 justify-end items-center'>
             {!asDialog && (
-              <StatusMenu documentId={documentId} type='core/planning-item' />
+              <StatusMenu
+                documentId={documentId}
+                type='core/planning-item'
+                isChanged={isChanged}
+              />
             )}
 
             {!!documentId && <ViewHeader.RemoteUsers documentId={documentId} />}


### PR DESCRIPTION
Add `onChange` prop to form components and propagate it through the form tree, allowing child components to notify the root form of unsaved changes. Update relevant components (e.g., Title, Description, Assignment, AssignmentTable, etc.) to call `onChange` when their state changes. Integrate this with the workflow status menu to show "Save changes" when there are unsaved changes. Use root.changed for tracking. This enables accurate UI feedback for unsaved changes across the planning view.

TODO: Implement onChange in Events and Factbox as well