### PR TITLE
fix(story): add asSubject prop to Story component

### DIFF
--- a/src/components/Story.tsx
+++ b/src/components/Story.tsx
@@ -5,7 +5,9 @@ import { ComboBox } from '@ttab/elephant-ui'
 import { useRef } from 'react'
 import type { FormProps } from './Form/Root'
 
-export const Story = ({ onChange }: FormProps): JSX.Element => {
+export const Story = ({ onChange, asSubject }: {
+  asSubject?: boolean
+} & FormProps): JSX.Element => {
   const allStories = useStories().map((_) => {
     return {
       value: _.id,
@@ -37,7 +39,9 @@ export const Story = ({ onChange }: FormProps): JSX.Element => {
             ? undefined
             : Block.create({
               type: 'core/story',
-              rel: 'story',
+              // Workaround for rel differences in the API
+              // Article is subject, planning and event are story
+              rel: asSubject ? 'subject' : 'story',
               uuid: option.value,
               title: option.label
             }))

--- a/src/views/Editor/components/MetaSheet.tsx
+++ b/src/views/Editor/components/MetaSheet.tsx
@@ -67,7 +67,7 @@ export function MetaSheet({ container, documentId, readOnly, readOnlyVersion }: 
 
                   <Label htmlFor='tags' className='text-xs text-muted-foreground -mb-3'>Etiketter</Label>
                   <div className='flex flex-row gap-3' id='tags'>
-                    <Story />
+                    <Story asSubject />
                     <Section />
                   </div>
 


### PR DESCRIPTION
Introduce an `asSubject` prop to the Story component to allow specifying the `rel` attribute as 'subject' or 'story' based on context. Update MetaSheet to use Story with `asSubject` for correct API behavior.