### PR TITLE
fix(TwirpFetchTransport): set sendJson for TwirpFetchTransport clients

### DIFF
--- a/__tests__/getStatusFromMeta.test.ts
+++ b/__tests__/getStatusFromMeta.test.ts
@@ -169,7 +169,6 @@ describe('getStatusInfo', () => {
   })
 
 
-
   it('returns most recently created status for current version with cause', () => {
     const meta = {
       currentVersion: BigInt(14),

--- a/shared/Baboon.ts
+++ b/shared/Baboon.ts
@@ -10,7 +10,8 @@ export class Baboon {
   constructor(baboonUrl: string) {
     this.#client = new PrintClient(
       new TwirpFetchTransport({
-        baseUrl: new URL('twirp', baboonUrl).toString()
+        baseUrl: new URL('twirp', baboonUrl).toString(),
+        sendJson: true
       })
     )
   }

--- a/shared/Index.ts
+++ b/shared/Index.ts
@@ -46,7 +46,8 @@ export class Index {
   constructor(indexUrl: string) {
     this.#client = new SearchV1Client(
       new TwirpFetchTransport({
-        baseUrl: new URL('twirp', indexUrl).toString()
+        baseUrl: new URL('twirp', indexUrl).toString(),
+        sendJson: true
       })
     )
   }

--- a/shared/Repository.ts
+++ b/shared/Repository.ts
@@ -36,13 +36,15 @@ export class Repository {
   constructor(repoUrl: string) {
     this.#client = new DocumentsClient(
       new TwirpFetchTransport({
-        baseUrl: new URL('twirp', repoUrl).toString()
+        baseUrl: new URL('twirp', repoUrl).toString(),
+        sendJson: true
       })
     )
 
     this.#metricsClient = new MetricsClient(
       new TwirpFetchTransport({
-        baseUrl: new URL('twirp', repoUrl).toString()
+        baseUrl: new URL('twirp', repoUrl).toString(),
+        sendJson: true
       })
     )
   }

--- a/shared/Spellchecker.ts
+++ b/shared/Spellchecker.ts
@@ -8,7 +8,8 @@ export class Spellchecker {
   constructor(repoUrl: string) {
     this.#client = new CheckClient(
       new TwirpFetchTransport({
-        baseUrl: new URL('twirp', repoUrl).toString()
+        baseUrl: new URL('twirp', repoUrl).toString(),
+        sendJson: true
       })
     )
   }

--- a/shared/User.ts
+++ b/shared/User.ts
@@ -14,7 +14,8 @@ export class User {
     this.#tokenService = tokenService
     this.#client = new MessagesClient(
       new TwirpFetchTransport({
-        baseUrl: new URL('twirp', userUrl).toString()
+        baseUrl: new URL('twirp', userUrl).toString(),
+        sendJson: true
       })
     )
   }

--- a/shared/Workflow.ts
+++ b/shared/Workflow.ts
@@ -11,7 +11,8 @@ export class Workflow {
   constructor(repoUrl: string) {
     this.#client = new WorkflowsClient(
       new TwirpFetchTransport({
-        baseUrl: new URL('twirp', repoUrl).toString()
+        baseUrl: new URL('twirp', repoUrl).toString(),
+        sendJson: true
       })
     )
 

--- a/src-srv/lib/errorHandler.ts
+++ b/src-srv/lib/errorHandler.ts
@@ -230,7 +230,9 @@ export function getErrorContext(
 }
 
 // Type guard function for onStatelessPayload
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function isOnStatelessPayload(payload: any): payload is onStatelessPayload {
-  return 'payload' in payload && typeof payload.payload === 'string'
+function isOnStatelessPayload(payload: unknown): payload is onStatelessPayload {
+  return payload !== null
+    && typeof payload === 'object'
+    && 'payload' in payload
+    && typeof payload.payload === 'string'
 }

--- a/src-srv/utils/assertAuthenticatedUser.ts
+++ b/src-srv/utils/assertAuthenticatedUser.ts
@@ -1,3 +1,4 @@
+import type { Session } from '@auth/express'
 import { getSession } from '@auth/express'
 import { type NextFunction, type Response, type Request } from 'express'
 import { authConfig } from './authConfig.js'
@@ -22,7 +23,8 @@ export async function assertAuthenticatedUser(
   res: Response,
   next: NextFunction
 ): Promise<void> {
-  const session = res.locals.session ?? (await getSession(req, authConfig))
+  const session: Session | null = res.locals.session as Session | null
+    ?? (await getSession(req, authConfig))
 
   if (isUnprotectedRoute(req)) {
     next()

--- a/src/components/Version/index.tsx
+++ b/src/components/Version/index.tsx
@@ -61,11 +61,11 @@ export const Version = ({ documentId, hideDetails = false, textOnly = true }: { 
       // Used to fetch the previous document version in order to get hold of the title,
       // that can be displayed in the list of previous versions.
       const response = await fetch(`${BASE_URL}/api/documents/${documentId}?version=${v.version}`)
-      return await response.json()
+      return await response.json() as EleDocumentResponse
     }
 
     result.versions = await Promise.all(result.versions.map(async (version) => {
-      const versionDoc = await fetchDoc(version) as EleDocumentResponse
+      const versionDoc = await fetchDoc(version)
 
       if (versionDoc) {
         const doc = versionDoc?.document


### PR DESCRIPTION
Set the `sendJson: true` option for all TwirpFetchTransport client instances to ensure JSON payloads are sent correctly. This affects Baboon, Index, Repository, Spellchecker, User, and Workflow shared clients. Also, improve type safety in assertAuthenticatedUser and isOnStatelessPayload functions, and add explicit type casting in Version component for document fetch responses.