### PR TITLE
fix(navigation): apply query to correct view when keepfocus is used

### DIFF
--- a/src/components/Header/Datechanger.tsx
+++ b/src/components/Header/Datechanger.tsx
@@ -1,39 +1,51 @@
 import { ChevronLeftIcon, ChevronRightIcon } from '@ttab/elephant-ui/icons'
 import { Link } from '@/components'
 import { DatePicker } from '../Datepicker'
-import { useMemo } from 'react'
 import { useQuery, useLink } from '@/hooks'
 import { addDays, subDays } from 'date-fns'
 import { type View } from '@/types/index'
+import { useMemo } from 'react'
 
-export const DateChanger = ({ type }: {
-  type: View
-}): JSX.Element | undefined => {
-  const [{ from, to }] = useQuery()
+const validViews: View[] = ['Plannings', 'Events', 'Assignments', 'Approvals', 'Print']
+
+export const DateChanger = ({ type }: { type: View }): JSX.Element | null => {
+  const [query] = useQuery()
+  const { from, to } = query
+
+  const linkTarget = validViews.find((view: View) => view.startsWith(type))
 
   const currentDate = useMemo(() => {
-    return typeof from === 'string'
-      ? new Date(from)
-      : new Date()
+    if (typeof from === 'string') {
+      const parsed = new Date(from)
+      if (!isNaN(parsed.getTime())) {
+        return parsed
+      }
+    }
+    return new Date()
   }, [from])
 
   const steps = to ? 7 : 1
 
-  const validViews: View[] = ['Plannings', 'Events', 'Assignments', 'Approvals', 'Print']
-  const linkTarget = validViews.find((view) => view.startsWith(type))
-  const [query] = useQuery()
-
   const changeDate = useLink(linkTarget || type)
 
+  const getDateString = (date: Date) => date.toISOString().split('T')[0]
+
+  const getLinkProps = (fn: (currentDate: Date, steps: number) => Date) => {
+    const date = fn(currentDate, steps)
+
+    return { ...query, from: getDateString(date) }
+  }
+
   if (!linkTarget) {
-    return
+    console.warn(`No valid linkTarget found for type: ${type}`)
+    return null
   }
 
   return (
     <div className='flex items-center'>
       <Link
         to={linkTarget}
-        props={{ ...query, from: decrementDate(currentDate, steps).toISOString().split('T')[0] }}
+        props={getLinkProps(subDays)}
         target='self'
       >
         <ChevronLeftIcon
@@ -46,7 +58,7 @@ export const DateChanger = ({ type }: {
 
       <Link
         to={linkTarget}
-        props={{ ...query, from: incrementDate(currentDate, steps).toISOString().split('T')[0] }}
+        props={getLinkProps(addDays)}
         target='self'
       >
         <ChevronRightIcon
@@ -56,12 +68,4 @@ export const DateChanger = ({ type }: {
       </Link>
     </div>
   )
-}
-
-function decrementDate(date: Date, steps: number): Date {
-  return subDays(date, steps)
-}
-
-function incrementDate(date: Date, steps: number): Date {
-  return addDays(date, steps)
 }

--- a/src/components/Link/lib/handleLink.ts
+++ b/src/components/Link/lib/handleLink.ts
@@ -77,7 +77,7 @@ export function handleLink({
   }
 
   const viewId = keepFocus && currentViewId ? currentViewId : newViewId
-  const path = keepFocus && currentPath ? currentPath.path : viewItem.meta.path
+  const path = keepFocus && currentPath ? currentPath.path : `${viewItem.meta.path}${toQueryString(props)}`
 
   // Listen for when the change has been done and then add onDocumentCreated callback
   // to the navigation state as we can't store functions in history state.
@@ -94,7 +94,7 @@ export function handleLink({
   }, { once: true })
 
   // Push new history state
-  history.pushState(`${path}${toQueryString(props)}`, {
+  history.pushState(path, {
     viewId,
     contentState: content
   })

--- a/src/components/Table/GroupedRows.tsx
+++ b/src/components/Table/GroupedRows.tsx
@@ -4,7 +4,7 @@ import { GroupedRowsHeader } from './GroupedRowsHeader'
 import { Row as RegularRow } from './Row'
 import { WireRow } from './WireRow'
 
-export const GroupedRows = <TData, TValue>({ row, columns, handleOpen, openDocuments, type, activeId }: {
+export const GroupedRows = <TData, TValue>({ row, columns, handleOpen, openDocuments, type }: {
   activeId?: string
   row: RowType<unknown>
   type: 'Planning' | 'Event' | 'Assignments' | 'Search' | 'Wires' | 'Factbox' | 'Print' | 'PrintEditor'
@@ -28,7 +28,6 @@ export const GroupedRows = <TData, TValue>({ row, columns, handleOpen, openDocum
           row={subRow}
           handleOpen={handleOpen}
           openDocuments={openDocuments}
-          isActive={activeId === (subRow.original as { id: string }).id}
         />
       ))}
     </React.Fragment>

--- a/src/components/Table/Row.tsx
+++ b/src/components/Table/Row.tsx
@@ -5,20 +5,22 @@ import { cn } from '@ttab/elephant-ui/utils'
 
 type DocumentType = 'Planning' | 'Event' | 'Assignments' | 'Search' | 'Wires' | 'Factbox' | 'Print' | 'PrintEditor'
 
-export const Row = ({ row, handleOpen, type, isActive }: {
-  isActive?: boolean
+export const Row = ({ row, handleOpen, type, openDocuments }: {
   type: DocumentType
   row: RowType<unknown>
   handleOpen: (event: MouseEvent<HTMLTableRowElement>, row: RowType<unknown>) => void
   openDocuments: string[]
 }): JSX.Element => {
+  const { id } = row.original as { id: string }
+  const selected = !!id && openDocuments.includes(id)
+
   return (
     <TableRow
       tabIndex={0}
+      data-state={selected && 'selected'}
       className={cn(
-        'flex cursor-default scroll-mt-10 ring-inset focus:outline-none focus-visible:ring-2 focus-visible:ring-table-selected data-[state=selected]:bg-table-selected',
-        type === 'Assignments' ? 'items-start' : 'items-center',
-        isActive ? 'bg-blue-200' : ''
+        'flex cursor-default scroll-mt-10 ring-inset focus:outline-none focus-visible:ring-2 focus-visible:ring-table-selected data-[state=selected]:bg-table-focused',
+        type === 'Assignments' ? 'items-start' : 'items-center'
       )}
       onClick={(event: MouseEvent<HTMLTableRowElement>) => handleOpen(event, row)}
       ref={(el) => {

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -23,8 +23,7 @@ import {
   useHistory,
   useNavigationKeys,
   useOpenDocuments,
-  useWorkflowStatus,
-  useQuery
+  useWorkflowStatus
 } from '@/hooks'
 import { handleLink } from '@/components/Link/lib/handleLink'
 import { NewItems } from './NewItems'
@@ -93,10 +92,6 @@ export const Table = <TData, TValue>({
   const openDocuments = useOpenDocuments({ idOnly: true })
   const { showModal, hideModal, currentModal } = useModal()
   const [, setDocumentStatus] = useWorkflowStatus()
-  const [,,allParams] = useQuery(['id'], true)
-  const activeId = allParams?.filter((item) => {
-    return item.name === 'PrintEditor'
-  })?.[0]?.params?.id as string
 
   const handlePreview = useCallback((row: RowType<unknown>): void => {
     row.toggleSelected(true)
@@ -315,7 +310,6 @@ export const Table = <TData, TValue>({
             columns={columns}
             handleOpen={handleOpen}
             openDocuments={openDocuments}
-            activeId={activeId}
           />
         )
       : (

--- a/src/hooks/useOpenDocuments.tsx
+++ b/src/hooks/useOpenDocuments.tsx
@@ -23,7 +23,7 @@ export function useOpenDocuments(params: { name?: string, idOnly?: boolean } = {
   const { currentModal } = useModal()
 
   useEffect(() => {
-    const names = ['Planning', 'Event', 'Editor', 'Factbox', 'Flash']
+    const names = ['Planning', 'Event', 'Editor', 'Factbox', 'Flash', 'PrintEditor']
     const filteredDocuments = state.content.filter((s) => {
       return (!!s?.props?.id) && ((name && s.name === name) || names.includes(s.name))
     }).map((s) => {


### PR DESCRIPTION
- Fix link handling to avoid duplicate query strings in path
- Remove unused `activeId` prop from `GroupedRows` and related logic
- Use `openDocuments` to determine selected rows in `Row` component
- Update row styling to use `data-state=selected` for selection
- Add 'PrintEditor' to open document names in `useOpenDocuments`
- Refactor `DateChanger` for better date handling and link props