### PR TITLE
It must be possible to mark used wires as not used

### DIFF
--- a/src/views/Wires/components/Stream.tsx
+++ b/src/views/Wires/components/Stream.tsx
@@ -406,7 +406,7 @@ export const Stream = memo(({
       if (!shiftAnchorRef.current) {
         shiftAnchorRef.current = entryId
         const currentWire = allDataRef.current.find((w) => w.id === entryId)
-        if (currentWire && getWireState(currentWire).status !== 'used') {
+        if (currentWire) {
           onToggleWire(currentWire, true)
           lastToggledWireIdRef.current = entryId
         }
@@ -422,7 +422,7 @@ export const Stream = memo(({
 
       if (movingAway) {
         const nextWire = allDataRef.current.find((w) => w.id === nextEntryId)
-        if (nextWire && getWireState(nextWire).status !== 'used') {
+        if (nextWire) {
           onToggleWire(nextWire, true)
           lastToggledWireIdRef.current = nextEntryId
         }

--- a/src/views/Wires/components/StreamEntry.tsx
+++ b/src/views/Wires/components/StreamEntry.tsx
@@ -86,12 +86,10 @@ export const StreamEntry = memo(({
       e.preventDefault()
       onPress?.(entry, e)
     } else if (e.key === 'm' || e.key === 'M') {
-      if (status !== 'used') {
-        e.preventDefault()
-        onToggleSelected(entry, e.shiftKey)
-      }
+      e.preventDefault()
+      onToggleSelected(entry, e.shiftKey)
     }
-  }, [entry, onPress, onToggleSelected, status])
+  }, [entry, onPress, onToggleSelected])
 
   const handleFocus = useCallback((e: React.FocusEvent<HTMLElement>) => {
     onFocus?.(entry, e)
@@ -145,7 +143,7 @@ export const StreamEntry = memo(({
         </div>
       )}
 
-      {!statusMutation && status !== 'used' && (
+      {!statusMutation && (
         <Button
           variant='icon'
           size='lg'

--- a/src/views/Wires/lib/setWireStatus.ts
+++ b/src/views/Wires/lib/setWireStatus.ts
@@ -61,8 +61,7 @@ export function calculateWireStatuses(wires: Wire[], newStatus: WireStatusName) 
     const currentVersion = wire.fields?.['current_version']?.values?.[0]
     const currentStatus = getWireStatus(wire)
 
-    // Don't allow changing status of used wires
-    if (!currentVersion || currentStatus === 'used') {
+    if (!currentVersion) {
       continue
     }
 


### PR DESCRIPTION
I would ideally want to hinder toggling back from 'used' status if there are planning assignments with links back to the wire(s) in question. But am unsure if that is possible and still be performant enough in this view.