### PR TITLE
fix(metasheet): show applicable fields for each documentType

### DIFF
--- a/src/views/Editor/components/MetaSheet.tsx
+++ b/src/views/Editor/components/MetaSheet.tsx
@@ -59,36 +59,40 @@ export function MetaSheet({ container, documentId, readOnly, readOnlyVersion }: 
             : (
                 <div className='flex flex-col gap-6 px-5 py-4 border-t'>
 
-                  <Label htmlFor='properties' className='text-xs text-muted-foreground -mb-3'>Egenskaper</Label>
-                  <div className='flex flex-row gap-3' id='properties'>
-                    <Newsvalue />
-                    <SluglineButton path='meta.tt/slugline[0].value' />
-                  </div>
+                  {documentType === 'core/article' && (
+                    <>
+                      <Label htmlFor='properties' className='text-xs text-muted-foreground -mb-3'>Egenskaper</Label>
+                      <div className='flex flex-row gap-3' id='properties'>
+                        <Newsvalue />
+                        <SluglineButton path='meta.tt/slugline[0].value' />
+                      </div>
 
-                  <Label htmlFor='tags' className='text-xs text-muted-foreground -mb-3'>Etiketter</Label>
-                  <div className='flex flex-row gap-3' id='tags'>
-                    <Story asSubject />
-                    <Section />
-                  </div>
+                      <Label htmlFor='tags' className='text-xs text-muted-foreground -mb-3'>Etiketter</Label>
+                      <div className='flex flex-row gap-3' id='tags'>
+                        <Story asSubject />
+                        <Section />
+                      </div>
 
-                  <Label htmlFor='byline' className='text-xs text-muted-foreground -mb-3'>Byline</Label>
-                  <div id='byline'>
-                    <Byline />
-                  </div>
+                      <Label htmlFor='byline' className='text-xs text-muted-foreground -mb-3'>Byline</Label>
+                      <div id='byline'>
+                        <Byline />
+                      </div>
 
-                  <Label htmlFor='actions' className='text-xs text-muted-foreground -mb-3'>Åtgärder</Label>
-                  <div className='flex flex-row gap-3' id='actions'>
-                    <AddNote text='Lägg till intern notering' variant='outline' />
-                  </div>
+                      <Label htmlFor='actions' className='text-xs text-muted-foreground -mb-3'>Åtgärder</Label>
+                      <div className='flex flex-row gap-3' id='actions'>
+                        <AddNote text='Lägg till intern notering' variant='outline' />
+                      </div>
+
+                      <Label htmlFor='content-source'>Källor andra än TT</Label>
+                      <div id='content-source'>
+                        <ContentSource />
+                      </div>
+                    </>
+                  )}
 
                   <Label htmlFor='version' className='text-xs text-muted-foreground -mb-3'>Versioner</Label>
                   <div id='version'>
                     <Version documentId={documentId} textOnly={false} />
-                  </div>
-
-                  <Label htmlFor='content-source'>Källor andra än TT</Label>
-                  <div id='content-source'>
-                    <ContentSource />
                   </div>
 
                   {documentType === 'core/editorial-info' && (

--- a/src/views/Wires/components/PreviewSheet.tsx
+++ b/src/views/Wires/components/PreviewSheet.tsx
@@ -49,7 +49,7 @@ export const PreviewSheet = ({ id, wire, handleClose, textOnly = true, version, 
     keys: ['s', 'r', 'c', 'u', 'Escape'],
     onNavigation: (event) => {
       event.stopPropagation()
-      if (documentStatus) {
+      if (documentStatus && wire) {
         if (event.key === 'r') {
           const payload = {
             name: currentWire?.status === 'read' ? 'draft' : 'read',
@@ -231,7 +231,7 @@ export const PreviewSheet = ({ id, wire, handleClose, textOnly = true, version, 
                 </ToggleGroup>
               </>
             )}
-            <MetaSheet container={containerRef.current} documentId={id} />
+            <MetaSheet container={containerRef.current} documentId={id} readOnly readOnlyVersion={version} />
             <SheetClose
               className='rounded-md hover:bg-gray-100 w-8 h-8 flex items-center justify-center outline-none -mr-7'
               onClick={handleClose}


### PR DESCRIPTION
Fix MetaSheet to display properties, tags, byline, actions, and content source fields only for documents of type 'core/article'. This prevents irrelevant fields from showing for other document types. Also, ensure PreviewSheet passes readOnly and readOnlyVersion props to MetaSheet for correct rendering in preview mode. Additionally, fix a navigation handler to check for wire existence before updating document status.

Additional change: When version param is provided, don't get document from cache.