### PR TITLE
fix(status-menu): drop redundant disabled guards and Tooltip wrapper

### DIFF
--- a/src/components/DocumentStatus/StatusMenuOption.tsx
+++ b/src/components/DocumentStatus/StatusMenuOption.tsx
@@ -30,16 +30,7 @@ export const StatusMenuOption = ({
         'flex flex-row gap-5 w-full py-2 pe-2 items-start rounded-md',
         isDisabled && 'opacity-50 cursor-not-allowed'
       )}
-      onSelect={(event) => {
-        if (isDisabled) {
-          event.preventDefault()
-          return
-        }
-      }}
-      onClick={() => {
-        if (isDisabled) return
-        onSelect({ status, ...state })
-      }}
+      onSelect={() => onSelect({ status, ...state })}
     >
       <div className='w-4 grow-0 shrink-0 pt-0.5'>
         {!!Icon && <Icon {...iconProps} />}
@@ -60,7 +51,7 @@ export const StatusMenuOption = ({
 
   return (
     <Tooltip content={disabledReason}>
-      <div>{item}</div>
+      {item}
     </Tooltip>
   )
 }


### PR DESCRIPTION
Radix's DropdownMenuItem disabled={true} already blocks onSelect, so the manual preventDefault/early-return guards on onSelect and onClick were dead code. Collapse to a single onSelect handler.

@ttab/elephant-ui's Tooltip wraps its trigger in a span via asChild, so the extra div around the disabled item is also redundant.