### PR TITLE
fix(flash): support startDate in planning selection

### DIFF
--- a/src/lib/index/fetch-plannings-twirp.ts
+++ b/src/lib/index/fetch-plannings-twirp.ts
@@ -113,7 +113,8 @@ export const fetch = async (
       payload: {
         slugline,
         sluglines: planning.fields['document.meta.core_assignment.meta.tt_slugline.value']?.values,
-        section: planning.fields['document.rel.section.uuid']?.values?.[0]
+        section: planning.fields['document.rel.section.uuid']?.values?.[0],
+        startDate: planning.fields['document.meta.core_planning_item.data.start_date']?.values?.[0]
       }
     }
   })

--- a/src/views/Flash/FlashDialog.tsx
+++ b/src/views/Flash/FlashDialog.tsx
@@ -28,7 +28,7 @@ export const FlashDialog = (props: ViewProps): JSX.Element => {
   const [sendPrompt, setSendPrompt] = useState(false)
   const [savePrompt, setSavePrompt] = useState(false)
   const [donePrompt, setDonePrompt] = useState(false)
-  const [selectedPlanning, setSelectedPlanning] = useState<DefaultValueOption | undefined>(undefined)
+  const [selectedPlanning, setSelectedPlanning] = useState<Omit<DefaultValueOption, 'payload'> & { payload: unknown } | undefined>(undefined)
   const [title, setTitle] = useYValue<string | undefined>('root.title')
   const { index, locale, timeZone } = useRegistry()
   const [searchOlder, setSearchOlder] = useState(false)
@@ -116,7 +116,8 @@ export const FlashDialog = (props: ViewProps): JSX.Element => {
                       if (option.value !== selectedPlanning?.value) {
                         setSelectedPlanning({
                           value: option.value,
-                          label: option.label
+                          label: option.label,
+                          payload: option.payload
                         })
 
                         const sectionPayload = option.payload as { section: string | undefined }
@@ -202,6 +203,10 @@ export const FlashDialog = (props: ViewProps): JSX.Element => {
                       props.onDialogClose(props.id, title)
                     }
 
+                    const { startDate } = (selectedPlanning?.payload ?? {}) as {
+                      startDate?: string
+                    }
+
                     createFlash({
                       flashProvider: provider,
                       status,
@@ -209,6 +214,7 @@ export const FlashDialog = (props: ViewProps): JSX.Element => {
                       planningId: selectedPlanning?.value,
                       timeZone,
                       documentStatus: config.documentStatus,
+                      startDate,
                       section: (!selectedPlanning?.value) ? section || undefined : undefined
                     })
                       .then(() => {

--- a/src/views/Flash/lib/createFlash.tsx
+++ b/src/views/Flash/lib/createFlash.tsx
@@ -15,7 +15,8 @@ export async function createFlash({
   planningId,
   timeZone,
   documentStatus,
-  section
+  section,
+  startDate
 }: {
   flashProvider: HocuspocusProvider
   status: string
@@ -27,7 +28,7 @@ export async function createFlash({
     uuid: string
     title: string
   }
-
+  startDate?: string
 }): Promise<void> {
   const flashEle = flashProvider.document.getMap('ele')
   const [documentId] = getValueByYPath<string>(flashEle, 'root.uuid')
@@ -58,8 +59,20 @@ export async function createFlash({
   // Create and collect all base data for the assignment
   const [flashTitle] = getValueByYPath<string>(flashEle, 'root.title')
   const dt = new Date()
-  const isoDateTime = `${new Date().toISOString().split('.')[0]}Z` // Remove ms, add Z back again
-  const localDate = convertToISOStringInTimeZone(dt, timeZone).slice(0, 10)
+  let localDate: string
+  let isoDateTime: string
+
+  if (startDate) {
+    // Use provided start date
+    const date = startDate.split('T')[0]
+    localDate = date
+    const currentTime = new Date().toISOString().split('T')[1].split('.')[0] + 'Z'
+    isoDateTime = `${date}T${currentTime}`
+  } else {
+    // create new date
+    isoDateTime = `${new Date().toISOString().split('.')[0]}Z`
+    localDate = convertToISOStringInTimeZone(dt, timeZone).slice(0, 10)
+  }
 
   const updatedPlanningId = await addAssignmentWithDeliverable({
     planningId,


### PR DESCRIPTION
Add support for passing and handling a `startDate` from planning selection throughout the flash creation flow. The start date is extracted from the planning fields and propagated via the payload to the flash creation logic. If a start date is provided, it is used to set the local date and ISO datetime for the flash; otherwise, the current date and time are used as before. This enables more accurate scheduling of flashes based on planning data.