### PR TITLE
fix(approvals): support editorial-info assignments

### DIFF
--- a/src/hooks/index/useAssignments.tsx
+++ b/src/hooks/index/useAssignments.tsx
@@ -56,7 +56,11 @@ export const useAssignments = ({ date, type, dateType = 'start-date', slots, sta
 
   const facets = getFacets(data)
 
-  useRepositoryEvents(['core/planning-item', 'core/planning-item+meta', 'core/article', 'core/article+meta'], (event) => {
+  useRepositoryEvents([
+    'core/planning-item', 'core/planning-item+meta',
+    'core/article', 'core/article+meta',
+    'core/editorial-info', 'core/editorial-info+meta'
+  ], (event) => {
     if ((event.event !== 'document' && event.event !== 'status' && event.event !== 'delete_document')) {
       return
     }

--- a/src/views/Approvals/index.tsx
+++ b/src/views/Approvals/index.tsx
@@ -54,7 +54,7 @@ export const ApprovalsView = (): JSX.Element => {
   }, [query.from, timeZone])
 
   const [data, facets] = useAssignments({
-    type: ['flash', 'text'],
+    type: ['flash', 'text', 'editorial-info'],
     requireDeliverable: true,
     requireMetrics: ['charcount'],
     date,


### PR DESCRIPTION
Extend the Approvals view and useAssignments hook to include 'editorial-info' types and listen for 'core/editorial-info' repository events. This enables handling of editorial info assignments and ensures real-time updates when related events occur.