### PR TITLE
chore(deps): bump auth packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "linux"
       ],
       "dependencies": {
-        "@auth/express": "^0.9.0",
+        "@auth/express": "^0.12.2",
         "@date-fns/utc": "^2.1.1",
         "@grafana/faro-react": "^2.3.1",
         "@hocuspocus/extension-logger": "^3.4.4",
@@ -46,7 +46,7 @@
         "i18next": "^26.0.4",
         "i18next-browser-languagedetector": "^8.2.1",
         "jose": "^6.2.2",
-        "next-auth": "^5.0.0-beta.30",
+        "next-auth": "^5.0.0-beta.31",
         "node-html-parser": "^7.1.0",
         "pino": "^10.3.1",
         "pino-http": "^11.0.0",
@@ -67,7 +67,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
-        "@auth/core": "^0.38.0",
+        "@auth/core": "^0.41.2",
         "@protobuf-ts/runtime-rpc": "^2.11.1",
         "@tailwindcss/vite": "^4.2.2",
         "@testing-library/jest-dom": "^6.9.1",
@@ -146,7 +146,9 @@
       "license": "MIT"
     },
     "node_modules/@auth/core": {
-      "version": "0.38.0",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.2.tgz",
+      "integrity": "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==",
       "license": "ISC",
       "dependencies": {
         "@panva/hkdf": "^1.2.1",
@@ -158,7 +160,7 @@
       "peerDependencies": {
         "@simplewebauthn/browser": "^9.0.1",
         "@simplewebauthn/server": "^9.0.2",
-        "nodemailer": "^6.8.0"
+        "nodemailer": "^7.0.7"
       },
       "peerDependenciesMeta": {
         "@simplewebauthn/browser": {
@@ -173,10 +175,12 @@
       }
     },
     "node_modules/@auth/express": {
-      "version": "0.9.0",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@auth/express/-/express-0.12.2.tgz",
+      "integrity": "sha512-IYsDgorPDb5O7/81+ja+PsC/Iu1Sem+ck9X6AmbbIsfXCjzm1zSnrKImDdAOG1xjuhMUXLXYGxekrJnxP9kr0w==",
       "license": "ISC",
       "dependencies": {
-        "@auth/core": "0.38.0"
+        "@auth/core": "0.41.2"
       },
       "peerDependencies": {
         "express": "^4.18.2 || ^5.0.0"
@@ -11509,10 +11513,12 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "5.0.0-beta.30",
+      "version": "5.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.31.tgz",
+      "integrity": "sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==",
       "license": "ISC",
       "dependencies": {
-        "@auth/core": "0.41.0"
+        "@auth/core": "0.41.2"
       },
       "peerDependencies": {
         "@simplewebauthn/browser": "^9.0.1",
@@ -11520,33 +11526,6 @@
         "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
         "nodemailer": "^7.0.7",
         "react": "^18.2.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@simplewebauthn/browser": {
-          "optional": true
-        },
-        "@simplewebauthn/server": {
-          "optional": true
-        },
-        "nodemailer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/next-auth/node_modules/@auth/core": {
-      "version": "0.41.0",
-      "license": "ISC",
-      "dependencies": {
-        "@panva/hkdf": "^1.2.1",
-        "jose": "^6.0.6",
-        "oauth4webapi": "^3.3.0",
-        "preact": "10.24.3",
-        "preact-render-to-string": "6.5.11"
-      },
-      "peerDependencies": {
-        "@simplewebauthn/browser": "^9.0.1",
-        "@simplewebauthn/server": "^9.0.2",
-        "nodemailer": "^6.8.0"
       },
       "peerDependenciesMeta": {
         "@simplewebauthn/browser": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@grafana/faro-core": "$@grafana/faro-react"
   },
   "dependencies": {
-    "@auth/express": "^0.9.0",
+    "@auth/express": "^0.12.2",
     "@date-fns/utc": "^2.1.1",
     "@grafana/faro-react": "^2.3.1",
     "@hocuspocus/extension-logger": "^3.4.4",
@@ -68,7 +68,7 @@
     "i18next": "^26.0.4",
     "i18next-browser-languagedetector": "^8.2.1",
     "jose": "^6.2.2",
-    "next-auth": "^5.0.0-beta.30",
+    "next-auth": "^5.0.0-beta.31",
     "node-html-parser": "^7.1.0",
     "pino": "^10.3.1",
     "pino-http": "^11.0.0",
@@ -89,7 +89,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@auth/core": "^0.38.0",
+    "@auth/core": "^0.41.2",
     "@protobuf-ts/runtime-rpc": "^2.11.1",
     "@tailwindcss/vite": "^4.2.2",
     "@testing-library/jest-dom": "^6.9.1",

--- a/src-srv/utils/authConfig.ts
+++ b/src-srv/utils/authConfig.ts
@@ -68,7 +68,6 @@ export async function createAuthInfo(
         // First time user is logging in
         if (account && user) {
           if (account.access_token) {
-            // @ts-expect-error sub exists
             user.sub = account.providerAccountId
           }
           return {


### PR DESCRIPTION
- @auth/core: 0.38.0 → 0.41.2
- @auth/express: 0.9.0 → 0.12.2
- next-auth: 5.0.0-beta.30 → 5.0.0-beta.31

Remove now-unnecessary @ts-expect-error for user.sub as types now include this property.