### PR TITLE
fix(hooks): improve query param parsing for inactive views

### DIFF
--- a/src/hooks/useQuery.tsx
+++ b/src/hooks/useQuery.tsx
@@ -29,11 +29,18 @@ export const useQuery = (keys?: string[], allParams?: boolean): [QueryParams, (p
   const parseQueryString = useCallback((): Record<string, string | string[] | undefined> => {
     // window.location.search will only return the query parameters of the active view
     // for others non-active use it's contentState.path from historyState
-    const historyPath = historyState?.contentState.find((cs) => cs.viewId === viewId)?.path
+    const currentHistory = historyState?.contentState.find((cs) => cs.viewId === viewId)
+    const currentPath = currentHistory?.path ?? ''
 
-    const searchParams = new URLSearchParams(isActive || !historyPath
-      ? window.location.search
-      : historyPath?.replace(window.location.pathname, ''))
+    const searchParams = new URLSearchParams(
+      isActive || !currentPath
+        ? window.location.search
+        : (() => {
+            const idx = currentPath.indexOf('?')
+            return idx !== -1 ? currentPath.substring(idx) : ''
+          })()
+    )
+
     const params: Record<string, string | string[] | undefined> = {}
 
     for (const [key, value] of searchParams.entries()) {


### PR DESCRIPTION
Refactor useQuery to handle query parameters more reliably for inactive views. Instead of replacing the pathname, now extracts the query string from the correct path segment, ensuring accurate parsing regardless of the view's active state. This prevents issues when the pathname differs between views and improves consistency in parameter retrieval.