### PR TITLE
make less assumptions about OpenID endpoints, get rid of globals

### DIFF
--- a/src-srv/api/signout/index.ts
+++ b/src-srv/api/signout/index.ts
@@ -2,6 +2,7 @@ import type { RouteHandler } from '../../routes.js'
 
 
 export const GET: RouteHandler = async (_) => {
+  // TODO: Should use OIDC configuation instead. How do we set such context?
   const KEYCLOAK_URL = process.env.AUTH_KEYCLOAK_ISSUER || ''
   const AUTH_POST_LOGOUT_URI = process.env.AUTH_POST_LOGOUT_URI || 'https://tt.se'
   const AUTH_KEYCLOAK_ID = process.env.AUTH_KEYCLOAK_ID || 'elephant'

--- a/src-srv/utils/CollaborationServer.ts
+++ b/src-srv/utils/CollaborationServer.ts
@@ -33,6 +33,7 @@ import { type GetDocumentResponse } from '@ttab/elephant-api/repository'
 import type { FinishedUnaryCall } from '@protobuf-ts/runtime-rpc'
 import { type Context, isContext } from '../lib/context.js'
 import { isValidUUID } from './isValidUUID.js'
+import type { AuthInfo } from './authConfig.js'
 
 interface CollaborationServerOptions {
   name: string
@@ -42,6 +43,7 @@ interface CollaborationServerOptions {
   repository: Repository
   user: User
   expressServer: Application
+  authInfo: AuthInfo
   quiet?: boolean
 }
 
@@ -62,7 +64,7 @@ export class CollaborationServer {
    * a Hocuspocus server and it's extensions. Call listen() to
    * open collaboration server for business.
    */
-  constructor({ port, redisUrl, redisCache, repository, expressServer, user, quiet = false }: CollaborationServerOptions) {
+  constructor({ port, redisUrl, redisCache, repository, expressServer, user, authInfo, quiet = false }: CollaborationServerOptions) {
     this.#quiet = quiet
     this.#port = port
     this.#expressServer = expressServer
@@ -123,7 +125,7 @@ export class CollaborationServer {
         new Snapshot({
           debounce: 120000
         }),
-        new Auth()
+        new Auth(authInfo.oidcConfig)
       ], this.#errorHandler),
 
       onStateless: async (payload: onStatelessPayload) => {

--- a/src-srv/utils/authConfig.ts
+++ b/src-srv/utils/authConfig.ts
@@ -1,6 +1,7 @@
 import { type AuthConfig } from '@auth/core'
 import Keycloak from '@auth/express/providers/keycloak'
 import { type JWT } from '@auth/core/jwt'
+import type pino from 'pino'
 
 const scopes = [
   'openid',
@@ -19,42 +20,142 @@ const scopes = [
   'asset_upload'
 ]
 
-const authorizationUrl = new URL(`${process.env.AUTH_KEYCLOAK_ISSUER}/protocol/openid-connect/auth`)
-authorizationUrl.searchParams.set('scope', scopes.join(' '))
-if (process.env.AUTH_KEYCLOAK_IDP_HINT) {
-  authorizationUrl.searchParams.set('kc_idp_hint', process.env.AUTH_KEYCLOAK_IDP_HINT)
+export interface OidcConfig {
+  token_endpoint: string
+  jwks_uri: string
+  end_session_endpoint: string
+  authorization_endpoint: string
+  userinfo_endpoint: string
 }
 
-async function refreshAccessToken(token: JWT): Promise<JWT> {
-  try {
-    const url = `${process.env.AUTH_KEYCLOAK_ISSUER}/protocol/openid-connect/token`
+export interface AuthInfo {
+  authConfig: AuthConfig
+  oidcConfig: OidcConfig
+}
 
+export async function createAuthInfo(
+  logger: pino.Logger,
+  providerUrl: string,
+  clientID: string, clientSecret: string,
+  idpHint?: string
+): Promise<AuthInfo> {
+  const oidcConf = await fetchOidcConfig(providerUrl).catch((e) => {
+    throw new Error('fetch OIDC configuration', { cause: e })
+  })
+
+  const authorizationUrl = new URL(oidcConf.authorization_endpoint)
+
+  authorizationUrl.searchParams.set('scope', scopes.join(' '))
+
+  if (idpHint) {
+    authorizationUrl.searchParams.set('kc_idp_hint', idpHint)
+  }
+
+  const auth = {
+    providers: [
+      Keycloak({
+        authorization: authorizationUrl.toString()
+      })
+    ],
+    callbacks: {
+      async session({ session, token }) {
+        return Promise.resolve({
+          ...session,
+          ...token
+        })
+      },
+      async jwt({ token, user, account }) {
+        // First time user is logging in
+        if (account && user) {
+          if (account.access_token) {
+            // @ts-expect-error sub exists
+            user.sub = account.providerAccountId
+          }
+          return {
+            accessToken: account.access_token,
+            accessTokenExpires: Date.now() + (account.expires_in || 300) * 1000,
+            refreshToken: account.refresh_token,
+            user
+          }
+        }
+
+        // The user is already logged in, check if the access token is expired
+        // We want to refresh with 150 seconds left
+        const accessTokenExpires = (Number(token.accessTokenExpires) || 0) - 150 * 1000
+        const remaining = accessTokenExpires - Date.now()
+        if (remaining < 0) {
+          return await refreshAccessToken(logger, oidcConf, token, clientID, clientSecret).catch((e) => {
+            throw new Error('refresh access token', { cause: e })
+          })
+        }
+
+        return token
+      }
+    },
+    pages: {
+      signIn: `${process.env.BASE_URL}/login`
+    }
+  } as AuthConfig
+
+  return {
+    oidcConfig: oidcConf,
+    authConfig: auth
+  }
+}
+
+async function fetchOidcConfig(provider: string): Promise<OidcConfig> {
+  const resp = await fetch(`${provider}/.well-known/openid-configuration`).catch((e) => {
+    throw new Error('make fetch request', { cause: e })
+  })
+
+  if (!resp.ok) {
+    throw new Error(`error response from provider: ${resp.status} ${resp.statusText}`)
+  }
+
+  const config = await resp.json().catch((e) => {
+    throw new Error('parse OIDC config', { cause: e })
+  }) as OidcConfig
+
+  return config
+}
+
+async function refreshAccessToken(
+  logger: pino.Logger,
+  conf: OidcConfig,
+  token: JWT,
+  clientID: string,
+  clientSecret: string
+): Promise<JWT> {
+  try {
     const params = new URLSearchParams({
-      client_id: process.env.AUTH_KEYCLOAK_ID ?? '',
-      client_secret: process.env.AUTH_KEYCLOAK_SECRET ?? '',
+      client_id: clientID,
+      client_secret: clientSecret,
       grant_type: 'refresh_token',
       refresh_token: token.refreshToken as string ?? ''
     })
 
-    const response = await fetch(url, {
+    const response = await fetch(conf.token_endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
         Accept: 'application/json'
       },
       body: params
+    }).catch((e) => {
+      throw new Error('fetch refresh token', { cause: e })
     })
 
     if (!response.ok) {
       throw new Error(`refresh request error response: ${response.statusText}`)
     }
 
-    const refreshedTokens = await response.json() as unknown
+    const refreshedTokens = await response.json().catch((e) => {
+      throw new Error('parse refresh response', { cause: e })
+    }) as unknown
 
     if (!isRefreshedTokens(refreshedTokens)) {
       throw new Error('refresh request error response: invalid token response')
     }
-
 
     return {
       ...token,
@@ -62,52 +163,13 @@ async function refreshAccessToken(token: JWT): Promise<JWT> {
       accessTokenExpires: Date.now() + refreshedTokens.expires_in * 1000,
       refreshToken: refreshedTokens.refresh_token ?? token.refreshToken
     }
-  } catch (_ex) {
+  } catch (ex) {
+    logger.error({
+      err: ex,
+      sub: token.sub
+    }, 'failed to refresh token')
+
     return { ...token, error: 'refreshAccessTokenError' }
-  }
-}
-
-export const authConfig: AuthConfig = {
-  providers: [
-    Keycloak({
-      authorization: authorizationUrl.toString()
-    })
-  ],
-  callbacks: {
-    async session({ session, token }) {
-      return Promise.resolve({
-        ...session,
-        ...token
-      })
-    },
-    async jwt({ token, user, account }) {
-      // First time user is logging in
-      if (account && user) {
-        if (account.access_token) {
-          // @ts-expect-error sub exists
-          user.sub = account.providerAccountId
-        }
-        return {
-          accessToken: account.access_token,
-          accessTokenExpires: Date.now() + (account.expires_in || 300) * 1000,
-          refreshToken: account.refresh_token,
-          user
-        }
-      }
-
-      // The user is already logged in, check if the access token is expired
-      // We want to refresh with 150 seconds left
-      const accessTokenExpires = (Number(token.accessTokenExpires) || 0) - 150 * 1000
-      const remaining = accessTokenExpires - Date.now()
-      if (remaining < 0) {
-        return await refreshAccessToken(token)
-      }
-
-      return token
-    }
-  },
-  pages: {
-    signIn: `${process.env.BASE_URL}/login`
   }
 }
 

--- a/src-srv/utils/authSession.ts
+++ b/src-srv/utils/authSession.ts
@@ -1,19 +1,23 @@
 import { type Request, type Response, type NextFunction } from 'express'
 import { getSession } from '@auth/express'
-import { authConfig } from './authConfig.js'
 import { isUnprotectedRoute } from './assertAuthenticatedUser.js'
+import type { AuthConfig } from '@auth/core'
 
-export function authSession(req: Request, res: Response, next: NextFunction): void {
-  if (isUnprotectedRoute(req)) {
-    next()
-  } else {
-    getSession(req, authConfig)
-      .then((session) => {
-        res.locals.session = session
-        next()
-      })
-      .catch((error) => {
-        next(error)
-      })
+export function authSessionMiddleware(
+  baseUrl: string, conf: AuthConfig
+) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (isUnprotectedRoute(baseUrl, req)) {
+      next()
+    } else {
+      getSession(req, conf)
+        .then((session) => {
+          res.locals.session = session
+          next()
+        })
+        .catch((error) => {
+          next(error)
+        })
+    }
   }
 }

--- a/src-srv/utils/extensions/Auth.ts
+++ b/src-srv/utils/extensions/Auth.ts
@@ -7,14 +7,21 @@ import {
 } from '@hocuspocus/server'
 import { decodeJwt } from 'jose'
 import { type JWT } from '@auth/core/jwt'
+import type { OidcConfig } from '../authConfig.js'
 
 export class Auth implements Extension {
+  oidc: OidcConfig
+
+  constructor(oidcConf: OidcConfig) {
+    this.oidc = oidcConf
+  }
+
   async onAuthenticate({ token: accessToken }: onAuthenticatePayload): Promise<{
     agent: string
     accessToken: string
     user: JWT
   }> {
-    const isValidAccessToken = await validateAccessToken(accessToken)
+    const isValidAccessToken = await this.validateAccessToken(accessToken)
 
     if (isValidAccessToken) {
       return {
@@ -31,24 +38,31 @@ export class Auth implements Extension {
     const statelessMessage = parseStateless<StatelessAuth>(payload)
 
     if (statelessMessage.type === StatelessType.AUTH) {
-      if (await validateAccessToken(statelessMessage.message.accessToken)) {
-        (connection.context as { accessToken: string })
-          .accessToken = statelessMessage.message.accessToken;
-        (connection.context as { user: User })
-          .user = { ...decodeJwt(statelessMessage.message.accessToken) }
+      const valid = await this.validateAccessToken(statelessMessage.message.accessToken)
+
+      if (valid) {
+        const context = connection.context as {
+          accessToken: string
+          user: User
+        }
+
+        context.accessToken = statelessMessage.message.accessToken
+        context.user = { ...decodeJwt(statelessMessage.message.accessToken) }
       } else {
         throw new Error('Could not authenticate: Invalid new accessToken')
       }
     }
   }
-}
 
-async function validateAccessToken(accessToken: string): Promise<boolean> {
-  const response = await fetch(`${process.env.AUTH_KEYCLOAK_ISSUER}/protocol/openid-connect/userinfo`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`
-    }
-  })
+  async validateAccessToken(accessToken: string): Promise<boolean> {
+    const response = await fetch(this.oidc.userinfo_endpoint, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`
+      }
+    }).catch((e) => {
+      throw new Error('validate access token', { cause: e })
+    })
 
-  return response.ok
+    return response.ok
+  }
 }


### PR DESCRIPTION
Also making sure that we capture the actual errors when token refresh fails.