### PR TITLE
fix(prompt-schedule): guard against missing publishDate in effect

### DIFF
--- a/__tests__/components/PromptSchedule.test.tsx
+++ b/__tests__/components/PromptSchedule.test.tsx
@@ -1,0 +1,83 @@
+import { render } from '@testing-library/react'
+import { PromptSchedule } from '@/components/DocumentStatus/PromptSchedule'
+import type { WorkflowTransition } from '@/defaults/workflowSpecification'
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query as unknown,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn()
+  }))
+})
+
+class ResizeObserverMock {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+}
+global.ResizeObserver = ResizeObserverMock
+Element.prototype.scrollIntoView = vi.fn()
+HTMLElement.prototype.hasPointerCapture = vi.fn()
+
+let mockPublishDate: Date | undefined
+
+vi.mock('@/modules/yjs/hooks', () => ({
+  useYValue: () => [mockPublishDate]
+}))
+
+vi.mock('@/hooks/useCollaborationDocument', () => ({
+  useCollaborationDocument: () => ({
+    document: undefined,
+    documentId: 'planning-1',
+    connected: false,
+    synced: false,
+    loading: false
+  })
+}))
+
+vi.mock('@/hooks/useRegistry', () => ({
+  useRegistry: () => ({ timeZone: 'Europe/Stockholm' })
+}))
+
+vi.mock('@/components/HastToggle', () => ({
+  HastToggle: () => null
+}))
+
+const usablePrompt: { status: string } & WorkflowTransition = {
+  status: 'usable',
+  title: 'Schedule',
+  promptTitle: 'Schedule publication',
+  description: 'Pick a publication time'
+}
+
+const renderSchedule = () =>
+  render(
+    <PromptSchedule
+      prompt={usablePrompt}
+      planningId='planning-1'
+      setStatus={vi.fn()}
+      showPrompt={vi.fn()}
+    />
+  )
+
+describe('PromptSchedule', () => {
+  beforeEach(() => {
+    mockPublishDate = undefined
+  })
+
+  it('renders without throwing when planning has no start_date and no embargo', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    expect(() => renderSchedule()).not.toThrow()
+    expect(document.getElementById('ScheduledTime')).toBeInTheDocument()
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+
+    consoleErrorSpy.mockRestore()
+  })
+})

--- a/src/components/DocumentStatus/PromptSchedule.tsx
+++ b/src/components/DocumentStatus/PromptSchedule.tsx
@@ -52,17 +52,19 @@ export const PromptSchedule = ({
   useEffect(() => {
     if (loading) return
 
-    const formatedPublishDate = publishDate.toLocaleString()
-    const formatedNow = now.toLocaleString().slice(0, 10)
-
     // If embargo is active, use embargo time as minimum
     if (embargoIsActive && embargoDate) {
       setTime(embargoDate)
       return
     }
 
+    if (!publishDate) return
+
+    const formatedPublishDate = publishDate.toLocaleString()
+    const formatedNow = now.toLocaleString().slice(0, 10)
+
     // only set to publish date if it's in the future, otherwise default to now
-    if (publishDate && formatedPublishDate >= formatedNow) {
+    if (formatedPublishDate >= formatedNow) {
       const d = new Date(publishDate)
       d.setHours(now.getHours(), now.getMinutes(), 0, 0)
       setTime(d)


### PR DESCRIPTION
The schedule effect called publishDate.toLocaleString() before its existence check, throwing whenever the linked planning had no start_date. The thrown effect tore down the prompt subtree, which then re-mounted and started loading the planning document again — leaving the user staring at a perpetual spinner.

Move the publishDate guard above the toLocaleString call so the effect short-circuits cleanly when no publish date is present.