### PR TITLE
feat(event): add status handling to event submission

### DIFF
--- a/src-srv/utils/CollaborationServer.ts
+++ b/src-srv/utils/CollaborationServer.ts
@@ -207,6 +207,9 @@ export class CollaborationServer {
     }
   }
 
+  /* Handles the removal of `__inProgress` flag and stores the document in the repository
+  * Subsequently adds the transaction to the userTracker document
+  * */
   async #statelessHandler(payload: onStatelessPayload): Promise<void> {
     const msg = parseStateless(payload.payload)
 

--- a/src/views/Event/index.tsx
+++ b/src/views/Event/index.tsx
@@ -92,7 +92,9 @@ const EventViewContent = (props: ViewProps & { documentId: string }): JSX.Elemen
     // eslint-disable-next-line
   }, [provider])
 
-  const handleSubmit = (): void => {
+  const handleSubmit = ({ documentStatus }: {
+    documentStatus: 'usable' | 'done' | undefined
+  }): void => {
     if (props?.onDialogClose) {
       props.onDialogClose()
     }
@@ -101,6 +103,7 @@ const EventViewContent = (props: ViewProps & { documentId: string }): JSX.Elemen
       provider.sendStateless(
         createStateless(StatelessType.IN_PROGRESS, {
           state: false,
+          status: documentStatus,
           id: props.documentId,
           context: {
             agent: 'server',
@@ -163,11 +166,22 @@ const EventViewContent = (props: ViewProps & { documentId: string }): JSX.Elemen
           </Form.Table>
 
           <Form.Footer>
-            <Form.Submit onSubmit={handleSubmit}>
-
-              <div className='flex justify-end px-6 py-4'>
+            <Form.Submit
+              onSubmit={() => handleSubmit({ documentStatus: 'usable' })}
+              onSecondarySubmit={() => handleSubmit({ documentStatus: 'done' })}
+              onTertiarySubmit={() => handleSubmit({ documentStatus: undefined })}
+            >
+              <div className='flex justify-between px-6 py-4'>
+                <div className='flex gap-2'>
+                  <Button type='button' variant='secondary' role='tertiary'>
+                    Spara
+                  </Button>
+                  <Button type='button' variant='secondary' role='secondary'>
+                    Intern
+                  </Button>
+                </div>
                 <Button type='submit'>
-                  Skapa händelse
+                  Publicera
                 </Button>
               </div>
             </Form.Submit>

--- a/src/views/Event/index.tsx
+++ b/src/views/Event/index.tsx
@@ -174,7 +174,7 @@ const EventViewContent = (props: ViewProps & { documentId: string }): JSX.Elemen
               <div className='flex justify-between px-6 py-4'>
                 <div className='flex gap-2'>
                   <Button type='button' variant='secondary' role='tertiary'>
-                    Spara
+                    Utkast
                   </Button>
                   <Button type='button' variant='secondary' role='secondary'>
                     Intern


### PR DESCRIPTION
Enhance the EventViewContent form to support document status handling ('usable', 'done', or undefined) on submit. Updated the submit handler to accept a status parameter and send it with the stateless message. Modified the form footer to provide buttons for different submission statuses, improving user control over event publishing workflow.

Based on: https://github.com/ttab/elephant-chrome/pull/1429