### PR TITLE
Set publish slot in text assignments

### DIFF
--- a/shared/templates/assignmentPlanningTemplate.ts
+++ b/shared/templates/assignmentPlanningTemplate.ts
@@ -2,7 +2,6 @@ import type { Wire } from '@/shared/schemas/wire.js'
 import type { IDBAuthor } from '../../src/datastore/types.js'
 import { Block } from '@ttab/elephant-api/newsdoc'
 
-
 /**
  * Create a template structure for an assigment
  * @returns Block
@@ -61,6 +60,13 @@ export function assignmentPlanningTemplate({
       : undefined
   ].filter((x): x is Block => x !== undefined)
 
+  // Text assignments should be set with a publish_slot
+  if (assignmentType === 'text') {
+    if (assignmentData && !assignmentData.publish_slot) {
+      assignmentData.publish_slot = new Date().getHours().toString()
+    }
+  }
+
   // Plain dates, are getting set with UI
   return Block.create({
     id: crypto.randomUUID(),
@@ -70,6 +76,7 @@ export function assignmentPlanningTemplate({
     data: assignmentData || {
       full_day: 'false',
       end_date: planningDate,
+      ...(assignmentType === 'text' && { publish_slot: new Date().getHours().toString() }),
       start_date: planningDate,
       start: startDateAndTime(assignmentType),
       public: assignmentType === 'flash'

--- a/src/components/AssignmentTime/TimeDeliveryMenu.tsx
+++ b/src/components/AssignmentTime/TimeDeliveryMenu.tsx
@@ -66,9 +66,11 @@ export const TimeDeliveryMenu = ({
               <CommandGroup>
                 <TimeSlotItems handleOnSelect={handleOnSelect} handleParentOpenChange={handleOpenChange} assignmentType={assignmentType} />
               </CommandGroup>
-              <CommandGroup>
-                <TimeSelectItem handleOnSelect={handleOnSelect} index={index} handleParentOpenChange={handleOpenChange} />
-              </CommandGroup>
+              {assignmentType !== 'text' && (
+                <CommandGroup>
+                  <TimeSelectItem handleOnSelect={handleOnSelect} index={index} handleParentOpenChange={handleOpenChange} />
+                </CommandGroup>
+              )}
             </div>
           </CommandList>
         </Command>


### PR DESCRIPTION
* Remove exact time option for text assignments
* Set publish slot when creating text assignments from scratch, or when creating an article from a wire