### PR TITLE
fix(repo): remove Redis lock from flush logic

### DIFF
--- a/src-srv/collaboration/extensions/Repository.ts
+++ b/src-srv/collaboration/extensions/Repository.ts
@@ -35,12 +35,10 @@ export class RepositoryExtension implements Extension {
   readonly #storeDebouncer: ReturnType<typeof createDebounceMap<onStoreDocumentPayload>>
 
   #hp?: Hocuspocus
-  #redis: Redis
 
   constructor(configuration: RepositoryExtensionConfiguration) {
     this.#repository = configuration.repository
     this.#errorHandler = configuration.errorHandler
-    this.#redis = configuration.redis
 
     this.#storeDebouncer = createDebounceMap<onStoreDocumentPayload>(
       (documentName, payload) => {
@@ -130,12 +128,6 @@ export class RepositoryExtension implements Extension {
   } | void> {
     if (!this.#hp) {
       throw new Error('Hocuspocus is not yet finished configuring')
-    }
-
-    // Only one server should handle a flush, acquire a lock or ignore
-    const serverId = this.#hp.configuration.name || 'default'
-    if (await this.#redis.acquireLock(documentName, serverId) !== true) {
-      return
     }
 
     const { status = null, cause = null } = options || {}

--- a/src-srv/utils/Redis.ts
+++ b/src-srv/utils/Redis.ts
@@ -42,13 +42,4 @@ export class Redis {
       Buffer.from(state).toString('binary')
     )
   }
-
-  async acquireLock(key: string, value: string, expire: number = 5000): Promise<boolean> {
-    const response = await this.#redisClient?.set(`${BASE_PREFIX}:lock:${key}`, value, {
-      PX: expire, // Expiration in milliseconds
-      NX: true // Only set if key doesn't exist
-    })
-
-    return response === 'OK'
-  }
 }


### PR DESCRIPTION
Eliminates Redis-based locking mechanism from RepositoryExtension's flush operation. Also removes the acquireLock method from the Redis utility class. This simplifies document flush handling and reduces Redis dependency.

Should no longer be needed, since stateless __inProgress is removed and everything related is handled via REST, to a specific instance.