### PR TITLE
feat(status): support workflow state/checkpoint in getStatusFromMeta

### DIFF
--- a/__tests__/getStatusFromMeta.test.ts
+++ b/__tests__/getStatusFromMeta.test.ts
@@ -10,15 +10,19 @@ describe('getStatusInfo', () => {
       updaterUri: 'core://user/abc'
     } as unknown as Partial<Meta> as Meta
 
-    expect(getStatusFromMeta(meta)).toEqual({
+    const expected = {
       name: 'draft',
       version: BigInt(0),
       creator: 'core://user/abc',
       cause: undefined
-    })
+    }
+
+    // isWorkflow doesn't affect the outcome
+    expect(getStatusFromMeta(meta, false)).toEqual(expected)
+    expect(getStatusFromMeta(meta, true)).toEqual(expected)
   })
 
-  it('returns unpublished when last status is usable and it´s version is -1', () => {
+  it('returns unpublished', () => {
     const meta = {
       currentVersion: BigInt(3),
       heads: {
@@ -36,18 +40,59 @@ describe('getStatusInfo', () => {
         }
       },
       creatorUri: 'core://user/abc',
-      updaterUri: 'core://user/abc'
+      updaterUri: 'core://user/abc',
+      workflowState: 'unpublished',
+      workflowCheckpoint: 'unpublished'
     } as unknown as Partial<Meta> as Meta
 
-    expect(getStatusFromMeta(meta)).toEqual({
+    const expected = {
       name: 'unpublished',
       version: BigInt(3),
       creator: 'core://user/abc',
-      cause: 'fixed'
-    })
+      cause: 'fixed',
+      checkpoint: 'unpublished'
+    }
+
+    // isWorkflow doesn't affect the outcome
+    expect(getStatusFromMeta(meta, false)).toEqual(expected)
+    expect(getStatusFromMeta(meta, true)).toEqual(expected)
   })
 
   it('uses workflowState when exists', () => {
+    const meta = {
+      currentVersion: BigInt(3),
+      heads: {
+        approved: {
+          version: BigInt(3),
+          creator: 'core://user/abc',
+          created: '2025-05-09T10:00:00Z',
+          meta: { cause: 'correction' }
+        },
+        usable: {
+          version: BigInt(-1),
+          creator: 'core://user/abc',
+          created: '2025-05-09T12:00:00Z',
+          meta: { cause: 'fixed' }
+        }
+      },
+      creatorUri: 'core://user/abc',
+      updaterUri: 'core://user/abc',
+      workflowState: 'invalid-state-for-test'
+    } as unknown as Partial<Meta> as Meta
+
+    const expected = {
+      name: 'invalid-state-for-test',
+      version: BigInt(3),
+      creator: 'core://user/abc',
+      cause: 'fixed'
+    }
+
+    // isWorkflow doesn't affect the outcome
+    expect(getStatusFromMeta(meta, false)).toEqual(expected)
+    expect(getStatusFromMeta(meta, true)).toEqual(expected)
+  })
+
+  it('uses workflowCheckpoint, workflowState and isWorkflow in conjunction', () => {
     const meta = {
       currentVersion: BigInt(3),
       heads: {
@@ -70,11 +115,24 @@ describe('getStatusInfo', () => {
       workflowCheckpoint: 'invalid-checkpoint-for-test'
     } as unknown as Partial<Meta> as Meta
 
-    expect(getStatusFromMeta(meta)).toEqual({
+    const baseExpected = {
       name: 'invalid-state-for-test',
       version: BigInt(3),
       creator: 'core://user/abc',
-      cause: 'fixed',
+      cause: 'fixed'
+    }
+
+    // When isWorkflow is false, it should use the workflowCheckpoint
+    expect(getStatusFromMeta(meta, false)).toEqual({
+      ...baseExpected,
+      name: 'invalid-checkpoint-for-test',
+      checkpoint: 'invalid-checkpoint-for-test'
+    })
+
+    // When isWorkflow is true, it should use the workflowState
+    expect(getStatusFromMeta(meta, true)).toEqual({
+      ...baseExpected,
+      name: 'invalid-state-for-test',
       checkpoint: 'invalid-checkpoint-for-test'
     })
   })
@@ -100,12 +158,16 @@ describe('getStatusInfo', () => {
       updaterUri: 'core://user/abc'
     } as unknown as Partial<Meta> as Meta
 
-    expect(getStatusFromMeta(meta)).toEqual({
+    const expected = {
       name: 'done',
       version: BigInt(3),
       creator: 'core://user/abc',
       cause: 'fixed'
-    })
+    }
+
+    // isWorkflow doesn't affect the outcome
+    expect(getStatusFromMeta(meta, false)).toEqual(expected)
+    expect(getStatusFromMeta(meta, true)).toEqual(expected)
   })
 
   it('returns draft if no matching version in heads', () => {
@@ -122,12 +184,16 @@ describe('getStatusInfo', () => {
       updaterUri: 'core://user/abc'
     } as unknown as Partial<Meta> as Meta
 
-    expect(getStatusFromMeta(meta)).toEqual({
+    const expected = {
       name: 'done',
       version: BigInt(5),
       creator: 'core://user/abc',
       cause: undefined
-    })
+    }
+
+    // isWorkflow doesn't affect the outcome
+    expect(getStatusFromMeta(meta, false)).toEqual(expected)
+    expect(getStatusFromMeta(meta, true)).toEqual(expected)
   })
 
   it('returns most recently created status for current version with cause', () => {
@@ -160,12 +226,16 @@ describe('getStatusInfo', () => {
       updaterUri: 'core://user/e475867c-9b16-4a24-9855-54dafe4b1be5'
     }
 
-    expect(getStatusFromMeta(meta)).toEqual({
+    const expected = {
       name: 'done',
       version: BigInt(3),
       creator: 'core://user/e475867c-9b16-4a24-9855-54dafe4b1be5',
       cause: 'correction'
-    })
+    }
+
+    // isWorkflow doesn't affect the outcome
+    expect(getStatusFromMeta(meta, false)).toEqual(expected)
+    expect(getStatusFromMeta(meta, true)).toEqual(expected)
   })
 
 
@@ -199,11 +269,14 @@ describe('getStatusInfo', () => {
       updaterUri: 'core://user/e475867c-9b16-4a24-9855-54dafe4b1be5'
     }
 
-    expect(getStatusFromMeta(meta)).toEqual({
+    const expected = {
       name: 'done',
       version: BigInt(14),
       creator: 'core://user/e475867c-9b16-4a24-9855-54dafe4b1be5',
       cause: 'correction'
-    })
+    }
+
+    expect(getStatusFromMeta(meta, false)).toEqual(expected)
+    expect(getStatusFromMeta(meta, true)).toEqual(expected)
   })
 })

--- a/src/components/DocumentStatus/StatusMenu.tsx
+++ b/src/components/DocumentStatus/StatusMenu.tsx
@@ -26,7 +26,14 @@ export const StatusMenu = ({ documentId, type, publishTime, onBeforeStatusChange
   ) => Promise<boolean>
   isChanged?: boolean
 }) => {
-  const [documentStatus, setDocumentStatus] = useWorkflowStatus(documentId, true)
+  const isWorkflow = [
+    'core/article',
+    'core/flash',
+    'core/event-editorial-info',
+    'core/print-article'
+  ].includes(type)
+
+  const [documentStatus, setDocumentStatus] = useWorkflowStatus(documentId, isWorkflow)
   const containerRef = useRef<HTMLDivElement>(null)
   const [dropdownWidth, setDropdownWidth] = useState<number>(0)
   const { statuses, workflow } = useWorkflow(type)
@@ -85,7 +92,6 @@ export const StatusMenu = ({ documentId, type, publishTime, onBeforeStatusChange
           'core/planning-item': 'Planning',
           'core/event': 'Event'
         }
-
         handleLink({
           dispatch,
           viewItem: state.viewRegistry.get(viewType[type]),

--- a/src/hooks/useWorkflowStatus.tsx
+++ b/src/hooks/useWorkflowStatus.tsx
@@ -34,7 +34,7 @@ export const useWorkflowStatus = (uuid?: string, isWorkflow: boolean = false): [
 
       return {
         uuid,
-        ...getStatusFromMeta(meta)
+        ...getStatusFromMeta(meta, isWorkflow)
       }
     }
   )


### PR DESCRIPTION
Extend getStatusFromMeta to accept an isWorkflow flag, allowing it to return the workflowState for workflow documents and workflowCheckpoint for non-workflow documents. Update useWorkflowStatus and StatusMenu to pass the correct isWorkflow value based on document type. Enhance tests to cover new logic and ensure isWorkflow does not affect non-workflow results.