### PR TITLE
feat(editor): show alert and disable editing on disconnect

### DIFF
--- a/src/views/Editor/components/ConnectionAlert.tsx
+++ b/src/views/Editor/components/ConnectionAlert.tsx
@@ -1,0 +1,14 @@
+import { Alert, AlertTitle, AlertDescription } from '@ttab/elephant-ui'
+import { Unplug } from '@ttab/elephant-ui/icons'
+
+export const ConnectionAlert = (): JSX.Element => (
+  <div className='p-4'>
+    <Alert variant='destructive'>
+      <Unplug size={18} strokeWidth={1.75} />
+      <AlertTitle>Du saknar anslutning till servern</AlertTitle>
+      <AlertDescription>
+        Försöker att återansluta... Under tiden kan du inte redigera dokumentet.
+      </AlertDescription>
+    </Alert>
+  </div>
+)


### PR DESCRIPTION
Add a ConnectionAlert component to inform users when the editor is disconnected from the server and attempting to reconnect. The editor is set to read-only mode during disconnection, preventing edits until the connection is restored. Also, update the collaboration context to track WebSocket status and handle reconnection attempts with user feedback.

This is probably not a complete solution, but a start.

How to test:
Wasn't able to use the dev server
* You need to `npm run build && npm run start:local`
* Kill the server
* Restart