### PR TITLE
feat(snapshot): refactor snapshot extension and API auth

### DIFF
--- a/shared/Repository.ts
+++ b/shared/Repository.ts
@@ -256,13 +256,15 @@ export class Repository {
     const payload: UpdateRequest = {
       document,
       meta: {},
-      ifMatch: version,
+      // No optimistic lock
+      ifMatch: 0n,
       status: status
         ? [{
             name: status,
             version,
             meta: cause ? { cause } : {},
-            ifMatch: version
+            // No optimistic lock
+            ifMatch: 0n
           }]
         : [],
       acl: [{ uri: 'core://unit/redaktionen', permissions: ['r', 'w'] }],

--- a/src-srv/utils/CollaborationServer.ts
+++ b/src-srv/utils/CollaborationServer.ts
@@ -3,7 +3,6 @@ import {
   type Hocuspocus,
   type fetchPayload,
   type storePayload,
-  type onStoreDocumentPayload,
   type onStatelessPayload
 } from '@hocuspocus/server'
 
@@ -123,24 +122,7 @@ export class CollaborationServer {
           }
         }),
         new Snapshot({
-          debounce: 120000,
-          snapshot: ({ context, ...rest }: onStoreDocumentPayload) => {
-            return async () => {
-              if (!assertContext(context)) {
-                throw new Error('Invalid context provided')
-              }
-
-              await this.snapshotDocument({ context, ...rest }).catch((ex) => {
-                const ctx = getErrorContext({ context, ...rest })
-
-                this.#errorHandler.error(ex, {
-                  id: rest.documentName,
-                  accessToken: context.accessToken,
-                  ...ctx
-                })
-              })
-            }
-          }
+          debounce: 120000
         }),
         new Auth()
       ], this.#errorHandler),


### PR DESCRIPTION
- Refactored Snapshot extension to handle debouncing and snapshot logic internally, removing the need to pass a snapshot function in config.
- Updated snapshot logic to call the API endpoint directly with proper authorization and user headers.
- Improved authentication in snapshot API route to support both session and header-based tokens and user info.
- Removed optimistic locking in Repository update payloads for snapshots.
- Cleaned up unused types and streamlined debounce handling.