### PR TITLE
fix(print-editor): prevent onChange on initial render

### DIFF
--- a/src/components/DocumentStatus/StatusMenu.tsx
+++ b/src/components/DocumentStatus/StatusMenu.tsx
@@ -30,9 +30,9 @@ export const StatusMenu = ({ documentId, type, publishTime, onBeforeStatusChange
   const shouldUseWorkflowStatus = [
     'core/article',
     'core/flash',
-    'core/editorial-info',
-    'tt/print-article'
+    'core/editorial-info'
   ].includes(type)
+
   const [documentStatus, setDocumentStatus] = useWorkflowStatus(documentId, shouldUseWorkflowStatus)
   const containerRef = useRef<HTMLDivElement>(null)
   const [dropdownWidth, setDropdownWidth] = useState<number>(0)

--- a/src/views/PrintEditor/index.tsx
+++ b/src/views/PrintEditor/index.tsx
@@ -419,13 +419,22 @@ function EditorContent({ provider, user, onChange }: {
     }
   }, [isActive, ref])
 
+  // Initialization of the editor causes a call to onChange, we're not interested in that.
+  const hasInitialized = useRef(false)
+
   return (
     <Textbit.Editable
       ref={ref}
       yjsEditor={yjsEditor}
       lang={documentLanguage}
       onSpellcheck={onSpellcheck}
-      onChange={() => onChange?.(true)}
+      onChange={(_value) => {
+        if (hasInitialized.current) {
+          onChange?.(true)
+        } else {
+          hasInitialized.current = true
+        }
+      }}
       className='outline-none
         h-full
         dark:text-slate-100


### PR DESCRIPTION
Previously, the onChange handler in the PrintEditor was triggered during the initial editor setup, causing unnecessary side effects. This change introduces a ref to track initialization and ensures onChange is only called after the first render. Also, removed 'tt/print-article' from the workflow status types in StatusMenu for consistency.