### PR TITLE
feat(flash): add document status and tertiary action

### DIFF
--- a/__tests__/createFlash.test.ts
+++ b/__tests__/createFlash.test.ts
@@ -56,7 +56,8 @@ describe('createFlash', () => {
       session,
       planning: { document: planning[1], id: planning[0] },
       hasSelectedPlanning: isExistingPlanning,
-      timeZone: 'Europe/Stockholm'
+      timeZone: 'Europe/Stockholm',
+      documentStatus: undefined
     })
 
     if (!result || !result.planning || !result.flash) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elephant-chrome",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "elephant-chrome",
-      "version": "0.20.3",
+      "version": "0.20.4",
       "license": "MIT",
       "dependencies": {
         "@auth/express": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "elephant-chrome",
   "private": false,
   "license": "MIT",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "type": "module",
   "scripts": {
     "debug": "concurrently npm:debug:vite npm:dev:client:css",

--- a/src/components/Form/Submit.tsx
+++ b/src/components/Form/Submit.tsx
@@ -1,6 +1,7 @@
 import type { ButtonHTMLAttributes } from 'react'
 import React from 'react'
 import { type FormProps } from './Root'
+import { toast } from 'sonner'
 
 
 export const Submit = ({
@@ -10,6 +11,7 @@ export const Submit = ({
   setValidateForm,
   onSubmit,
   onSecondarySubmit,
+  onTertiarySubmit,
   onDocumentCreated,
   onReset
 }: FormProps & {
@@ -17,6 +19,7 @@ export const Submit = ({
   onDialogClose?: (id: string, title: string) => void
   onSubmit?: () => void
   onSecondarySubmit?: () => void
+  onTertiarySubmit?: () => void
   onDocumentCreated?: () => void
   onReset?: () => void
 }): JSX.Element | null => {
@@ -32,7 +35,8 @@ export const Submit = ({
 
   const handleClick = (
     event: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLButtonElement>,
-    type: ButtonHTMLAttributes<HTMLButtonElement>['type']
+    type: ButtonHTMLAttributes<HTMLButtonElement>['type'],
+    role: 'primary' | 'secondary' | 'tertiary'
   ): void => {
     event.preventDefault()
     event.stopPropagation()
@@ -51,7 +55,7 @@ export const Submit = ({
           break
 
         case 'button':
-          if (onSecondarySubmit) {
+          if (onSecondarySubmit && role === 'secondary') {
             handleValidate(() => {
               onSecondarySubmit()
               if (onDocumentCreated) {
@@ -59,7 +63,17 @@ export const Submit = ({
               }
             })
           }
+
+          if (onTertiarySubmit && role === 'tertiary') {
+            handleValidate(() => {
+              onTertiarySubmit()
+              if (onDocumentCreated) {
+                onDocumentCreated()
+              }
+            })
+          }
           break
+
 
         case 'reset':
           if (onReset) {
@@ -80,39 +94,45 @@ export const Submit = ({
           onKeyDown?: (event: React.KeyboardEvent<HTMLButtonElement>) => void
         } = {}
 
-      const childProps = child.props as { type: string, children: React.ReactElement }
+      const childProps = child.props as { type: string, children: React.ReactElement, role: 'primary' | 'secondary' | 'tertiary' }
+
 
       if (child.props && 'type' in child.props) {
+        if (childProps.type === 'button' && !childProps.role) {
+          console.error('Button without role, please add a role to the button')
+          toast.error('Kunde inte skicka data')
+        }
+
         switch (childProps.type) {
           case 'submit':
             props.onClick = (event: React.MouseEvent<HTMLButtonElement>) =>
-              handleClick(event, 'submit')
+              handleClick(event, 'submit', childProps.role)
 
             props.onKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
               if (event.key === 'Enter') {
-                handleClick(event, 'submit')
+                handleClick(event, 'submit', childProps.role)
               }
             }
             break
 
           case 'reset':
             props.onClick = (event: React.MouseEvent<HTMLButtonElement>) =>
-              handleClick(event, 'reset')
+              handleClick(event, 'reset', childProps.role)
 
             props.onKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
               if (event.key === 'Enter') {
-                handleClick(event, 'reset')
+                handleClick(event, 'reset', childProps.role)
               }
             }
             break
 
           case 'button':
             props.onClick = (event: React.MouseEvent<HTMLButtonElement>) =>
-              handleClick(event, 'button')
+              handleClick(event, 'button', childProps.role)
 
             props.onKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
               if (event.key === 'Enter') {
-                handleClick(event, 'button')
+                handleClick(event, 'button', childProps.role)
               }
             }
             break

--- a/src/defaults/documentStatuses.tsx
+++ b/src/defaults/documentStatuses.tsx
@@ -2,7 +2,6 @@ import { type DefaultValueOption } from '@/types'
 import {
   CircleCheck,
   CircleDot,
-  CircleX,
   BadgeCheck
 } from '@ttab/elephant-ui/icons'
 
@@ -53,17 +52,6 @@ export const DocumentStatuses: DefaultValueOption[] = [
     }
   },
   {
-    label: 'Inställd',
-    value: 'cancelled',
-    icon: CircleX,
-    iconProps: {
-      color: '#ffffff',
-      className: 'bg-cancelled fill-cancelled rounded-full',
-      size: 18,
-      strokeWidth: 1.75
-    }
-  },
-  {
     label: 'Utkast',
     value: 'draft',
     icon: CircleDot,
@@ -105,17 +93,6 @@ export const PlanningEventStatuses: DefaultValueOption[] = [
     iconProps: {
       color: '#ffffff',
       className: 'bg-done fill-done rounded-full',
-      size: 18,
-      strokeWidth: 1.75
-    }
-  },
-  {
-    label: 'Inställd',
-    value: 'cancelled',
-    icon: CircleX,
-    iconProps: {
-      color: '#ffffff',
-      className: 'bg-cancelled fill-cancelled rounded-full',
       size: 18,
       strokeWidth: 1.75
     }

--- a/src/defaults/workflowSpecification.tsx
+++ b/src/defaults/workflowSpecification.tsx
@@ -1,7 +1,6 @@
 import {
   CircleCheck,
   CircleDot,
-  CircleX,
   CircleArrowLeft,
   BadgeCheck,
   type LucideIcon
@@ -48,10 +47,6 @@ export const StatusSpecifications: Record<string, StatusSpecification> = {
     icon: CircleCheck,
     className: 'bg-usable text-white fill-usable rounded-full'
   },
-  cancelled: {
-    icon: CircleX,
-    className: 'bg-cancelled text-white fill-cancelled rounded-full'
-  },
   unpublished: {
     icon: CircleArrowLeft,
     className: 'bg-unpublished text-white fill-unpublished rounded-full'
@@ -75,24 +70,19 @@ export const WorkflowSpecifications: Record<string, WorkflowSpecification> = {
       transitions: {
         done: {
           default: true,
-          title: 'Publicera internt',
-          description: 'Publicera händelsen internt hos TT'
+          title: 'Använd internt',
+          description: 'Gör händelsen internt synlig'
         },
         usable: {
           verify: true,
           title: 'Publicera externt',
           description: 'Publicera händelsen externt'
-        },
-        cancelled: {
-          verify: true,
-          title: 'Avbryt',
-          description: 'Avbryt, gå inte vidare med händelsen'
         }
       }
     },
     done: {
       title: 'Intern',
-      description: 'Händelsen är publicerad internt hos TT',
+      description: 'Händelsen är internt synlig',
       transitions: {
         usable: {
           verify: true,
@@ -116,22 +106,6 @@ export const WorkflowSpecifications: Record<string, WorkflowSpecification> = {
           description: 'Avpublicera händelsen externt'
         }
       }
-    },
-    cancelled: {
-      title: 'Avbruten',
-      description: 'Händelsen har avbrutits. Lägg till innehåll för att fortsätta med en ny version.',
-      transitions: {
-        done: {
-          verify: true,
-          title: 'Publicera internt',
-          description: 'Publicera händelsen internt hos TT'
-        },
-        usable: {
-          verify: true,
-          title: 'Publicera externt',
-          description: 'Publicera händelsen externt'
-        }
-      }
     }
   },
   'core/planning-item': {
@@ -141,29 +115,24 @@ export const WorkflowSpecifications: Record<string, WorkflowSpecification> = {
       transitions: {
         done: {
           default: true,
-          title: 'Publicera internt',
-          description: 'Publicera planeringen internt hos TT'
+          title: 'Använd internt',
+          description: 'Gör planeringen internt synlig'
         },
         usable: {
           verify: true,
           title: 'Publicera externt',
           description: 'Publicera planeringen externt'
-        },
-        cancelled: {
-          verify: true,
-          title: 'Avbryt',
-          description: 'Avbryt, gå inte vidare med planeringen'
         }
       }
     },
     done: {
       title: 'Intern',
-      description: 'Planeringen är publicerad internt hos TT',
+      description: 'Planeringen är internt synlig',
       transitions: {
         usable: {
           verify: true,
           title: 'Publicera',
-          description: 'Publicera planeringen externt synlig'
+          description: 'Publicera planeringen externt'
         },
         unpublished: {
           verify: true,
@@ -180,22 +149,6 @@ export const WorkflowSpecifications: Record<string, WorkflowSpecification> = {
           verify: true,
           title: 'Avpublicera',
           description: 'Avpublicera planeringen externt'
-        }
-      }
-    },
-    cancelled: {
-      title: 'Avbruten',
-      description: 'Planeringen har avbrutits. Lägg till innehåll för att fortsätta med en ny version.',
-      transitions: {
-        done: {
-          verify: true,
-          title: 'Publicera internt',
-          description: 'Publicera planeringen internt hos TT'
-        },
-        usable: {
-          verify: true,
-          title: 'Publicera externt',
-          description: 'Publicera planeringen externt'
         }
       }
     },
@@ -228,11 +181,6 @@ export const WorkflowSpecifications: Record<string, WorkflowSpecification> = {
           verify: true,
           title: 'Schemalägg publicering',
           description: 'Ange datum och tid för publicering'
-        },
-        cancelled: {
-          verify: true,
-          title: 'Avbryt',
-          description: 'Avbryt och gå inte vidare med artikeln'
         }
       }
     },
@@ -355,7 +303,7 @@ export const WorkflowSpecifications: Record<string, WorkflowSpecification> = {
       title: 'Användbar',
       description: 'Faktarutan är användbar',
       transitions: {
-        cancelled: {
+        unpublished: {
           verify: true,
           title: 'Arkivera',
           description: 'Dra tillbaka och arkivera den här faktarutan'
@@ -429,7 +377,7 @@ export const WorkflowSpecifications: Record<string, WorkflowSpecification> = {
           title: 'Till utkast',
           description: 'Gör om till red till ett utkast igen'
         },
-        cancelled: {
+        unpublished: {
           title: 'Dra tillbaka',
           description: 'Avbryt publiceringen och arkivera till red'
         }
@@ -504,16 +452,16 @@ export const WorkflowSpecifications: Record<string, WorkflowSpecification> = {
       title: 'Exporterad',
       description: 'Printartikeln är exporterad',
       transitions: {
-        cancelled: {
+        unpublished: {
           verify: true,
           title: 'Dra tillbaka',
           description: 'Avbryt export och arkivera printartikeln'
         }
       }
     },
-    cancelled: {
+    unpublished: {
       title: 'Inställd',
-      description: 'Printartikeln är inställd',
+      description: 'Printartikeln är avpublicerad',
       transitions: {
         draft: {
           title: 'Till utkast',

--- a/src/views/Flash/FlashViewContent.tsx
+++ b/src/views/Flash/FlashViewContent.tsx
@@ -215,10 +215,10 @@ export const FlashViewContent = (props: ViewProps): JSX.Element => {
                 >
                   <div className='flex justify-between'>
                     <div className='flex gap-2'>
-                      <Button variant='secondary' type='button' role='secondary'>Spara flash</Button>
-                      <Button variant='secondary' type='button' role='tertiary'>Godkänn flash</Button>
+                      <Button variant='secondary' type='button' role='secondary'>Utkast</Button>
+                      <Button variant='secondary' type='button' role='tertiary'>Godkänn</Button>
                     </div>
-                    <Button type='submit' role='primary'>Skicka flash</Button>
+                    <Button type='submit' role='primary'>Publicera</Button>
                   </div>
                 </Form.Submit>
               </Form.Footer>

--- a/src/views/Flash/FlashViewContent.tsx
+++ b/src/views/Flash/FlashViewContent.tsx
@@ -14,6 +14,7 @@ import { FlashEditor } from './FlashEditor'
 import { UserMessage } from '@/components/UserMessage'
 import { Form } from '@/components/Form'
 import { fetch } from '@/lib/index/fetch-plannings-twirp'
+import type { CreateFlashDocumentStatus } from './lib/createFlash'
 import { createFlash } from './lib/createFlash'
 import type * as Y from 'yjs'
 import { CreatePrompt } from '@/components/CreatePrompt'
@@ -26,6 +27,7 @@ export const FlashViewContent = (props: ViewProps): JSX.Element => {
   const planningAwareness = useRef<(value: boolean) => void>(null)
   const [sendPrompt, setSendPrompt] = useState(false)
   const [savePrompt, setSavePrompt] = useState(false)
+  const [donePrompt, setDonePrompt] = useState(false)
   const [selectedPlanning, setSelectedPlanning] = useState<DefaultValueOption | undefined>(undefined)
   const [title, setTitle] = useYValue<string | undefined>('root.title', true)
   const { index, locale, timeZone } = useRegistry()
@@ -36,6 +38,45 @@ export const FlashViewContent = (props: ViewProps): JSX.Element => {
   const handleSubmit = (setCreatePrompt: Dispatch<SetStateAction<boolean>>): void => {
     setCreatePrompt(true)
   }
+
+  const promptConfig = [
+    {
+      visible: sendPrompt,
+      key: 'send',
+      title: 'Skapa och skicka flash?',
+      description: !selectedPlanning
+        ? 'En ny planering med tillhörande uppdrag för denna flash kommer att skapas åt dig.'
+        : `Denna flash kommer att läggas i ett nytt uppdrag i planeringen "${selectedPlanning.label}"`,
+      secondaryLabel: 'Avbryt',
+      primaryLabel: 'Skicka',
+      documentStatus: 'usable' as CreateFlashDocumentStatus,
+      setPrompt: setSendPrompt
+    },
+    {
+      visible: donePrompt,
+      key: 'done',
+      title: 'Skapa och godkänn flash?',
+      description: !selectedPlanning
+        ? 'En ny planering med tillhörande uppdrag för denna flash kommer att skapas åt dig.'
+        : `Denna flash kommer att läggas i ett nytt uppdrag i planeringen "${selectedPlanning.label}". Med status godkänd.`,
+      secondaryLabel: 'Avbryt',
+      primaryLabel: 'Godkänn',
+      documentStatus: 'done' as CreateFlashDocumentStatus,
+      setPrompt: setDonePrompt
+    },
+    {
+      visible: savePrompt,
+      key: 'save',
+      title: 'Spara flash?',
+      description: !selectedPlanning
+        ? 'En ny planering med tillhörande uppdrag för denna flash kommer att skapas åt dig.'
+        : `Denna flash kommer att läggas i ett nytt uppdrag i planeringen "${selectedPlanning.label}"`,
+      secondaryLabel: 'Avbryt',
+      primaryLabel: 'Spara',
+      documentStatus: undefined,
+      setPrompt: setSavePrompt
+    }
+  ]
 
   return (
     <View.Root asDialog={props.asDialog} className={props.className}>
@@ -117,97 +158,50 @@ export const FlashViewContent = (props: ViewProps): JSX.Element => {
           </Form.Content>
 
           {
-            sendPrompt
-            && (
-              <CreatePrompt
-                title='Skapa och skicka flash?'
-                description={!selectedPlanning
-                  ? 'En ny planering med tillhörande uppdrag för denna flash kommer att skapas åt dig.'
-                  : `Denna flash kommer att läggas i ett nytt uppdrag i planeringen "${selectedPlanning.label}"`}
-                secondaryLabel='Avbryt'
-                primaryLabel='Skicka'
-                selectedPlanning={selectedPlanning}
-                payload={{
-                  meta: {
-                    'core/newsvalue': [Block.create({ type: 'core/newsvalue', value: '4' })]
-                  }
-                }}
-                onPrimary={(planning: Y.Doc | undefined, planningId: string | undefined) => {
-                  if (!provider || !props.id || !provider || !session) {
-                    console.error('Environment is not sane, flash cannot be created')
-                    return
-                  }
+            promptConfig.map((config) =>
+              config.visible && (
+                <CreatePrompt
+                  key={config.key}
+                  title={config.title}
+                  description={config.description}
+                  secondaryLabel={config.secondaryLabel}
+                  primaryLabel={config.primaryLabel}
+                  selectedPlanning={selectedPlanning}
+                  payload={{
+                    meta: {
+                      'core/newsvalue': [Block.create({ type: 'core/newsvalue', value: '5' })]
+                    }
+                  }}
+                  onPrimary={(planning: Y.Doc | undefined, planningId: string | undefined) => {
+                    if (!provider || !props.id || !session) {
+                      console.error('Environment is not sane, flash cannot be created')
+                      return
+                    }
 
-                  if (props?.onDialogClose) {
-                    props.onDialogClose(props.id, title)
-                  }
+                    if (props?.onDialogClose) {
+                      props.onDialogClose(props.id, title)
+                    }
 
-                  createFlash({
-                    provider,
-                    status,
-                    session,
-                    planning: {
-                      document: planning,
-                      id: planningId
-                    },
-                    hasSelectedPlanning: !!selectedPlanning,
-                    timeZone,
-                    documentStatus: 'done'
-                  })
+                    createFlash({
+                      provider,
+                      status,
+                      session,
+                      planning: {
+                        document: planning,
+                        id: planningId
+                      },
+                      hasSelectedPlanning: !!selectedPlanning,
+                      timeZone,
+                      documentStatus: config.documentStatus
+                    })
 
-                  setSendPrompt(false)
-                }}
-                onSecondary={() => {
-                  setSendPrompt(false)
-                }}
-              />
-            )
-          }
-
-          {
-            savePrompt
-            && (
-              <CreatePrompt
-                title='Spara flash?'
-                description={!selectedPlanning
-                  ? 'En ny planering med tillhörande uppdrag för denna flash kommer att skapas åt dig.'
-                  : `Denna flash kommer att läggas i ett nytt uppdrag i planeringen "${selectedPlanning.label}"`}
-                secondaryLabel='Avbryt'
-                primaryLabel='Spara'
-                selectedPlanning={selectedPlanning}
-                payload={{
-                  meta: {
-                    'core/newsvalue': [Block.create({ type: 'core/newsvalue', value: '4' })]
-                  }
-                }}
-                onPrimary={(planning: Y.Doc | undefined, planningId: string | undefined) => {
-                  if (!provider || !props.id || !provider || !session) {
-                    console.error('Environment is not sane, flash cannot be created')
-                    return
-                  }
-
-                  if (props?.onDialogClose) {
-                    props.onDialogClose(props.id, title)
-                  }
-
-                  createFlash({
-                    provider,
-                    status,
-                    session,
-                    planning: {
-                      document: planning,
-                      id: planningId
-                    },
-                    hasSelectedPlanning: !!selectedPlanning,
-                    timeZone
-                  })
-
-                  setSavePrompt(false)
-                }}
-                onSecondary={() => {
-                  setSavePrompt(false)
-                }}
-              />
+                    config.setPrompt(false)
+                  }}
+                  onSecondary={() => {
+                    config.setPrompt(false)
+                  }}
+                />
+              )
             )
           }
 
@@ -217,10 +211,14 @@ export const FlashViewContent = (props: ViewProps): JSX.Element => {
                 <Form.Submit
                   onSubmit={() => handleSubmit(setSendPrompt)}
                   onSecondarySubmit={() => handleSubmit(setSavePrompt)}
+                  onTertiarySubmit={() => handleSubmit(setDonePrompt)}
                 >
-                  <div className='flex justify-end gap-4'>
-                    <Button variant='secondary' type='button'>Spara flash</Button>
-                    <Button type='submit'>Skicka flash</Button>
+                  <div className='flex justify-between'>
+                    <div className='flex gap-2'>
+                      <Button variant='secondary' type='button' role='secondary'>Spara flash</Button>
+                      <Button variant='secondary' type='button' role='tertiary'>Godkänn flash</Button>
+                    </div>
+                    <Button type='submit' role='primary'>Skicka flash</Button>
                   </div>
                 </Form.Submit>
               </Form.Footer>


### PR DESCRIPTION
- Introduced `CreateFlashDocumentStatus` type to handle different flash document statuses: 'usable', 'done', or undefined.
- Refactored `FlashViewContent` to use a prompt config array for handling send, save, and done prompts, reducing code duplication.
- Added tertiary button/action for "Godkänn flash" (approve flash).
- Updated `createFlash` to show different toast messages based on document status and improved error handling with user feedback.
- Updated form submit logic to require explicit button roles and handle tertiary actions.
- Updated newsvalue for created planning to 5