### PR TITLE
feat(status-menu): default cause to UV when cause is required

### DIFF
--- a/__tests__/components/PromptDefault.test.tsx
+++ b/__tests__/components/PromptDefault.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { PromptDefault } from '@/components/DocumentStatus/PromptDefault'
+import type { WorkflowTransition } from '@/defaults/workflowSpecification'
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query as unknown,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn()
+  }))
+})
+
+class ResizeObserverMock {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+}
+global.ResizeObserver = ResizeObserverMock
+Element.prototype.scrollIntoView = vi.fn()
+HTMLElement.prototype.hasPointerCapture = vi.fn()
+
+vi.mock('@/hooks/useRegistry', () => ({
+  useRegistry: () => ({ timeZone: 'Europe/Stockholm' })
+}))
+
+vi.mock('@/components/HastToggle', () => ({
+  HastToggle: () => null
+}))
+
+const draftPrompt: { status: string } & WorkflowTransition = {
+  status: 'draft',
+  title: 'New version',
+  promptTitle: 'New version of article',
+  description: 'Continue working on a new version',
+  verify: true
+}
+
+const renderPrompt = (props: Partial<Parameters<typeof PromptDefault>[0]> = {}) => {
+  const setStatus = vi.fn()
+  const showPrompt = vi.fn()
+
+  render(
+    <PromptDefault
+      prompt={draftPrompt}
+      setStatus={setStatus}
+      showPrompt={showPrompt}
+      requireCause
+      {...props}
+    />
+  )
+
+  return { setStatus, showPrompt, user: userEvent.setup() }
+}
+
+describe('PromptDefault', () => {
+  it('defaults the cause to development (UV) when requireCause is true and no current cause', () => {
+    renderPrompt()
+
+    expect(screen.getByRole('combobox')).toHaveTextContent('UV')
+  })
+
+  it('does not pre-select a cause when requireCause is false', () => {
+    renderPrompt({ requireCause: false })
+
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+  })
+
+  it('uses the existing currentCause instead of the development default', () => {
+    renderPrompt({ currentCause: 'fix' })
+
+    expect(screen.getByRole('combobox')).toHaveTextContent('KORR')
+  })
+
+  it('submits with cause=development when accepted with the default', async () => {
+    const { setStatus, user } = renderPrompt()
+
+    await user.click(screen.getByRole('button', { name: 'New version' }))
+
+    expect(setStatus).toHaveBeenCalledWith('draft', { cause: 'development' })
+  })
+})

--- a/src/components/DocumentStatus/PromptDefault.tsx
+++ b/src/components/DocumentStatus/PromptDefault.tsx
@@ -42,7 +42,9 @@ export const PromptDefault = ({
   anchor?: HTMLElement | null
   typeIcon?: LucideIcon
 }) => {
-  const [cause, setCause] = useState<string | undefined>(currentCause)
+  const [cause, setCause] = useState<string | undefined>(
+    currentCause || (requireCause ? 'development' : undefined)
+  )
   const isUnpublishPrompt = prompt.status === 'unpublished'
   const { t } = useTranslation('common')
   const { timeZone } = useRegistry()
@@ -57,12 +59,6 @@ export const PromptDefault = ({
   const disablePrimary = isUnpublishPrompt
     ? false
     : (requireCause && !cause) || embargoBlocksPublish
-
-  useEffect(() => {
-    if (prompt.status === 'draft') {
-      setCause('')
-    }
-  }, [prompt.status])
 
   const handleSubmit = useCallback(() => {
     if (isUnpublishPrompt && unPublishDocument) {
@@ -114,7 +110,7 @@ export const PromptDefault = ({
       {(showCauseField) && (
         <PromptCauseField
           onValueChange={setCause}
-          cause={prompt.status !== 'draft' ? cause : ''}
+          cause={cause}
         />
       )}
     </Prompt>


### PR DESCRIPTION
Pre-fill the cause selector with 'development' (UV) when a status transition requires a cause and the document has none set, so users hitting "New version" on a published article get a sensible default instead of an empty selector.

Add tests covering the default, the no-requireCause path, an existing cause taking precedence, and submission with the default.