### PR TITLE
test: remove misplaced vi.hoisted() in useInitFilters test

### DIFF
--- a/__tests__/useInitFilters.test.tsx
+++ b/__tests__/useInitFilters.test.tsx
@@ -24,10 +24,6 @@ describe('useInitFilters', () => {
   const mockSetQuery = vi.fn()
 
   beforeEach(() => {
-    // needed to reset previous use of useQuery otherwise it can not be mocked
-    vi.hoisted(() => {
-      vi.resetModules()
-    })
     vi.clearAllMocks()
   })
 


### PR DESCRIPTION
vi.hoisted() is a module-level API that always runs before imports regardless of where it's called. Placing it inside beforeEach was misleading and triggered a Vitest deprecation warning.