### PR TITLE
fix(print-editor): track unsaved changes in editor UI

### DIFF
--- a/src/views/PrintEditor/LayoutBox.tsx
+++ b/src/views/PrintEditor/LayoutBox.tsx
@@ -19,13 +19,15 @@ export function LayoutBox({
   layoutIdForRender,
   layoutId,
   index,
-  deleteLayout
+  deleteLayout,
+  onChange
 }: {
   documentId: string
   layoutIdForRender: string
   layoutId: string
   index: number
   deleteLayout: (layoutId: string) => void
+  onChange?: (value: boolean) => void
 }) {
   const { baboon } = useRegistry()
   const { data: session } = useSession()
@@ -144,10 +146,11 @@ export function LayoutBox({
           articleLayoutId={layoutId}
           basePath={base}
           className='w-full'
+          onChange={onChange}
         />
       </div>
-      <Position basePath={base} />
-      <Additionals basePath={base} />
+      <Position basePath={base} onChange={onChange} />
+      <Additionals basePath={base} onChange={onChange} />
     </div>
   )
 }

--- a/src/views/PrintEditor/PrintEditorHeader.tsx
+++ b/src/views/PrintEditor/PrintEditorHeader.tsx
@@ -25,11 +25,13 @@ import { PenBoxIcon } from '@ttab/elephant-ui/icons'
 export const EditorHeader = ({
   documentId,
   name,
-  flowName
+  flowName,
+  isChanged
 }: {
   documentId: string
   name?: string
   flowName?: string
+  isChanged?: boolean
 }): JSX.Element => {
   const { viewId } = useView()
   const containerRef = useRef<HTMLElement | null>(null)
@@ -62,6 +64,7 @@ export const EditorHeader = ({
                   <StatusMenu
                     documentId={documentId}
                     type='tt/print-article'
+                    isChanged={isChanged}
                   />
                 </>
               )}

--- a/src/views/PrintEditor/components/Additionals.tsx
+++ b/src/views/PrintEditor/components/Additionals.tsx
@@ -6,8 +6,9 @@ export interface Additional {
   value: string
 }
 
-export const Additionals = ({ basePath }: {
+export const Additionals = ({ basePath, onChange }: {
   basePath: string
+  onChange?: (value: boolean) => void
 }): JSX.Element | null => {
   const [additionals, setAdditionals] = useYValue<Additional[]>(`${basePath}.meta.tt/print-features[0].content.tt/print-feature`)
 
@@ -17,6 +18,7 @@ export const Additionals = ({ basePath }: {
       i === index ? { ...item, value: item.value === 'true' ? 'false' : 'true' } : item
     )
     setAdditionals(updated)
+    onChange?.(true)
   }
 
   if (additionals?.length) {
@@ -47,8 +49,9 @@ const Additional = ({ additional, index, onChange }: {
     <Checkbox
       className='bg-white'
       checked={additional.value === 'true'}
-      onCheckedChange={() =>
-        onChange(index)}
+      onCheckedChange={() => {
+        onChange(index)
+      }}
     />
     {additional.name}
   </Label>

--- a/src/views/PrintEditor/components/Layouts.tsx
+++ b/src/views/PrintEditor/components/Layouts.tsx
@@ -5,10 +5,11 @@ import { Loader } from '@ttab/elephant-ui/icons'
 import { useYValue } from '@/hooks/useYValue'
 import { cn } from '@ttab/elephant-ui/utils'
 
-export const Layouts = ({ articleLayoutId, basePath, className }: {
+export const Layouts = ({ articleLayoutId, basePath, onChange, className }: {
   articleLayoutId?: string
   className?: string
   basePath: string
+  onChange?: (value: boolean) => void
 }) => {
   const { data: layouts } = useDocuments({
     documentType: 'tt/print-layout',
@@ -44,6 +45,7 @@ export const Layouts = ({ articleLayoutId, basePath, className }: {
           value: l
         }))}
       onSelect={(option) => {
+        onChange?.(true)
         setArticleLayoutName(option.value)
       }}
     />

--- a/src/views/PrintEditor/components/Position.tsx
+++ b/src/views/PrintEditor/components/Position.tsx
@@ -1,7 +1,10 @@
 import { useYValue } from '@/hooks/useYValue'
 import { Input } from '@ttab/elephant-ui'
 
-export const Position = ({ basePath }: { basePath: string }) => {
+export const Position = ({ basePath, onChange }: {
+  basePath: string
+  onChange?: (value: boolean) => void
+}) => {
   const [position, setPosition] = useYValue<string>(`${basePath}.data.position`)
   return (
     <div className='col-span-2 row-span-1'>
@@ -11,6 +14,7 @@ export const Position = ({ basePath }: { basePath: string }) => {
         placeholder='Position'
         value={position}
         onChange={(e) => {
+          onChange?.(true)
           setPosition(e.target.value)
         }}
       />


### PR DESCRIPTION
Add `isChanged` prop to EditorHeader and propagate change tracking through LayoutBox, Layouts, Position, and Additionals components. Introduce `onChange` callbacks to update a Yjs-backed `changed` flag when edits occur. This enables UI elements to reflect unsaved changes state, improving user awareness of document modifications.