### PR TITLE
fix(previewsheet): correct escape key handler logic

### DIFF
--- a/src/views/Wires/components/PreviewSheet.tsx
+++ b/src/views/Wires/components/PreviewSheet.tsx
@@ -93,10 +93,10 @@ export const PreviewSheet = ({ id, wire, handleClose, textOnly = true, version, 
           showModal(<Wire onDialogClose={hideModal} asDialog wire={wire} />)
           return
         }
+      }
 
-        if (event.key === 'Escape') {
-          handleClose()
-        }
+      if (event.key === 'Escape') {
+        handleClose()
       }
     }
   })


### PR DESCRIPTION
Moved the Escape key event handler outside of a conditional block to ensure the handleClose function is always called when Escape is pressed. This fixes an issue where the modal would not close in certain cases.