### PR TITLE
fix: only seed article body when npk translating

### DIFF
--- a/src/views/WireCreation/lib/createArticle.tsx
+++ b/src/views/WireCreation/lib/createArticle.tsx
@@ -62,11 +62,15 @@ export async function createArticle({
   // and unmounts the component, triggering CollaborationClientRegistry cleanup)
   const yjsDocument = ydoc.provider?.document
 
-  // Set wire content on the Y.Doc SYNCHRONOUSLY before any async operations.
-  // After the first await, dialog close may unmount the component and disconnect
-  // the provider, making ydoc.ele potentially stale. Setting content now ensures
-  // it is captured by snapshotDocument even in that case.
-  if (wireContent) {
+  // Seed the article with the wire body only when the user has opted into
+  // translation — the translated version replaces this below. Without
+  // translation, the article keeps the empty template content.
+  //
+  // Done SYNCHRONOUSLY before any async operations: after the first await,
+  // dialog close may unmount the component and disconnect the provider,
+  // making ydoc.ele potentially stale. Setting content now ensures it is
+  // captured by snapshotDocument even in that case (e.g. if translation fails).
+  if (wireContent && translationMode) {
     ydoc.ele.set('content', toContentYXmlText(wireContent))
   }
 


### PR DESCRIPTION
When creating an article from a wire, the wire body was being copied into the article unconditionally. The wire body should only be seeded into the article when the user opts into npk translation (the translated content replaces it); otherwise the article should keep the empty template.

Regression introduced in f8b3612c.