### PR TITLE
fix(snapshot): handle and return error status from snapshot

### DIFF
--- a/src/hooks/useWorkflowStatus.tsx
+++ b/src/hooks/useWorkflowStatus.tsx
@@ -62,6 +62,10 @@ export const useWorkflowStatus = (uuid?: string, isWorkflow: boolean = false): [
       // Snapshot document to make sure we have the latest version, get the new version from the response
       const snapshotResponse = uuid && await snapshot(uuid, true)
 
+      if (snapshotResponse && 'statusCode' in snapshotResponse && snapshotResponse.statusCode !== 200) {
+        return
+      }
+
       const newVersion = snapshotResponse && 'version' in snapshotResponse && typeof snapshotResponse.version === 'string'
         ? BigInt(snapshotResponse.version)
         : documentStatus?.version

--- a/src/hooks/useWorkflowStatus.tsx
+++ b/src/hooks/useWorkflowStatus.tsx
@@ -63,6 +63,7 @@ export const useWorkflowStatus = (uuid?: string, isWorkflow: boolean = false): [
       const snapshotResponse = uuid && await snapshot(uuid, true)
 
       if (snapshotResponse && 'statusCode' in snapshotResponse && snapshotResponse.statusCode !== 200) {
+        toast.error(`Ett fel uppstod när aktuell status skulle ändras: ${snapshotResponse.statusMessage || 'Okänt fel'}`)
         return
       }
 

--- a/src/lib/snapshot.ts
+++ b/src/lib/snapshot.ts
@@ -37,8 +37,16 @@ export async function snapshot(id: string, force?: true, delay: number = 0): Pro
     if (ex instanceof Error) {
       console.error('Failed to save snapshot:', ex.message)
       toast.error(`Lyckades inte spara kopia! ${ex.message}`)
+      return {
+        statusCode: 500,
+        statusMessage: ex.message
+      }
     } else {
       toast.error(`Lyckades inte spara kopia!`)
+      return {
+        statusCode: 500,
+        statusMessage: 'Unknown error occurred while saving snapshot'
+      }
     }
   }
 }

--- a/src/lib/snapshot.ts
+++ b/src/lib/snapshot.ts
@@ -1,5 +1,3 @@
-import { toast } from 'sonner'
-
 const BASE_URL = import.meta.env.BASE_URL
 
 type SnapshotResponse = {
@@ -27,26 +25,22 @@ export async function snapshot(id: string, force?: true, delay: number = 0): Pro
     const data = await response.json() as SnapshotResponse
 
     if (!response.ok) {
-      throw new Error((data && typeof data?.statusMessage === 'string')
-        ? data.statusMessage
-        : response.statusText)
+      return {
+        statusCode: response.status,
+        statusMessage: (data && typeof data?.statusMessage === 'string')
+          ? data.statusMessage
+          : response.statusText
+      }
     }
 
     return data
   } catch (ex) {
-    if (ex instanceof Error) {
-      console.error('Failed to save snapshot:', ex.message)
-      toast.error(`Lyckades inte spara kopia! ${ex.message}`)
-      return {
-        statusCode: 500,
-        statusMessage: ex.message
-      }
-    } else {
-      toast.error(`Lyckades inte spara kopia!`)
-      return {
-        statusCode: 500,
-        statusMessage: 'Unknown error occurred while saving snapshot'
-      }
+    const msg = (ex instanceof Error) ? ex.message : 'Failed saving snapshot'
+    console.error(msg)
+
+    return {
+      statusCode: -1,
+      statusMessage: msg
     }
   }
 }


### PR DESCRIPTION
Add error handling in the snapshot function to return a status code and message when an error occurs, instead of throwing. Update useWorkflowStatus to check for error status in the snapshot response and exit early if an error is detected. This prevents further processing on failed snapshot attempts and improves error feedback.