### PR TITLE
feat(metasheet): add ContentSource combobox

### DIFF
--- a/src/components/Category.tsx
+++ b/src/components/Category.tsx
@@ -2,10 +2,10 @@ import { Awareness } from '@/components'
 import { ComboBox } from '@ttab/elephant-ui'
 import { useCategories, useYValue } from '@/hooks'
 import { Block } from '@ttab/elephant-api/newsdoc'
-
 import { useRef } from 'react'
+import type { ViewProps } from '../types'
 
-export const Category = ({ asDialog }: { asDialog?: boolean }): JSX.Element => {
+export const Category = ({ asDialog }: ViewProps): JSX.Element => {
   const allCategories = useCategories().map((_) => {
     return {
       value: _.id,

--- a/src/components/ContentSource.tsx
+++ b/src/components/ContentSource.tsx
@@ -1,0 +1,69 @@
+import { ComboBox } from '@ttab/elephant-ui'
+import { useWireSources, useYValue } from '../hooks'
+import { Block } from '@ttab/elephant-api/newsdoc'
+import { Awareness } from './Awareness'
+import { useRef } from 'react'
+
+export const ContentSource = (): JSX.Element => {
+  // Workaround, useWireSources, since they are close to similar
+  const allWireSources = useWireSources().map((_) => {
+    return {
+      value: _.uri,
+      label: _.title
+    }
+  })
+  const removeList = [
+    'wires://source/globenewswire',
+    'wires://source/email',
+    'wires://source/rss',
+    'wires://source/businesswire',
+    'wires://source/viatt',
+    'wires://source/efes'
+  ]
+
+  const allContentSources = allWireSources
+    .filter((source) => !removeList.includes(source.value))
+    .map((source) => ({
+      ...source,
+      value: source.value.replace('wires://source/', 'tt://content-source/')
+    }))
+
+  const path = 'links.core/content-source'
+  const setFocused = useRef<(value: boolean, start: string) => void>(() => { })
+  const [contentSources, setContentSources] = useYValue<Block[] | undefined>(path)
+  const selectedOptions = allContentSources.filter((contentSource) =>
+    contentSources?.some((cs) => cs.uri === contentSource.value)
+  )
+
+  return (
+    <Awareness ref={setFocused} path={path}>
+      <ComboBox
+        sortOrder='label'
+        size='xs'
+        modal={false}
+        options={allContentSources}
+        selectedOptions={selectedOptions}
+        placeholder='Lägg till källa'
+        onOpenChange={(isOpen: boolean) => {
+          if (setFocused?.current) {
+            setFocused.current(true, (isOpen) ? path : '')
+          }
+        }}
+        onSelect={(option) => {
+          if ((contentSources || [])?.some((c) => c.uri === option.value)) {
+            setContentSources(contentSources?.filter((c: Block) => {
+              return c.uri !== option.value
+            }))
+          } else {
+            setContentSources([...(contentSources || []), Block.create({
+              type: 'core/content-source',
+              rel: 'source',
+              uri: option.value,
+              title: option.label
+            })])
+          }
+        }}
+      />
+    </Awareness>
+  )
+}

--- a/src/views/Editor/components/MetaSheet.tsx
+++ b/src/views/Editor/components/MetaSheet.tsx
@@ -17,6 +17,7 @@ import { AddNote } from './Notes/AddNote'
 import { Version } from '@/components/Version'
 import { ReadOnly } from './ReadOnly'
 import { EditorialInfoTypes } from '@/components/EditorialInfoTypes'
+import { ContentSource } from '@/components/ContentSource'
 
 export function MetaSheet({ container, documentId, readOnly, readOnlyVersion }: {
   container: HTMLElement | null
@@ -24,7 +25,6 @@ export function MetaSheet({ container, documentId, readOnly, readOnlyVersion }: 
   readOnly?: boolean
   readOnlyVersion?: bigint
 }): JSX.Element {
-  const [contentSource] = useYValue<string | undefined>('links.core/content-source[0].uri')
   const [documentType] = useYValue<string | undefined>('root.type')
   const [isOpen, setIsOpen] = useState(false)
 
@@ -86,6 +86,11 @@ export function MetaSheet({ container, documentId, readOnly, readOnlyVersion }: 
                     <Version documentId={documentId} textOnly={false} />
                   </div>
 
+                  <Label htmlFor='content-source'>Källor andra än TT</Label>
+                  <div id='content-source'>
+                    <ContentSource />
+                  </div>
+
                   {documentType === 'core/editorial-info' && (
                     <>
                       <Label htmlFor='editorial-info-type'>Redaktionell info, typ</Label>
@@ -96,11 +101,6 @@ export function MetaSheet({ container, documentId, readOnly, readOnlyVersion }: 
                   )}
                 </div>
               )}
-        </div>
-
-        <div className='flex flex-col gap-6 px-5 py-4 border-t'>
-          <Label htmlFor='' className='text-xs text-muted-foreground -mb-3'>Extra information</Label>
-          <span className='font-thin text-muted-foreground text-xs'>{contentSource}</span>
         </div>
       </SheetContent>
     </Sheet>

--- a/src/views/Editor/components/ReadOnly.tsx
+++ b/src/views/Editor/components/ReadOnly.tsx
@@ -72,7 +72,7 @@ export const ReadOnly = ({ documentId, version }: { documentId: string, version:
   const category = data?.links?.['core/category']?.[0]?.title
   const story = data?.links?.['core/story']?.[0]?.title
   const author = data?.links?.['core/author']?.[0]?.title
-  const contentSource = data?.links?.['core/content-source']?.[0]?.title
+  const contentSource = data?.links?.['core/content-source']
 
   const editorialInfoTypeId = data?.links?.['core/editorial-info-type']?.[0]?.uuid
   const editorialInfoTypeTitle = editorialInfoTypes.find((type) => type.id === editorialInfoTypeId)?.title
@@ -94,7 +94,7 @@ export const ReadOnly = ({ documentId, version }: { documentId: string, version:
         <Version documentId={documentId} textOnly={false} />
       </InfoBlock>
       <InfoBlock text='Extra information' labelId=''>
-        <ValueBlock label='Källa' value={contentSource} />
+        <ValueBlock label='Källa' value={(contentSource || []).map((cs) => cs.title).join('-')} />
         <ValueBlock label='Redaktionell info, typ' value={editorialInfoTypeTitle} />
       </InfoBlock>
     </div>


### PR DESCRIPTION
Introduce a new ContentSource component for selecting and displaying non-TT sources in the MetaSheet. Remove the old single content source display and update the ReadOnly view to support multiple sources. This improves source management and clarity for editorial metadata.