### PR TITLE
fix(tests): resolve lint warnings in Hast test files

### DIFF
--- a/__tests__/HastIndicator.test.tsx
+++ b/__tests__/HastIndicator.test.tsx
@@ -33,7 +33,10 @@ vi.mock('@/hooks/useWorkflowStatus', () => ({
 
 let repositoryEventCallback: ((event: { uuid?: string, event?: string }) => void) | null = null
 vi.mock('@/hooks/useRepositoryEvents', () => ({
-  useRepositoryEvents: vi.fn((_eventTypes, callback) => {
+  useRepositoryEvents: vi.fn((
+    _eventTypes: string[],
+    callback: (event: { uuid?: string, event?: string }) => void
+  ) => {
     repositoryEventCallback = callback
   })
 }))

--- a/__tests__/HastToggle.test.tsx
+++ b/__tests__/HastToggle.test.tsx
@@ -14,7 +14,7 @@ let mockHasHastFlag = true
 vi.mock('sonner')
 
 vi.mock('@/lib/snapshotDocument', () => ({
-  snapshotDocument: (...args: unknown[]) => mockSnapshotDocument(...args)
+  snapshotDocument: (...args: unknown[]) => mockSnapshotDocument(...args) as unknown
 }))
 
 vi.mock('@/modules/yjs/hooks', () => ({

--- a/__tests__/RemoveHastFromArticle.test.tsx
+++ b/__tests__/RemoveHastFromArticle.test.tsx
@@ -14,7 +14,7 @@ let mockHasHastFlag = true
 vi.mock('sonner')
 
 vi.mock('@/lib/snapshotDocument', () => ({
-  snapshotDocument: (...args: unknown[]) => mockSnapshotDocument(...args)
+  snapshotDocument: (...args: unknown[]) => mockSnapshotDocument(...args) as unknown
 }))
 
 vi.mock('@/modules/yjs/hooks', () => ({


### PR DESCRIPTION
Add explicit types to mock parameters and return values to satisfy TypeScript strict type checking rules.