### PR TITLE
fix(image-plugin): use session accessToken in consume

### DIFF
--- a/src/views/PrintEditor/ImagePlugin/index.tsx
+++ b/src/views/PrintEditor/ImagePlugin/index.tsx
@@ -12,9 +12,12 @@ import { consumes } from './lib/consumes'
 import { normalizeImage } from './lib/normalizeImage'
 import { actionHandler } from './lib/actionHandler'
 import type { Repository } from '@/shared/Repository'
+import { useSession } from 'next-auth/react'
 
 // @ts-expect-error Textbit types uncertainty
 export const ImagePlugin: Plugin.InitFunction = (options) => {
+  const { data } = useSession()
+
   return {
     class: 'block',
     name: 'core/image',
@@ -24,7 +27,7 @@ export const ImagePlugin: Plugin.InitFunction = (options) => {
       consume: ({ input }) => consume(
         input,
         options?.repository as Repository,
-        options?.accessToken as string
+        data?.accessToken as string
       )
     },
     actions: [


### PR DESCRIPTION
Update the ImagePlugin to retrieve the accessToken from the current user session using next-auth's useSession hook, instead of relying on the options parameter. This ensures the correct token is used for image consumption and improves authentication consistency.