### PR TITLE
fix(status-menu): prevent status button label from wrapping

### DIFF
--- a/src/components/DocumentStatus/StatusButton.tsx
+++ b/src/components/DocumentStatus/StatusButton.tsx
@@ -27,7 +27,7 @@ export const StatusButton = forwardRef<HTMLButtonElement, {
       ref={ref}
       size='sm'
       variant='outline'
-      className='flex items-center h-8 px-3'
+      className='flex items-center h-8 px-3 whitespace-nowrap'
       title={asSave ? workflow[props.currentStatusName]?.changedDescription : workflow[props.currentStatusName]?.description}
       disabled={isTransitioning}
       {...rest}


### PR DESCRIPTION
Add whitespace-nowrap so labels like "Unpublished changes" stay on a single line in the StatusMenu trigger button.