### PR TITLE
fix(event): update time granularity and UI defaults

### DIFF
--- a/src/defaults/templates/eventDocumentTemplate.ts
+++ b/src/defaults/templates/eventDocumentTemplate.ts
@@ -19,7 +19,7 @@ export function eventDocumentTemplate(id: string): Document {
           end: new Date().toISOString(),
           start: new Date().toISOString(),
           registration: '',
-          dateGranularity: 'date'
+          dateGranularity: 'time'
         }
       }),
       Block.create({

--- a/src/views/Event/components/EventTime.tsx
+++ b/src/views/Event/components/EventTime.tsx
@@ -92,7 +92,7 @@ export const EventTimeMenu = (): JSX.Element => {
   const [mounted, setMounted] = useState(false)
   const [startTimeValid, setStartTimeValid] = useState(false)
   const [endTimeValid, setEndTimeValid] = useState(false)
-  const [fullDay, setFullDay] = useState(true)
+  const [fullDay, setFullDay] = useState(false)
 
   useEffect(() => {
     if (!mounted && eventData) {

--- a/src/views/Event/index.tsx
+++ b/src/views/Event/index.tsx
@@ -165,7 +165,7 @@ const EventViewContent = (props: ViewProps & { documentId: string }): JSX.Elemen
           <Form.Footer>
             <Form.Submit onSubmit={handleSubmit}>
 
-              <div className='flex justify-end px-6 py-4'>
+              <div className='flex justify-end'>
                 <Button type='submit'>
                   Skapa händelse
                 </Button>


### PR DESCRIPTION
Set event dateGranularity to 'time' in the template and default fullDay to false in EventTime menu. Also adjust EventViewContent footer padding for better alignment. These changes improve event time handling and UI consistency.

> Default should be todays date and time. End time should be set to same as start time.

Was already, current date, current time, for both start and end

> When changing the start time to a later time than end time, the end time should be set to same as start time.

I would argue that this isn't transparent to the user, now we have validation if start is after end -  that is more transparent I would say. :shrug: 