### PR TITLE
feat: ignore unknown fields in Twirp clients

### DIFF
--- a/shared/Baboon.ts
+++ b/shared/Baboon.ts
@@ -11,7 +11,10 @@ export class Baboon {
     this.#client = new PrintClient(
       new TwirpFetchTransport({
         baseUrl: new URL('twirp', baboonUrl).toString(),
-        sendJson: true
+        sendJson: true,
+        jsonOptions: {
+          ignoreUnknownFields: true
+        }
       })
     )
   }

--- a/shared/Index.ts
+++ b/shared/Index.ts
@@ -47,7 +47,10 @@ export class Index {
     this.#client = new SearchV1Client(
       new TwirpFetchTransport({
         baseUrl: new URL('twirp', indexUrl).toString(),
-        sendJson: true
+        sendJson: true,
+        jsonOptions: {
+          ignoreUnknownFields: true
+        }
       })
     )
   }

--- a/shared/Repository.ts
+++ b/shared/Repository.ts
@@ -37,14 +37,20 @@ export class Repository {
     this.#client = new DocumentsClient(
       new TwirpFetchTransport({
         baseUrl: new URL('twirp', repoUrl).toString(),
-        sendJson: true
+        sendJson: true,
+        jsonOptions: {
+          ignoreUnknownFields: true
+        }
       })
     )
 
     this.#metricsClient = new MetricsClient(
       new TwirpFetchTransport({
         baseUrl: new URL('twirp', repoUrl).toString(),
-        sendJson: true
+        sendJson: true,
+        jsonOptions: {
+          ignoreUnknownFields: true
+        }
       })
     )
   }

--- a/shared/Spellchecker.ts
+++ b/shared/Spellchecker.ts
@@ -9,7 +9,10 @@ export class Spellchecker {
     this.#client = new CheckClient(
       new TwirpFetchTransport({
         baseUrl: new URL('twirp', repoUrl).toString(),
-        sendJson: true
+        sendJson: true,
+        jsonOptions: {
+          ignoreUnknownFields: true
+        }
       })
     )
   }

--- a/shared/User.ts
+++ b/shared/User.ts
@@ -15,7 +15,10 @@ export class User {
     this.#client = new MessagesClient(
       new TwirpFetchTransport({
         baseUrl: new URL('twirp', userUrl).toString(),
-        sendJson: true
+        sendJson: true,
+        jsonOptions: {
+          ignoreUnknownFields: true
+        }
       })
     )
   }

--- a/shared/Workflow.ts
+++ b/shared/Workflow.ts
@@ -12,7 +12,10 @@ export class Workflow {
     this.#client = new WorkflowsClient(
       new TwirpFetchTransport({
         baseUrl: new URL('twirp', repoUrl).toString(),
-        sendJson: true
+        sendJson: true,
+        jsonOptions: {
+          ignoreUnknownFields: true
+        }
       })
     )
 


### PR DESCRIPTION
Add `jsonOptions: { ignoreUnknownFields: true }` to all TwirpFetchTransport client initializations in shared modules. This ensures that clients will gracefully handle extra fields in JSON responses, improving forward compatibility and robustness against backend changes.