### PR TITLE
fix(assignments): show section title instead of id in column

### DIFF
--- a/src/views/Assignments/AssignmentColumns.tsx
+++ b/src/views/Assignments/AssignmentColumns.tsx
@@ -106,7 +106,7 @@ export function assignmentColumns({ authors = [], locale, timeZone, sections = [
         display: (value: string) => (
           <span>
             {sections
-              .find((section) => section.id === value)?.id}
+              .find((section) => section.id === value)?.title}
           </span>
         )
       },


### PR DESCRIPTION
Updated the assignment columns to display the section title rather than the section id. This improves readability for users by showing more meaningful information in the assignments view.