### PR TITLE
fix: remove version param from saveDocument calls

### DIFF
--- a/__tests__/initializeAuthor.test.ts
+++ b/__tests__/initializeAuthor.test.ts
@@ -100,7 +100,6 @@ describe('initializeAuthor', () => {
         ])
       }),
       mockSession.accessToken,
-      expect.any(BigInt),
       expect.any(String)
     )
     expect(toast.success).toHaveBeenCalledWith('Författardokument är uppdaterat')

--- a/shared/Repository.ts
+++ b/shared/Repository.ts
@@ -253,7 +253,7 @@ export class Repository {
    * @param accessToken string
    * @returns Promise<FinishedUnaryCall<UpdateRequest, UpdateResponse>
    */
-  async saveDocument(document: Document, accessToken: string, version: bigint, status?: string, cause?: string): Promise<FinishedUnaryCall<UpdateRequest, UpdateResponse> | undefined> {
+  async saveDocument(document: Document, accessToken: string, status?: string, cause?: string): Promise<FinishedUnaryCall<UpdateRequest, UpdateResponse> | undefined> {
     const payload: UpdateRequest = {
       document,
       meta: {},
@@ -262,7 +262,8 @@ export class Repository {
       status: status
         ? [{
             name: status,
-            version,
+            // Use the resulting version from the save
+            version: 0n,
             meta: cause ? { cause } : {},
             // No optimistic lock
             ifMatch: 0n

--- a/src-srv/utils/CollaborationServer.ts
+++ b/src-srv/utils/CollaborationServer.ts
@@ -371,7 +371,7 @@ export class CollaborationServer {
     transactingDoc?: Y.Doc,
     cause?: string
   ): Promise<FinishedUnaryCall<UpdateRequest, UpdateResponse>> {
-    const { document, version } = documentResponse
+    const { document } = documentResponse
     if (!document) {
       throw new Error(`Store document ${documentName} failed, no document in GetDocumentResponse parameter`)
     }
@@ -379,7 +379,6 @@ export class CollaborationServer {
     const result = await this.#repository.saveDocument(
       document,
       accessToken,
-      version,
       status,
       cause
     )

--- a/src/components/Init/lib/actions/author.ts
+++ b/src/components/Init/lib/actions/author.ts
@@ -80,7 +80,7 @@ export async function initializeAuthor({ url, session, repository }: {
       ? (operation = 'update', appendSub(authorDoc.hits[0].document!, session, envRole))
       : createAuthorDoc(session, envRole, 'sv-se')
 
-    const result = await repository.saveDocument(document, session.accessToken, 0n, 'usable')
+    const result = await repository.saveDocument(document, session.accessToken, 'usable')
     if (result?.status.code !== 'OK') {
       throw new Error(`Failed to ${operation} author doc`)
     }

--- a/src/views/Planning/components/CreateDeliverablePrompt.tsx
+++ b/src/views/Planning/components/CreateDeliverablePrompt.tsx
@@ -33,8 +33,7 @@ export function CreateDeliverablePrompt({ deliverableType, payload, onClose, tit
     const template = getTemplateFromDeliverable(deliverableType)
     await repository.saveDocument(
       template(id, payload),
-      session.accessToken,
-      BigInt(-1)
+      session.accessToken
     )
 
     return id


### PR DESCRIPTION
Fixed the saveDocument method in Repository and all its usages to remove the version parameter. The version is now handled internally within the save operation. Updated related function signatures and callers to reflect this change.