### PR TITLE
fix: validate UUIDs before repository operations

### DIFF
--- a/src-srv/utils/CollaborationServer.ts
+++ b/src-srv/utils/CollaborationServer.ts
@@ -34,6 +34,7 @@ import { type GetDocumentResponse } from '@ttab/elephant-api/repository'
 import type { FinishedUnaryCall } from '@protobuf-ts/runtime-rpc'
 import type { Context } from '../lib/assertContext.js'
 import { assertContext } from '../lib/assertContext.js'
+import { isValidUUID } from './isValidUUID.js'
 
 interface CollaborationServerOptions {
   name: string
@@ -293,6 +294,12 @@ export class CollaborationServer {
       return state
     }
 
+    // If not a valid uuid, we're not going to be able to get any from the repository
+    // Most likely a userTracker document
+    if (!isValidUUID(uuid)) {
+      return null
+    }
+
     // Fetch content
     const newsDoc = await this.#repository.getDocument({
       uuid,
@@ -321,8 +328,8 @@ export class CollaborationServer {
     force?: boolean
     transacting?: boolean
   }): Promise<FinishedUnaryCall<UpdateRequest, UpdateResponse> | null> {
-    // Ignore userTracker documents
-    if (context.user.sub?.endsWith(documentName)) {
+    // Ignore userTracker documents and invalid uuids, most likely same as the first
+    if (context.user.sub?.endsWith(documentName) || !isValidUUID(documentName)) {
       return null
     }
 
@@ -378,9 +385,6 @@ export class CollaborationServer {
     )
 
     if (result?.status.code !== 'OK') {
-      // TODO: what does an error response look like? Is it parsed? A full twirp
-      // error response looks like this:
-      // https://twitchtv.github.io/twirp/docs/errors.html#metadata
       throw new Error('Save snapshot document to repository failed', { cause: result })
     }
 


### PR DESCRIPTION
Add UUID validation to prevent repository calls with invalid UUIDs, which are likely userTracker documents. This avoids unnecessary repository requests and potential errors.