### PR TITLE
add support for a separation of cluster-internal and public URLs

### DIFF
--- a/src-srv/api/urls/index.ts
+++ b/src-srv/api/urls/index.ts
@@ -1,14 +1,14 @@
 export const GET = (): Promise<unknown> => {
   return Promise.resolve({
     payload: {
-      indexUrl: process.env.INDEX_URL ?? '',
+      indexUrl: process.env.INDEX_PUBLIC_URL ?? process.env.INDEX_URL ?? '',
       webSocketUrl: process.env.WS_URL ?? '',
-      repositoryUrl: process.env.REPOSITORY_URL ?? '',
-      userUrl: process.env.USER_URL ?? '',
-      contentApiUrl: process.env.CONTENT_API_URL ?? '',
-      spellcheckUrl: process.env.SPELLCHECK_URL ?? '',
-      faroUrl: process.env.FARO_URL ?? '',
-      baboonUrl: process.env.BABOON_URL ?? ''
+      repositoryUrl: process.env.REPOSITORY_PUBLIC_URL ?? process.env.REPOSITORY_URL ?? '',
+      userUrl: process.env.USER_PUBLIC_URL ?? process.env.USER_URL ?? '',
+      contentApiUrl: process.env.CONTENT_API_PUBLIC_URL ?? process.env.CONTENT_API_URL ?? '',
+      spellcheckUrl: process.env.SPELLCHECK_PUBLIC_URL ?? process.env.SPELLCHECK_URL ?? '',
+      faroUrl: process.env.FARO_PUBLIC_URL ?? process.env.FARO_URL ?? '',
+      baboonUrl: process.env.BABOON_PUBLIC_URL ?? process.env.BABOON_URL ?? ''
     }
   })
 }

--- a/src/lib/getServerUrls.ts
+++ b/src/lib/getServerUrls.ts
@@ -38,9 +38,10 @@ export async function getServerUrls(): Promise<ServerUrls> {
       urls[field] = new URL(value)
     }
 
-    urls['repositoryEventsUrl'] = new URL('/sse', urls['repositoryUrl'])
-
-    return urls as unknown as ServerUrls
+    return {
+      ...urls,
+      repositoryEventsUrl: new URL('/sse', urls['repositoryUrl'])
+    } as ServerUrls
   } catch (ex) {
     throw new Error('Failed fetching remote server urls in getServerUrls', { cause: ex as Error })
   }

--- a/src/lib/getServerUrls.ts
+++ b/src/lib/getServerUrls.ts
@@ -3,8 +3,8 @@ const BASE_URL = import.meta.env.BASE_URL || ''
 interface ServerUrls {
   webSocketUrl: URL
   indexUrl: URL
-  repositoryEventsUrl: URL
   repositoryUrl: URL
+  repositoryEventsUrl: URL
   contentApiUrl: URL
   spellcheckUrl: URL
   userUrl: URL
@@ -20,42 +20,27 @@ export async function getServerUrls(): Promise<ServerUrls> {
   }
 
   try {
-    const {
-      indexUrl,
-      repositoryUrl,
-      webSocketUrl,
-      contentApiUrl,
-      spellcheckUrl,
-      userUrl,
-      faroUrl,
-      baboonUrl
-    } = await response.json() as ServerUrls
+    const servers = await response.json() as Record<string, string>
+    const attributes = [
+      'webSocketUrl', 'indexUrl', 'repositoryUrl', 'contentApiUrl',
+      'spellcheckUrl', 'userUrl', 'faroUrl', 'baboonUrl'
+    ]
 
+    const urls = {} as Record<string, URL>
 
-    if (typeof indexUrl !== 'string' || indexUrl === ''
-      || typeof repositoryUrl !== 'string' || repositoryUrl === ''
-      || typeof webSocketUrl !== 'string' || webSocketUrl === ''
-      || typeof contentApiUrl !== 'string' || contentApiUrl === ''
-      || typeof spellcheckUrl !== 'string' || spellcheckUrl === ''
-      || typeof userUrl !== 'string' || userUrl === ''
-      || typeof faroUrl !== 'string' || faroUrl === ''
-      || typeof baboonUrl !== 'string' || baboonUrl === ''
-    ) {
-      throw new Error('One or several server urls are empty')
+    for (const field of attributes) {
+      const value = servers[field]
+
+      if (typeof value != 'string' || value == '') {
+        throw new Error(`missing '${field}' server URL`)
+      }
+
+      urls[field] = new URL(value)
     }
 
+    urls['repositoryEventsUrl'] = new URL('/sse', urls['repositoryUrl'])
 
-    return {
-      webSocketUrl: new URL(webSocketUrl),
-      indexUrl: new URL(indexUrl),
-      repositoryEventsUrl: new URL('/sse', repositoryUrl),
-      repositoryUrl: new URL(repositoryUrl),
-      contentApiUrl: new URL(contentApiUrl),
-      spellcheckUrl: new URL(spellcheckUrl),
-      userUrl: new URL(userUrl),
-      faroUrl: new URL(faroUrl),
-      baboonUrl: new URL(baboonUrl)
-    }
+    return urls as unknown as ServerUrls
   } catch (ex) {
     throw new Error('Failed fetching remote server urls in getServerUrls', { cause: ex as Error })
   }


### PR DESCRIPTION
It's more efficient to communicate directly to internal services rather than through the public domain and load balancer that clients have to go through.

This adds support for specifying a separate `[SERVICE]_PUBLIC_URL` that will be preferred over the normal URL by the "/api/urls" endpoint.

Also made the `getServerurls()` method more "data driven". Probably less typescript friendly, which I guess was the main driver for the previous method, but gives us the benefit of better error messages when a server URL is missing.