### PR TITLE
refactor(snapshot): support status/cause in snapshot API and wire status

### DIFF
--- a/src-srv/api/snapshot/[id]/index.ts
+++ b/src-srv/api/snapshot/[id]/index.ts
@@ -61,7 +61,7 @@ export const POST: RouteHandler = async (req: Request, { collaborationServer, ca
   try {
     // Check if document exists in cache
     const state = await cache.get(uuid)
-    // TODO: CHECK THIS
+
     if (!state && !payload) {
       const notFoundMessage = `Document not found in cache: ${uuid}`
       logger.warn(notFoundMessage)
@@ -81,7 +81,6 @@ export const POST: RouteHandler = async (req: Request, { collaborationServer, ca
       statusMessage: cacheErrorMessage
     }
   }
-
 
   const connection = await collaborationServer.server.openDirectConnection(uuid, context)
 

--- a/src-srv/routes.ts
+++ b/src-srv/routes.ts
@@ -7,6 +7,8 @@ import type { CollaborationServer } from './utils/CollaborationServer.js'
 import type { RedisCache } from './utils/RedisCache.js'
 import logger from './lib/logger.js'
 
+import { raw as expressRaw } from 'express'
+
 /* Route types */
 interface Route {
   path: string
@@ -89,6 +91,7 @@ export function connectRouteHandlers(app: Application, routes: RouteMap, context
 
     const { GET, POST, PUT, PATCH, DELETE, WEB_SOCKET } = routes[route].handlers || {}
 
+
     if (GET) {
       connectRouteHandler(app, routePath, GET, context)
     }
@@ -168,6 +171,18 @@ function connectRouteHandler(app: Application, routePath: string, func: RouteHan
       return app.get(routePath, handlerFunc)
 
     case 'POST':
+      if (func.length > 0) {
+        return app.post(
+          routePath,
+          (req, res, next) => {
+            if (req.is('application/octet-stream')) {
+              return expressRaw({ type: 'application/octet-stream' })(req, res, next)
+            }
+            next()
+          },
+          handlerFunc
+        )
+      }
       return app.post(routePath, handlerFunc)
 
     case 'PUT':

--- a/src-srv/routes.ts
+++ b/src-srv/routes.ts
@@ -91,7 +91,6 @@ export function connectRouteHandlers(app: Application, routes: RouteMap, context
 
     const { GET, POST, PUT, PATCH, DELETE, WEB_SOCKET } = routes[route].handlers || {}
 
-
     if (GET) {
       connectRouteHandler(app, routePath, GET, context)
     }

--- a/src-srv/utils/CollaborationServer.ts
+++ b/src-srv/utils/CollaborationServer.ts
@@ -313,11 +313,13 @@ export class CollaborationServer {
     return Y.encodeStateAsUpdate(yDoc)
   }
 
-  async snapshotDocument({ documentName, document: yDoc, context, force = false, transacting = false }: {
+  async snapshotDocument({ documentName, document: yDoc, context, force = false, transacting = false, status, cause }: {
     documentName: string
     document: Y.Doc
     context: Context
     force?: boolean
+    status?: string
+    cause?: string
     transacting?: boolean
   }): Promise<FinishedUnaryCall<UpdateRequest, UpdateResponse> | null> {
     // Ignore userTracker documents and invalid uuids, most likely same as the first
@@ -350,8 +352,9 @@ export class CollaborationServer {
       hash,
       context.accessToken,
       context,
-      undefined,
-      transacting ? yDoc : undefined
+      status,
+      transacting ? yDoc : undefined,
+      cause
     )
   }
 
@@ -362,7 +365,8 @@ export class CollaborationServer {
     accessToken: string,
     context: Context,
     status?: string,
-    transactingDoc?: Y.Doc
+    transactingDoc?: Y.Doc,
+    cause?: string
   ): Promise<FinishedUnaryCall<UpdateRequest, UpdateResponse>> {
     const { document, version } = documentResponse
     if (!document) {
@@ -373,7 +377,8 @@ export class CollaborationServer {
       document,
       accessToken,
       version,
-      status
+      status,
+      cause
     )
 
     if (result?.status.code !== 'OK') {

--- a/src-srv/utils/CollaborationServer.ts
+++ b/src-srv/utils/CollaborationServer.ts
@@ -273,7 +273,10 @@ export class CollaborationServer {
     }
 
     if (!assertContext(context)) {
-      logger.warn({ context, documentName: uuid }, 'Invalid context provided')
+      logger.warn({
+        context: context as unknown,
+        documentName: uuid
+      }, 'Invalid context provided')
       throw new Error('#fetchDocument - Invalid context provided')
     }
 

--- a/src-srv/utils/createSnapshot.ts
+++ b/src-srv/utils/createSnapshot.ts
@@ -12,6 +12,8 @@ export async function createSnapshot(collaborationServer: CollaborationServer, p
   document: Y.Doc
   context: Context
   force?: boolean
+  status?: string
+  cause?: string
 }): Promise<Response> {
   // FIXME: We should probably expose collaborationServer.#storeDocumentInRepository and call directly
   // FIXME: So we don't need to pass on transacting etc.

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -193,7 +193,7 @@ export const Table = <TData, TValue>({
             name: currentStatus === 'read' ? 'draft' : 'read',
             uuid: wireRow.original.id,
             version: BigInt(wireRow.original.fields.current_version.values?.[0])
-          })
+          }, undefined, true)
         }
         return
       }
@@ -207,7 +207,7 @@ export const Table = <TData, TValue>({
             name: currentStatus === 'used' ? 'draft' : 'used',
             uuid: wireRow.original.id,
             version: BigInt(wireRow.original.fields.current_version.values?.[0])
-          })
+          }, undefined, true)
         }
         return
       }
@@ -224,7 +224,7 @@ export const Table = <TData, TValue>({
             name: currentStatus === 'saved' ? 'draft' : 'saved',
             uuid: wireRow.original.id,
             version: BigInt(wireRow.original.fields.current_version.values?.[0])
-          })
+          }, undefined, true)
         }
         return
       }
@@ -238,7 +238,7 @@ export const Table = <TData, TValue>({
               name: 'used',
               uuid: wireRow.original.id,
               version: BigInt(wireRow.original.fields.current_version.values?.[0])
-            })
+            }, undefined, true)
           }
           showModal(
             <Wire

--- a/src/hooks/useWorkflowStatus.tsx
+++ b/src/hooks/useWorkflowStatus.tsx
@@ -62,7 +62,6 @@ export const useWorkflowStatus = (uuid?: string, isWorkflow: boolean = false): [
 
       // Handle wire status updates
       if (asWire && typeof newStatus === 'object' && repository) {
-        console.log('handle wire', newStatus)
         void setWireStatus(newStatus, repository, session)
         return
       }

--- a/src/hooks/useWorkflowStatus.tsx
+++ b/src/hooks/useWorkflowStatus.tsx
@@ -1,24 +1,28 @@
 import { useSession } from 'next-auth/react'
+import type { KeyedMutator } from 'swr'
 import useSWR, { mutate as globalMutate } from 'swr'
 import { useCallback } from 'react'
-import { useRegistry, useYValue } from '@/hooks'
+import { useCollaboration, useRegistry, useYValue } from '@/hooks'
 import { toast } from 'sonner'
-import type { Status } from '@/shared/Repository'
+import type { Repository, Status } from '@/shared/Repository'
 import { snapshot } from '@/lib/snapshot'
 import { getStatusFromMeta } from '@/lib/getStatusFromMeta'
+import type { Session } from 'next-auth'
 
 export const useWorkflowStatus = (uuid?: string, isWorkflow: boolean = false): [
   Status | undefined,
-  (newStatusName: string | Status, cause?: string) => Promise<void>
+  (newStatusName: string | Status, cause?: string, asWire?: boolean) => Promise<void>,
+  KeyedMutator<Status | undefined>
 ] => {
   const { repository } = useRegistry()
   const { data: session } = useSession()
+  const { provider } = useCollaboration()
   const [, setChanged] = useYValue('root.changed')
 
   /**
    * SWR callback that fetches current workflow status
    */
-  const { data: documentStatus, mutate, error } = useSWR<Status | undefined, Error>(
+  const { data: documentStatus, error, mutate } = useSWR<Status | undefined, Error>(
     (uuid && session && repository) ? [`status/${uuid}`] : null,
     async () => {
       // Dont try to fetch if document is inProgress
@@ -50,89 +54,60 @@ export const useWorkflowStatus = (uuid?: string, isWorkflow: boolean = false): [
    * Callback hook to update the workflow status of a document
    */
   const setDocumentStatus = useCallback(
-    async (newStatus: string | Status, cause?: string) => {
-      if (!session || !repository) {
+    async (newStatus: string | Status, cause?: string, asWire?: boolean) => {
+      if (!session) {
         toast.error('Ett fel har uppstått, aktuell status kunde inte ändras! Ladda om webbläsaren och försök igen.')
         return
       }
 
-      // Work with the latest status if possible
-      const currentStatus = documentStatus || await globalMutate([`status/${uuid}`], undefined, false)
+      // Handle wire status updates
+      if (asWire && typeof newStatus === 'object' && repository) {
+        console.log('handle wire', newStatus)
+        void setWireStatus(newStatus, repository, session)
+        return
+      }
 
-      // Snapshot document to make sure we have the latest version, get the new version from the response
-      const snapshotResponse = uuid && await snapshot(uuid, true)
+
+      // Snapshot and if applicable, update the status with cause in one call
+      const snapshotResponse = uuid && await snapshot(uuid, {
+        force: true,
+        status: typeof newStatus === 'string'
+          ? newStatus
+          : newStatus.name,
+        cause
+      }, provider?.document)
 
       if (snapshotResponse && 'statusCode' in snapshotResponse && snapshotResponse.statusCode !== 200) {
         toast.error(`Ett fel uppstod när aktuell status skulle ändras: ${snapshotResponse.statusMessage || 'Okänt fel'}`)
         return
       }
 
-      const newVersion = snapshotResponse && 'version' in snapshotResponse && typeof snapshotResponse.version === 'string'
-        ? BigInt(snapshotResponse.version)
-        : documentStatus?.version
 
-      let payload: Status | undefined
-      if (typeof newStatus !== 'string') {
-        payload = {
-          ...newStatus,
-          version: newVersion || newStatus.version
-        }
-      } else if (typeof newStatus === 'string' && documentStatus && uuid) {
-        if (!newVersion) {
-          console.error('Unable to get current version to update status')
-          toast.error('Ett fel har uppstått, aktuell status kunde inte ändras!')
-          return
-        }
+      // Reset unsaved changes state
+      setChanged(undefined)
 
-        payload = {
-          ...documentStatus,
-          uuid,
-          name: newStatus,
-          version: newVersion
-        }
-      }
-
-      if (!payload) {
-        toast.error('Ett fel uppstod och status kunde inte ändras!')
-        return
-      }
-
-      // Optimistically update the SWR cache before performing the actual API call
-      await mutate(payload, false)
-
-      // Change status of document in repository
-      try {
-        // If there is a previous checkpoint (published/scheduled/unpublished version) we require a cause to publish a new version
-        if (currentStatus?.checkpoint
-          && ['usable', 'withheld', 'unpublished'].includes(payload.name)
-          && typeof cause !== 'string'
-        ) {
-          toast.error('En anledning måste ges för att skapa en ny version. Aktuell status kunde inte ändras!')
-          return
-        }
-
-        await repository.saveMeta({
-          status: payload,
-          currentStatus: isWorkflow ? currentStatus : undefined,
-          accessToken: session.accessToken,
-          cause,
-          isWorkflow
-        })
-
-        // Reset unsaved changes state
-        setChanged(undefined)
-
-        // Revalidate after the mutation completes
-        await globalMutate([`status/${uuid || payload.uuid}`])
-      } catch (error) {
-        console.error('Failed to update status', error)
-        toast.error('Ett fel uppstod och aktuell status kunde inte ändras!')
-        // Rollback the optimistic update if the ststus update fails
-        await mutate(currentStatus, false)
-      }
+      // Revalidate after the mutation completes
+      await globalMutate([`status/${uuid}`])
     },
-    [session, uuid, documentStatus, mutate, repository, isWorkflow, setChanged]
+    [session, uuid, setChanged, provider?.document, repository]
   )
 
-  return [documentStatus, setDocumentStatus]
+  return [documentStatus, setDocumentStatus, mutate]
+}
+
+async function setWireStatus(newStatus: Status, repository: Repository, session: Session) {
+  try {
+    if (!repository || !session.accessToken) {
+      throw new Error('Repository or session access token is not available')
+    }
+
+    await repository.saveMeta({
+      status: newStatus,
+      currentStatus: undefined,
+      accessToken: session.accessToken
+    })
+  } catch (error) {
+    console.error('Failed to set wire status', error)
+    toast.error('Ett fel uppstod när aktuell status skulle sparas')
+  }
 }

--- a/src/lib/snapshot.ts
+++ b/src/lib/snapshot.ts
@@ -36,10 +36,8 @@ export async function snapshot(
     if (options?.status) url.searchParams.set('status', options.status)
     if (options?.cause) url.searchParams.set('cause', options.cause)
 
-    // TODO: v1 or v2
     const update = document ? Y.encodeStateAsUpdateV2(document) : null
 
-    console.log('src/lib/snapshot', url)
     const response = await fetch(url, {
       method: 'POST',
       headers: {
@@ -49,7 +47,6 @@ export async function snapshot(
     })
 
     const result = await response.json() as SnapshotResponse
-    console.log('Snapshot response', result)
 
     if (!response.ok) {
       return {

--- a/src/views/Planning/components/AssignmentRow.tsx
+++ b/src/views/Planning/components/AssignmentRow.tsx
@@ -388,7 +388,9 @@ export const AssignmentRow = ({ index, onSelect, isFocused = false, asDialog, on
               })
 
               if (planningId) {
-                void snapshot(planningId, undefined, 800).then(() => {
+                void snapshot(planningId, {
+                  force: true
+                }, provider.document).then(() => {
                   const openDocument = assignmentType === 'flash' ? openFlash : openArticle
                   openDocument(undefined, { id, planningId }, 'blank')
                 })

--- a/src/views/Planning/components/AssignmentRow.tsx
+++ b/src/views/Planning/components/AssignmentRow.tsx
@@ -388,9 +388,7 @@ export const AssignmentRow = ({ index, onSelect, isFocused = false, asDialog, on
               })
 
               if (planningId) {
-                void snapshot(planningId, {
-                  force: true
-                }, provider.document).then(() => {
+                void snapshot(planningId, undefined, provider.document).then(() => {
                   const openDocument = assignmentType === 'flash' ? openFlash : openArticle
                   openDocument(undefined, { id, planningId }, 'blank')
                 })

--- a/src/views/Planning/components/AssignmentTable.tsx
+++ b/src/views/Planning/components/AssignmentTable.tsx
@@ -145,8 +145,10 @@ export const AssignmentTable = ({ asDialog = false, documentId, onChange }: {
             deleteByYPath(yRoot, `meta.core/assignment[${newAssigment.index}]`)
           }}
           onClose={() => {
-            handleClose().catch(console.error)
-            toast.error('Kunde inte spara uppdraget.')
+            handleClose().catch((ex) => {
+              console.error('Error closing assignment:', ex)
+              toast.error('Kunde inte spara uppdraget.')
+            })
           }}
           className='mb-6'
         />

--- a/src/views/Planning/components/AssignmentTable.tsx
+++ b/src/views/Planning/components/AssignmentTable.tsx
@@ -13,6 +13,7 @@ import { cva } from 'class-variance-authority'
 import { Button } from '@ttab/elephant-ui'
 import { useActiveAuthor } from '@/hooks/useActiveAuthor'
 import { snapshot } from '@/lib/snapshot'
+import { toast } from 'sonner'
 
 export const AssignmentTable = ({ asDialog = false, documentId, onChange }: {
   asDialog?: boolean
@@ -83,7 +84,7 @@ export const AssignmentTable = ({ asDialog = false, documentId, onChange }: {
       }, provider?.document)
     }
 
-    // Set document as changed once we abort the new assignment
+    // Set document as changed once we close the new assignment
     onChange?.(true)
   }
 
@@ -145,6 +146,7 @@ export const AssignmentTable = ({ asDialog = false, documentId, onChange }: {
           }}
           onClose={() => {
             handleClose().catch(console.error)
+            toast.error('Kunde inte spara uppdraget.')
           }}
           className='mb-6'
         />

--- a/src/views/Planning/index.tsx
+++ b/src/views/Planning/index.tsx
@@ -187,7 +187,7 @@ const PlanningViewContent = (props: ViewProps & { documentId: string, setNewItem
           </Form.Content>
 
           <Form.Table>
-            <AssignmentTable asDialog={props.asDialog} onChange={handleChange} />
+            <AssignmentTable asDialog={props.asDialog} onChange={handleChange} documentId={props.documentId} />
           </Form.Table>
 
           <Form.Footer>

--- a/src/views/Wires/components/PreviewSheet.tsx
+++ b/src/views/Wires/components/PreviewSheet.tsx
@@ -88,18 +88,18 @@ export const PreviewSheet = ({ id, wire, handleClose, textOnly = true, version, 
 
 
   if (!wire) {
-    return <p>no wire</p>
+    return <p>No wire id provided</p>
   }
 
-  const source = wire?.fields['document.rel.source.uri']?.values[0]
+  const source = wire.fields['document.rel.source.uri']?.values[0]
     ?.replace('wires://source/', '')
 
-  const provider = wire?.fields['document.rel.provider.uri']?.values[0]
+  const provider = wire.fields['document.rel.provider.uri']?.values[0]
     ?.replace('wires://provider/', '')
 
-  const role = wire?.fields['document.meta.tt_wire.role'].values[0]
-  const newsvalue = wire?.fields['document.meta.core_newsvalue.value']?.values[0]
-  const currentVersion = BigInt(wire?.fields['current_version']?.values[0] || '')
+  const role = wire.fields['document.meta.tt_wire.role'].values[0]
+  const newsvalue = wire.fields['document.meta.core_newsvalue.value']?.values[0]
+  const currentVersion = BigInt(wire.fields['current_version']?.values[0] || '')
   const currentStatus = getWireStatus('Wires', wire)
 
   return (


### PR DESCRIPTION
- Add support for sending `status` and `cause` as query params and payload in the snapshot API POST endpoint.
- Update backend and utility functions to handle new parameters and propagate them through snapshot and document update flows.
- Refactor `useWorkflowStatus` to allow direct wire status updates and pass status/cause to snapshot.
- Update Table and PreviewSheet components to use new wire status logic, including keyboard shortcuts and status dropdown.
- Update snapshot utility to POST with Yjs update and new options.