### PR TITLE
fix(table): handle empty table rows as error objects

### DIFF
--- a/shared/transformations/newsdoc/core/table-rows.ts
+++ b/shared/transformations/newsdoc/core/table-rows.ts
@@ -18,6 +18,16 @@ export function parseTableRows(tablebody: string) {
 
   return rows.map((row) => {
     const cells = row.children
+
+    // Handle empty rows, will be displayed a 'unknown object'
+    if (cells.length === 0) {
+      return {
+        type: 'core/table/row/error',
+        class: 'block',
+        children: [{ text: '' }]
+      }
+    }
+
     return {
       type: 'core/table/row',
       class: 'block',


### PR DESCRIPTION
Previously, empty rows in tables were not handled, which could lead to unexpected behavior or display issues. This change ensures that empty rows are returned as 'core/table/row/error' objects, allowing them to be displayed as 'unknown object' and improving robustness.