### PR TITLE
feat(approvals): add focus style to planning icon

### DIFF
--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -23,30 +23,43 @@ export const Link = forwardRef((props: LinkProps, ref: ForwardedRef<HTMLAnchorEl
 
   const { viewId: origin } = useView()
 
+  const handleClick = (
+    event: MouseEvent<HTMLAnchorElement>
+  ) => {
+    event.stopPropagation()
+    // Execute forwarded onClick handler
+    if (props.onClick) {
+      props.onClick(event)
+    }
+
+    // Our onClick handler
+    handleLink({
+      event,
+      dispatch,
+      viewItem,
+      props: { ...props.props },
+      viewId,
+      origin,
+      target: props.target,
+      history
+    })
+  }
+
+  const handleKeyDown = (
+    event: React.KeyboardEvent<HTMLAnchorElement>
+  ) => {
+    if (event.key === 'Enter') {
+      handleClick(event as unknown as MouseEvent<HTMLAnchorElement>)
+    }
+  }
+
   return (
     <a
       className={props?.className || ''}
       {...props}
       href={`${viewItem.meta.path}${qs || ''}`}
-      onClick={(event) => {
-        event.stopPropagation()
-        // Execute forwarded onClick handler
-        if (props.onClick) {
-          props.onClick(event)
-        }
-
-        // Our onClick handler
-        handleLink({
-          event,
-          dispatch,
-          viewItem,
-          props: { ...props.props },
-          viewId,
-          origin,
-          target: props.target,
-          history
-        })
-      }}
+      onKeyDown={(event) => handleKeyDown(event)}
+      onClick={(event) => handleClick(event)}
       ref={ref}
     >
       {props.children}

--- a/src/views/Approvals/ApprovalsCard.tsx
+++ b/src/views/Approvals/ApprovalsCard.tsx
@@ -209,16 +209,16 @@ export const ApprovalsCard = ({ assignment, isSelected, isFocused, status, autho
                 </span>
               )}
             </div>
-            <Tooltip content='Öppna planering'>
-              <div
-                className='opacity-70 block md:opacity-0 md:group-hover:opacity-70 md:group-focus:opacity-70 hover:bg-gray-300 dark:hover:bg-gray-700 p-1 -m-1 rounded transition-all'
-                onClick={(e) => e.stopPropagation()}
-              >
-                <Link to='Planning' props={{ id: assignment._id }}>
-                  <CalendarDaysIcon size={16} strokeWidth={1.75} />
-                </Link>
-              </div>
-            </Tooltip>
+            <Link
+              to='Planning'
+              props={{ id: assignment._id }}
+              className='block p-1 -m-1 rounded transition-all opacity-70 md:opacity-0 md:group-hover:opacity-70 md:group-focus:opacity-70 md:group-focus-within:opacity-70 hover:bg-gray-300 dark:hover:bg-gray-700'
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Tooltip content='Öppna planering'>
+                <CalendarDaysIcon size={16} strokeWidth={1.75} />
+              </Tooltip>
+            </Link>
           </div>
         </div>
       </Card.Footer>


### PR DESCRIPTION
Adds `md:group-focus:opacity-70` to the planning icon in ApprovalsCard so the option will be shown when navigating using keyboard.