### PR TITLE
feat: StatusMenu degrades gracefully without planning

### DIFF
--- a/__tests__/components/StatusOptions.test.tsx
+++ b/__tests__/components/StatusOptions.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@ttab/elephant-ui'
+import { StatusOptions } from '@/components/DocumentStatus/StatusOptions'
+import { ClockIcon } from '@ttab/elephant-ui/icons'
+import type { WorkflowTransition, StatusSpecification } from '@/defaults/workflowSpecification'
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query as unknown,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn()
+  }))
+})
+
+class ResizeObserverMock {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+}
+global.ResizeObserver = ResizeObserverMock
+Element.prototype.scrollIntoView = vi.fn()
+
+const withheldTransition: WorkflowTransition = {
+  title: 'Schedule',
+  description: 'Schedule publishing'
+}
+const usableTransition: WorkflowTransition = {
+  title: 'Publish',
+  description: 'Publish now'
+}
+
+const statuses: Record<string, StatusSpecification> = {
+  withheld: { icon: ClockIcon, className: '' },
+  usable: { icon: ClockIcon, className: '' }
+}
+
+const renderOptions = (disabledTransitions?: Record<string, { reason: string }>) => {
+  const onSelect = vi.fn()
+  const user = userEvent.setup()
+  render(
+    <DropdownMenu defaultOpen>
+      <DropdownMenuTrigger>open</DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <StatusOptions
+          transitions={{ withheld: withheldTransition, usable: usableTransition }}
+          statuses={statuses}
+          onSelect={onSelect}
+          disabledTransitions={disabledTransitions}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+  return { onSelect, user }
+}
+
+describe('StatusOptions', () => {
+  it('renders all transitions as enabled by default', () => {
+    renderOptions()
+
+    const items = screen.getAllByRole('menuitem')
+    expect(items).toHaveLength(2)
+    items.forEach((item) => {
+      expect(item).not.toHaveAttribute('data-disabled')
+    })
+  })
+
+  it('marks a transition as disabled when disabledTransitions contains its key', () => {
+    renderOptions({ withheld: { reason: 'Planning required' } })
+
+    const items = screen.getAllByRole('menuitem')
+    const withheldItem = items.find((el) => el.textContent?.includes('Schedule'))
+    const usableItem = items.find((el) => el.textContent?.includes('Publish'))
+
+    expect(withheldItem).toHaveAttribute('data-disabled')
+    expect(usableItem).not.toHaveAttribute('data-disabled')
+  })
+
+  it('does not call onSelect when a disabled option is clicked', async () => {
+    const { onSelect, user } = renderOptions({ withheld: { reason: 'Planning required' } })
+
+    const withheldItem = screen.getAllByRole('menuitem')
+      .find((el) => el.textContent?.includes('Schedule'))
+    expect(withheldItem).toBeDefined()
+    await user.click(withheldItem!)
+
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('calls onSelect when an enabled option is clicked', async () => {
+    const { onSelect, user } = renderOptions({ withheld: { reason: 'Planning required' } })
+
+    const usableItem = screen.getAllByRole('menuitem')
+      .find((el) => el.textContent?.includes('Publish'))
+    expect(usableItem).toBeDefined()
+    await user.click(usableItem!)
+
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ status: 'usable' }))
+  })
+})

--- a/src/components/DocumentStatus/StatusMenu.tsx
+++ b/src/components/DocumentStatus/StatusMenu.tsx
@@ -64,6 +64,11 @@ export const StatusMenu = ({ ydoc, onBeforeStatusChange, planningId, embargoUnti
   // Callback function to set status. Will first call onBeforeStatusChange() if
   // provided by props, then proceed to change the status if allowed.
   const setStatus = useCallback(async (newStatus: string, data?: Record<string, unknown>) => {
+    if (newStatus === 'withheld' && !planningId) {
+      toast.error(t('shared:status_menu.schedulingRequiresPlanning'))
+      return
+    }
+
     setIsTransitioning(true)
 
     try {
@@ -83,7 +88,7 @@ export const StatusMenu = ({ ydoc, onBeforeStatusChange, planningId, embargoUnti
     } finally {
       setIsTransitioning(false)
     }
-  }, [onBeforeStatusChange, setDocumentStatus])
+  }, [onBeforeStatusChange, setDocumentStatus, planningId, t])
 
   const unPublishDocument = async (newStatus?: string) => {
     if (!repository || !session?.accessToken || newStatus !== 'unpublished') {
@@ -171,6 +176,13 @@ export const StatusMenu = ({ ydoc, onBeforeStatusChange, planningId, embargoUnti
               statuses={statuses}
               onSelect={showPrompt}
               hasChanges={asSave && isChanged}
+              disabledTransitions={!planningId
+                ? {
+                    withheld: {
+                      reason: t('shared:status_menu.schedulingRequiresPlanning')
+                    }
+                  }
+                : undefined}
             >
               {asSave && isChanged && (
                 <StatusMenuOption

--- a/src/components/DocumentStatus/StatusMenuOption.tsx
+++ b/src/components/DocumentStatus/StatusMenuOption.tsx
@@ -1,14 +1,17 @@
 import type { StatusSpecification, WorkflowTransition } from '@/defaults/workflowSpecification'
-import { DropdownMenuItem } from '@ttab/elephant-ui'
+import { DropdownMenuItem, Tooltip } from '@ttab/elephant-ui'
 import { cn } from '@ttab/elephant-ui/utils'
 import { CircleArrowRightIcon } from '@ttab/elephant-ui/icons'
 
-export const StatusMenuOption = ({ statusDef, state, status, onSelect, hasChanges }: {
+export const StatusMenuOption = ({
+  statusDef, state, status, onSelect, hasChanges, disabledReason
+}: {
   statusDef: StatusSpecification
   state: WorkflowTransition
   status: string
   onSelect: (state: { status: string } & WorkflowTransition) => void
   hasChanges?: boolean
+  disabledReason?: string
 }) => {
   const iconProps = {
     size: 21,
@@ -18,11 +21,25 @@ export const StatusMenuOption = ({ statusDef, state, status, onSelect, hasChange
   }
 
   const Icon = status === 'usable' && hasChanges ? CircleArrowRightIcon : statusDef.icon
+  const isDisabled = !!disabledReason
 
-  return (
+  const item = (
     <DropdownMenuItem
-      className='flex flex-row gap-5 w-full py-2 pe-2 items-start rounded-md'
-      onClick={() => onSelect({ status, ...state })}
+      disabled={isDisabled}
+      className={cn(
+        'flex flex-row gap-5 w-full py-2 pe-2 items-start rounded-md',
+        isDisabled && 'opacity-50 cursor-not-allowed'
+      )}
+      onSelect={(event) => {
+        if (isDisabled) {
+          event.preventDefault()
+          return
+        }
+      }}
+      onClick={() => {
+        if (isDisabled) return
+        onSelect({ status, ...state })
+      }}
     >
       <div className='w-4 grow-0 shrink-0 pt-0.5'>
         {!!Icon && <Icon {...iconProps} />}
@@ -35,5 +52,15 @@ export const StatusMenuOption = ({ statusDef, state, status, onSelect, hasChange
         </div>
       </div>
     </DropdownMenuItem>
+  )
+
+  if (!isDisabled) {
+    return item
+  }
+
+  return (
+    <Tooltip content={disabledReason}>
+      <div>{item}</div>
+    </Tooltip>
   )
 }

--- a/src/components/DocumentStatus/StatusOptions.tsx
+++ b/src/components/DocumentStatus/StatusOptions.tsx
@@ -6,11 +6,14 @@ import {
 import { StatusMenuOption } from './StatusMenuOption'
 import type { PropsWithChildren } from 'react'
 
-export const StatusOptions = ({ transitions, statuses, onSelect, children, hasChanges }: {
+export const StatusOptions = ({
+  transitions, statuses, onSelect, children, hasChanges, disabledTransitions
+}: {
   transitions: Record<string, WorkflowTransition>
   statuses: Record<string, StatusSpecification>
   onSelect: (state: { status: string } & WorkflowTransition) => void
   hasChanges?: boolean
+  disabledTransitions?: Record<string, { reason: string }>
 } & PropsWithChildren) => {
   return (
     <div className='p-2'>
@@ -31,6 +34,7 @@ export const StatusOptions = ({ transitions, statuses, onSelect, children, hasCh
               state={state}
               onSelect={onSelect}
               hasChanges={hasChanges}
+              disabledReason={disabledTransitions?.[status]?.reason}
             />
           )
         })}

--- a/src/components/QuickDocument/StatusMenu.tsx
+++ b/src/components/QuickDocument/StatusMenu.tsx
@@ -30,8 +30,9 @@ export const StatusMenuLogic = ({ ydoc, propPlanningId, view }: StatusMenuHeader
   const { t } = useTranslation()
 
   const onBeforeStatusChange = useCallback(async (newStatus: string, data?: Record<string, unknown>) => {
-    if (!planningId) {
-      // Use view-specific error message
+    // Scheduling (withheld) is the only transition that requires planning.
+    // Other transitions should still work when no planning is associated.
+    if (newStatus === 'withheld' && !planningId) {
       toast.error(viewConfig.statusErrorText)
       return false
     }
@@ -83,23 +84,22 @@ export const StatusMenuLogic = ({ ydoc, propPlanningId, view }: StatusMenuHeader
       ? data.time
       : new Date()
 
-    if (ydoc.id) {
+    if (ydoc.id && planningId) {
       await updateAssignmentTime(ydoc.id, planningId, newStatus, newPublishTime, t)
     }
 
     return true
   }, [planningId, ydoc.id, dispatch, history, state.viewRegistry, viewId, workflowStatus, viewConfig.statusErrorText, viewConfig.linkTarget, t])
 
+  if (!ydoc.id) {
+    return null
+  }
+
   return (
-    <>
-      {/* Renders if planningId exists from prop or hook, AND ydoc.id exists */}
-      {!!(propPlanningId || planningId) && ydoc.id && (
-        <StatusMenu
-          ydoc={ydoc}
-          planningId={propPlanningId || planningId}
-          onBeforeStatusChange={onBeforeStatusChange}
-        />
-      )}
-    </>
+    <StatusMenu
+      ydoc={ydoc}
+      planningId={propPlanningId || planningId || undefined}
+      onBeforeStatusChange={onBeforeStatusChange}
+    />
   )
 }

--- a/src/locales/en/shared.json
+++ b/src/locales/en/shared.json
@@ -35,6 +35,7 @@
     "setTime": "Set time",
     "asSavePlaceholder": "Publish new information",
     "embargoMinTime": "Embargo: cannot schedule before {{time}}",
+    "schedulingRequiresPlanning": "Scheduling is unavailable because this document has no associated planning.",
     "causes": {
       "development_short": "DEV",
       "development_long": "Development",

--- a/src/locales/nb/shared.json
+++ b/src/locales/nb/shared.json
@@ -35,6 +35,7 @@
     "setTime": "Skriv inn tid",
     "asSavePlaceholder": "Publiser ny informasjon",
     "embargoMinTime": "Embargo: kan ikke planlegges før {{time}}",
+    "schedulingRequiresPlanning": "Planlegging er ikke tilgjengelig fordi dokumentet mangler en tilknyttet planlegging.",
     "causes": {
       "development_short": "UV",
       "development_long": "Utvikling",

--- a/src/locales/sv/shared.json
+++ b/src/locales/sv/shared.json
@@ -35,6 +35,7 @@
     "setTime": "Ange tid",
     "asSavePlaceholder": "Publicera ny information",
     "embargoMinTime": "Embargo: kan inte schemaläggas före {{time}}",
+    "schedulingRequiresPlanning": "Schemaläggning är inte tillgänglig eftersom dokumentet saknar en kopplad planering.",
     "causes": {
       "development_short": "UV",
       "development_long": "Utveckling",

--- a/src/views/Editor/EditorHeader.tsx
+++ b/src/views/Editor/EditorHeader.tsx
@@ -101,8 +101,10 @@ export const EditorHeader = ({ ydoc, readOnly, readOnlyVersion, planningId: prop
       })
     }
 
-    // When we set withheld or draft we must change related dates (publish and start respecively)
-    if (['withheld', 'draft'].includes(newStatus)) {
+    // When we set withheld or draft we must change related dates on the planning
+    // assignment (publish and start respectively). Skip when no planning is associated —
+    // the transition still succeeds, but no assignment times are touched.
+    if (['withheld', 'draft'].includes(newStatus) && planningId) {
       // We require a valid publish time if scheduling
       if (newStatus === 'withheld' && !(data?.time instanceof Date)) {
         toast.error(t('errors:toasts.couldNotScheduleArticle'))
@@ -180,9 +182,9 @@ export const EditorHeader = ({ ydoc, readOnly, readOnlyVersion, planningId: prop
                   </Button>
                 )}
 
-                {!!(propPlanningId || planningId) && (!isReadOnlyAndUpdated || isUnpublished) && (
+                {(!isReadOnlyAndUpdated || isUnpublished) && (
                   <StatusMenu
-                    planningId={propPlanningId || planningId}
+                    planningId={propPlanningId || planningId || undefined}
                     ydoc={ydoc}
                     onBeforeStatusChange={onBeforeStatusChange}
                     embargoUntil={embargoUntil}


### PR DESCRIPTION
Render StatusMenu even when a deliverable has no associated planning item. All transitions work normally except scheduling (withheld), which appears disabled with a tooltip explaining that a planning item is required. Skips assignment-time updates when no planning is linked.

Closes ELELOG-580