### PR TITLE
feat(templates): derive content-source from session org + unit

### DIFF
--- a/__tests__/initializeAuthor.test.ts
+++ b/__tests__/initializeAuthor.test.ts
@@ -34,6 +34,7 @@ describe('initializeAuthor', () => {
       expires: 'mockExpires',
       status: 'authenticated',
       units: [],
+      org: '',
       error: '',
       user: {
         sub: 'core://user/5558',

--- a/__tests__/lib/getContentSourceLink.test.ts
+++ b/__tests__/lib/getContentSourceLink.test.ts
@@ -1,0 +1,36 @@
+import { getContentSourceLink } from '@/shared/getContentSourceLink'
+
+describe('getContentSourceLink', () => {
+  it('returns TT source when org is core://org/tt', () => {
+    const link = getContentSourceLink({ org: 'core://org/tt', units: ['/redaktionen'] })
+
+    expect(link).toBeDefined()
+    expect(link?.type).toBe('core/content-source')
+    expect(link?.rel).toBe('source')
+    expect(link?.uri).toBe('tt://content-source/tt')
+    expect(link?.title).toBe('TT')
+  })
+
+  it('returns NTB source when org is core://org/ntb', () => {
+    const link = getContentSourceLink({ org: 'core://org/ntb', units: ['/redaktionen'] })
+
+    expect(link?.uri).toBe('tt://content-source/ntb')
+    expect(link?.title).toBe('NTB')
+  })
+
+  it('returns NPK source when units include /redaktionen-npk (overrides org)', () => {
+    const link = getContentSourceLink({
+      org: 'core://org/ntb',
+      units: ['/redaktionen-npk', '/other']
+    })
+
+    expect(link?.uri).toBe('tt://content-source/npk')
+    expect(link?.title).toBe('NPK')
+  })
+
+  it('returns undefined when neither org nor units match', () => {
+    expect(getContentSourceLink({})).toBeUndefined()
+    expect(getContentSourceLink({ org: 'core://org/unknown' })).toBeUndefined()
+    expect(getContentSourceLink({ units: ['/redaktionen'] })).toBeUndefined()
+  })
+})

--- a/__tests__/templates/articleDocumentTemplate.test.ts
+++ b/__tests__/templates/articleDocumentTemplate.test.ts
@@ -66,10 +66,28 @@ describe('articleDocumentTemplate', () => {
     expect(storyLink.rel).toBe('subject')
   })
 
-  it('includes TT content source link', () => {
+  it('passes through caller-provided content-source link', () => {
+    const payload: TemplatePayload = {
+      links: {
+        'core/content-source': [
+          Block.create({
+            type: 'core/content-source',
+            rel: 'source',
+            uri: 'tt://content-source/ntb',
+            title: 'NTB'
+          })
+        ]
+      }
+    }
+    const doc = articleDocumentTemplate('id', payload)
+    const source = doc.links.find((l: Block) => l.type === 'core/content-source')
+    expect(source?.uri).toBe('tt://content-source/ntb')
+    expect(source?.title).toBe('NTB')
+  })
+
+  it('omits content-source link when caller provides none', () => {
     const doc = articleDocumentTemplate('id')
-    const links = doc.links
-    expect(links.some((l: Block) => l.type === 'core/content-source' && l.title === 'TT')).toBe(true)
+    expect(doc.links.some((l: Block) => l.type === 'core/content-source')).toBe(false)
   })
 
   it('matches inline snapshot with fixed date', () => {
@@ -163,26 +181,7 @@ describe('articleDocumentTemplate', () => {
           },
         ],
         "language": "sv-se",
-        "links": [
-          {
-            "content": [],
-            "contenttype": "",
-            "data": {},
-            "id": "",
-            "links": [],
-            "meta": [],
-            "name": "",
-            "rel": "source",
-            "role": "",
-            "sensitivity": "",
-            "title": "TT",
-            "type": "core/content-source",
-            "uri": "tt://content-source/tt",
-            "url": "",
-            "uuid": "",
-            "value": "",
-          },
-        ],
+        "links": [],
         "meta": [],
         "title": "",
         "type": "core/article",

--- a/__tests__/timelessArticle.test.ts
+++ b/__tests__/timelessArticle.test.ts
@@ -43,12 +43,26 @@ describe('timelessArticleDocumentTemplate', () => {
     expect(categoryLink?.rel).toBe('subject')
   })
 
-  it('includes default content-source link', () => {
-    const doc = timelessArticleDocumentTemplate('test-id')
+  it('passes through caller-provided content-source link', () => {
+    const doc = timelessArticleDocumentTemplate('test-id', {
+      links: {
+        'core/content-source': [Block.create({
+          type: 'core/content-source',
+          rel: 'source',
+          uri: 'tt://content-source/npk',
+          title: 'NPK'
+        })]
+      }
+    })
     const source = doc.links.find((l) => l.type === 'core/content-source')
 
-    expect(source).toBeDefined()
-    expect(source?.title).toBe('TT')
+    expect(source?.uri).toBe('tt://content-source/npk')
+    expect(source?.title).toBe('NPK')
+  })
+
+  it('omits content-source link when caller provides none', () => {
+    const doc = timelessArticleDocumentTemplate('test-id')
+    expect(doc.links.some((l) => l.type === 'core/content-source')).toBe(false)
   })
 
   it('includes meta from payload', () => {

--- a/shared/getContentSourceLink.ts
+++ b/shared/getContentSourceLink.ts
@@ -1,0 +1,44 @@
+import { Block } from '@ttab/elephant-api/newsdoc'
+
+const NPK_UNIT = '/redaktionen-npk'
+const ORG_NTB = 'core://org/ntb'
+const ORG_TT = 'core://org/tt'
+
+/**
+ * Derives the default `core/content-source` link for a new document from the
+ * session's `org` claim and `units`. NPK is keyed on the unit membership
+ * (matches `buildAcl()` in `shared/Repository.ts`).
+ *
+ * Returns `undefined` when neither claim identifies a known source — callers
+ * can then decide whether to omit the link or fall back to something else.
+ */
+export function getContentSourceLink({
+  org,
+  units
+}: {
+  org?: string
+  units?: string[]
+}): Block | undefined {
+  if (units?.includes(NPK_UNIT)) {
+    return buildSource('npk', 'NPK')
+  }
+
+  if (org === ORG_NTB) {
+    return buildSource('ntb', 'NTB')
+  }
+
+  if (org === ORG_TT) {
+    return buildSource('tt', 'TT')
+  }
+
+  return undefined
+}
+
+function buildSource(slug: string, title: string): Block {
+  return Block.create({
+    type: 'core/content-source',
+    rel: 'source',
+    uri: `tt://content-source/${slug}`,
+    title
+  })
+}

--- a/shared/templates/articleDocumentTemplate.ts
+++ b/shared/templates/articleDocumentTemplate.ts
@@ -58,16 +58,7 @@ export function articleDocumentTemplate(id: string, payload?: TemplatePayload): 
       ...Object.values(payload?.meta ?? {}).flat()
     ],
     links: [
-      ...Object.values(payload?.links ?? {}).flat(),
-      ...(payload?.links?.['core/content-source']?.length
-        ? []
-        : [Block.create({
-            uri: 'tt://content-source/tt',
-            type: 'core/content-source',
-            title: 'TT',
-            rel: 'source'
-          })]
-      )
+      ...Object.values(payload?.links ?? {}).flat()
     ]
   })
 }

--- a/shared/templates/timelessArticleDocumentTemplate.ts
+++ b/shared/templates/timelessArticleDocumentTemplate.ts
@@ -43,13 +43,7 @@ export function timelessArticleDocumentTemplate(
       ...Object.values(payload?.meta ?? {}).flat()
     ],
     links: [
-      ...Object.values(payload?.links ?? {}).flat(),
-      Block.create({
-        uri: 'tt://content-source/tt',
-        type: 'core/content-source',
-        title: 'TT',
-        rel: 'source'
-      })
+      ...Object.values(payload?.links ?? {}).flat()
     ]
   })
 }

--- a/src-srv/utils/authConfig.ts
+++ b/src-srv/utils/authConfig.ts
@@ -73,12 +73,14 @@ export async function createAuthInfo(
             user.sub = account.providerAccountId
           }
 
-          // Extract units from the JWT access token
+          // Extract units and org from the JWT access token
           let units: string[] = []
+          let org = ''
           if (account.access_token) {
             try {
               const decoded = decodeJwt(account.access_token)
               units = Array.isArray(decoded.units) ? decoded.units as string[] : []
+              org = typeof decoded.org === 'string' ? decoded.org : ''
             } catch {
               // Token decode failure is non-fatal
             }
@@ -89,6 +91,7 @@ export async function createAuthInfo(
             accessTokenExpires: Date.now() + (account.expires_in || 300) * 1000,
             refreshToken: account.refresh_token,
             units,
+            org,
             user
           }
         }
@@ -171,13 +174,15 @@ async function refreshAccessToken(
       throw new Error('refresh request error response: invalid token response')
     }
 
-    // Re-extract units from the refreshed access token
+    // Re-extract units and org from the refreshed access token
     let units: string[] = (token.units as string[]) || []
+    let org = typeof token.org === 'string' ? token.org : ''
     try {
       const decoded = decodeJwt(refreshedTokens.access_token as string)
       units = Array.isArray(decoded.units) ? decoded.units as string[] : units
+      org = typeof decoded.org === 'string' ? decoded.org : org
     } catch {
-      // Token decode failure is non-fatal, keep existing units
+      // Token decode failure is non-fatal, keep existing values
     }
 
     return {
@@ -185,7 +190,8 @@ async function refreshAccessToken(
       accessToken: refreshedTokens.access_token,
       accessTokenExpires: Date.now() + refreshedTokens.expires_in * 1000,
       refreshToken: refreshedTokens.refresh_token ?? token.refreshToken,
-      units
+      units,
+      org
     }
   } catch (ex) {
     logger.error({

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -15,6 +15,7 @@ declare module 'next-auth' {
       sub: string
     }
     units: string[]
+    org: string
     error: string
   }
   interface User extends NextAuthUser {

--- a/src/views/Planning/components/CreateDeliverablePrompt.tsx
+++ b/src/views/Planning/components/CreateDeliverablePrompt.tsx
@@ -5,6 +5,7 @@ import { useSession } from 'next-auth/react'
 import { useRegistry } from '@/hooks'
 import { toast } from 'sonner'
 import { getTemplateFromDeliverable } from '@/shared/templates/lib/getTemplateFromDeliverable'
+import { getContentSourceLink } from '@/shared/getContentSourceLink'
 import type { YDocument } from '@/modules/yjs/hooks'
 import type * as Y from 'yjs'
 import type { JSX } from 'react'
@@ -63,6 +64,19 @@ export const CreateDeliverablePrompt = ({
       finalPayload.links = {
         ...finalPayload.links,
         'core/timeless-category': [selectedCategory]
+      }
+    }
+
+    // Derive the default content-source from the session unless the caller
+    // already supplied one on the payload.
+    const callerSource = finalPayload.links?.['core/content-source']
+    if (!callerSource?.length) {
+      const contentSource = getContentSourceLink({ org: session.org, units: session.units })
+      if (contentSource) {
+        finalPayload.links = {
+          ...finalPayload.links,
+          'core/content-source': [contentSource]
+        }
       }
     }
 

--- a/src/views/TimelessCreation/lib/createNewTimelessArticle.ts
+++ b/src/views/TimelessCreation/lib/createNewTimelessArticle.ts
@@ -2,6 +2,7 @@ import type { Repository } from '@/shared/Repository'
 import { timeless as timelessTemplate } from '@/shared/templates'
 import type { Session } from 'next-auth'
 import { Block } from '@ttab/elephant-api/newsdoc'
+import { getContentSourceLink } from '@/shared/getContentSourceLink'
 
 /**
  * Save a new timeless article document. The caller is responsible for
@@ -46,6 +47,7 @@ export async function createNewTimelessArticle({
   }
 
   try {
+    const contentSource = getContentSourceLink({ org: session.org, units: session.units })
     const document = timelessTemplate(id, {
       title,
       meta: {
@@ -54,7 +56,8 @@ export async function createNewTimelessArticle({
       },
       links: {
         'core/timeless-category': [category],
-        ...(section ? { 'core/section': [section] } : {})
+        ...(section ? { 'core/section': [section] } : {}),
+        ...(contentSource ? { 'core/content-source': [contentSource] } : {})
       }
     })
     await repository.saveDocument(document, session.accessToken)

--- a/src/views/WireCreation/index.tsx
+++ b/src/views/WireCreation/index.tsx
@@ -28,8 +28,6 @@ export const WireCreation = (props: ViewProps & {
   wires?: WireType[]
 }): JSX.Element => {
   const { data: session } = useSession()
-  const sessionOrg = session?.org
-  const sessionUnits = session?.units
 
   // The article we're creating
   const [documentId, data] = useMemo(() => {
@@ -44,7 +42,7 @@ export const WireCreation = (props: ViewProps & {
       }
     }))
 
-    const contentSource = getContentSourceLink({ org: sessionOrg, units: sessionUnits })
+    const contentSource = getContentSourceLink({ org: session?.org, units: session?.units })
 
     const payload = {
       meta: {
@@ -64,7 +62,7 @@ export const WireCreation = (props: ViewProps & {
       subset: [],
       document: Templates.article(documentId, payload)
     })]
-  }, [props.wires, sessionOrg, sessionUnits])
+  }, [props.wires, session?.units, session?.org])
 
   return (
     <>

--- a/src/views/WireCreation/index.tsx
+++ b/src/views/WireCreation/index.tsx
@@ -5,6 +5,8 @@ import { useMemo, type JSX } from 'react'
 import { Block } from '@ttab/elephant-api/newsdoc'
 import type { Wire as WireType } from '@/shared/schemas/wire'
 import { toGroupedNewsDoc } from '@/shared/transformations/groupedNewsDoc'
+import { useSession } from 'next-auth/react'
+import { getContentSourceLink } from '@/shared/getContentSourceLink'
 
 const meta: ViewMetadata = {
   name: 'WireCreation',
@@ -25,6 +27,10 @@ const meta: ViewMetadata = {
 export const WireCreation = (props: ViewProps & {
   wires?: WireType[]
 }): JSX.Element => {
+  const { data: session } = useSession()
+  const sessionOrg = session?.org
+  const sessionUnits = session?.units
+
   // The article we're creating
   const [documentId, data] = useMemo(() => {
     const documentId = crypto.randomUUID()
@@ -38,13 +44,16 @@ export const WireCreation = (props: ViewProps & {
       }
     }))
 
+    const contentSource = getContentSourceLink({ org: sessionOrg, units: sessionUnits })
+
     const payload = {
       meta: {
         'tt/slugline': [Block.create({ type: 'tt/slugline' })],
         'core/newsvalue': [Block.create({ type: 'core/newsvalue' })]
       },
       links: {
-        'tt/wire': ttWireLinks
+        'tt/wire': ttWireLinks,
+        ...(contentSource ? { 'core/content-source': [contentSource] } : {})
       }
     }
 
@@ -55,7 +64,7 @@ export const WireCreation = (props: ViewProps & {
       subset: [],
       document: Templates.article(documentId, payload)
     })]
-  }, [props.wires])
+  }, [props.wires, sessionOrg, sessionUnits])
 
   return (
     <>

--- a/src/views/WireCreation/lib/createArticle.tsx
+++ b/src/views/WireCreation/lib/createArticle.tsx
@@ -82,16 +82,30 @@ export async function createArticle({
     title: section.title
   }))
 
-  // Replace default content sources with wire-provided ones
+  // Merge wire-provided content-sources with the template's (session-derived)
+  // default. De-duplicate by URI so the session default is kept when the wire
+  // carries the same source.
   if (contentSources?.length) {
-    setValueByYPath(ydoc.ele, 'links.core/content-source', contentSources.map((source) =>
-      Block.create({
-        type: 'core/content-source',
-        uri: source.uri,
-        title: source.title,
-        rel: source.rel || 'source'
-      })
-    ))
+    const [existing] = getValueByYPath<EleBlock[]>(ydoc.ele, 'links.core/content-source')
+    const merged: Block[] = (existing ?? []).map((source) => Block.create({
+      type: 'core/content-source',
+      uri: source.uri,
+      title: source.title,
+      rel: source.rel || 'source'
+    }))
+    const seen = new Set(merged.map((block) => block.uri))
+    for (const source of contentSources) {
+      if (!seen.has(source.uri)) {
+        merged.push(Block.create({
+          type: 'core/content-source',
+          uri: source.uri,
+          title: source.title,
+          rel: source.rel || 'source'
+        }))
+        seen.add(source.uri)
+      }
+    }
+    setValueByYPath(ydoc.ele, 'links.core/content-source', merged)
   }
 
   // Collect all base data from the Y.Doc synchronously before any async operations


### PR DESCRIPTION
Remove hardcoded tt://content-source/tt / TT from article and timeless templates. Callers now pass a session-derived core/content-source link in the payload; a new shared helper maps the session's org claim (core://org/tt → TT, core://org/ntb → NTB) and unit (/redaktionen-npk → NPK) to the link.

Also fixes the timeless template appending the fallback unconditionally, and WireCreation now merges wire source-document content-sources with the session-derived one instead of replacing.

Exposes the org claim on the next-auth Session (decoded alongside units in authConfig).