### PR TITLE
fix(wire-preview): use title fields for source and provider

### DIFF
--- a/__tests__/components/WirePreview.test.tsx
+++ b/__tests__/components/WirePreview.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react'
+import { HitV1 } from '@ttab/elephant-api/index'
+import { WirePreview } from '@/components/WirePreview/WirePreview'
+import type { Wire } from '@/shared/schemas/wire'
+
+vi.mock('@/components/WirePreview/DocumentHistory', () => ({
+  DocumentHistory: () => null
+}))
+
+vi.mock('@/components/PlainEditor', () => ({
+  Editor: () => null
+}))
+
+function buildWire(extraFields: Record<string, { values: string[] }>): Wire {
+  const hit = HitV1.create({
+    id: 'wire-1',
+    fields: {
+      'document.meta.tt_wire.role': { values: ['article'] },
+      current_version: { values: ['1'] },
+      ...extraFields
+    }
+  })
+  return hit as Wire
+}
+
+describe('WirePreview', () => {
+  it('renders the source and provider title fields', async () => {
+    const wire = buildWire({
+      'document.rel.source.uri': { values: ['wires://source/raw-slug'] },
+      'document.rel.source.title': { values: ['Reuters'] },
+      'document.rel.provider.uri': { values: ['wires://provider/raw-provider'] },
+      'document.rel.provider.title': { values: ['ReutersPro'] }
+    })
+
+    render(<WirePreview wire={wire} />)
+
+    expect(await screen.findByText('Reuters')).toBeInTheDocument()
+    expect(screen.getByText('ReutersPro')).toBeInTheDocument()
+    expect(screen.queryByText('raw-slug')).not.toBeInTheDocument()
+    expect(screen.queryByText('raw-provider')).not.toBeInTheDocument()
+  })
+
+  it('falls back to a URI-stripped slug for source when its title is missing', async () => {
+    const wire = buildWire({
+      'document.rel.source.uri': { values: ['wires://source/tt'] },
+      'document.rel.provider.title': { values: ['ReutersPro'] }
+    })
+
+    render(<WirePreview wire={wire} />)
+
+    expect(await screen.findByText('tt')).toBeInTheDocument()
+    expect(screen.getByText('ReutersPro')).toBeInTheDocument()
+  })
+
+  it('falls back to a URI-stripped slug for provider when its title is missing', async () => {
+    const wire = buildWire({
+      'document.rel.source.title': { values: ['Reuters'] },
+      'document.rel.provider.uri': { values: ['wires://provider/tt-pro'] }
+    })
+
+    render(<WirePreview wire={wire} />)
+
+    expect(await screen.findByText('Reuters')).toBeInTheDocument()
+    expect(screen.getByText('tt-pro')).toBeInTheDocument()
+  })
+
+  it('decodes HTML entities in both source and provider badges', async () => {
+    const wire = buildWire({
+      'document.rel.source.title': { values: ['AFP &amp; Co'] },
+      'document.rel.provider.title': { values: ['Reuters &#39;Pro&#39;'] }
+    })
+
+    render(<WirePreview wire={wire} />)
+
+    expect(await screen.findByText('AFP & Co')).toBeInTheDocument()
+    expect(screen.getByText('Reuters \'Pro\'')).toBeInTheDocument()
+    expect(screen.queryByText('AFP &amp; Co')).not.toBeInTheDocument()
+    expect(screen.queryByText('Reuters &#39;Pro&#39;')).not.toBeInTheDocument()
+  })
+
+  it('hides the provider badge when it matches the source case-insensitively', async () => {
+    const wire = buildWire({
+      'document.rel.source.title': { values: ['TT'] },
+      'document.rel.provider.title': { values: ['tt'] }
+    })
+
+    render(<WirePreview wire={wire} />)
+
+    expect(await screen.findByText('TT')).toBeInTheDocument()
+    expect(screen.queryByText('tt')).not.toBeInTheDocument()
+  })
+})

--- a/shared/schemas/wire.ts
+++ b/shared/schemas/wire.ts
@@ -6,7 +6,9 @@ import type { FieldValuesV1, HitV1 } from '@ttab/elephant-api/index'
  */
 const _fields = [
   'document.rel.source.uri',
+  'document.rel.source.title',
   'document.rel.provider.uri',
+  'document.rel.provider.title',
   'modified',
   'document.meta.core_newsvalue.value',
   'document.title',

--- a/src/components/WirePreview/WirePreview.tsx
+++ b/src/components/WirePreview/WirePreview.tsx
@@ -14,10 +14,8 @@ export const WirePreview = ({ wire }: {
 }) => {
   const { t } = useTranslation('wires')
   const data = {
-    source: wire?.fields['document.rel.source.uri']?.values[0]
-      ?.replace('wires://source/', ''),
-    provider: wire?.fields['document.rel.provider.uri']?.values[0]
-      ?.replace('wires://provider/', ''),
+    source: wire?.fields['document.rel.source.title']?.values[0],
+    provider: wire?.fields['document.rel.provider.title']?.values[0],
     role: wire?.fields['document.meta.tt_wire.role'].values[0],
     newsvalue: wire?.fields['document.meta.core_newsvalue.value']?.values[0],
     status: getWireStatus(wire),

--- a/src/components/WirePreview/WirePreview.tsx
+++ b/src/components/WirePreview/WirePreview.tsx
@@ -13,9 +13,13 @@ export const WirePreview = ({ wire }: {
   wire: Wire
 }) => {
   const { t } = useTranslation('wires')
+  const sourceTitle = wire?.fields['document.rel.source.title']?.values[0]
+  const sourceUri = wire?.fields['document.rel.source.uri']?.values[0]
+  const providerTitle = wire?.fields['document.rel.provider.title']?.values[0]
+  const providerUri = wire?.fields['document.rel.provider.uri']?.values[0]
   const data = {
-    source: wire?.fields['document.rel.source.title']?.values[0],
-    provider: wire?.fields['document.rel.provider.title']?.values[0],
+    source: sourceTitle || sourceUri?.replace('wires://source/', ''),
+    provider: providerTitle || providerUri?.replace('wires://provider/', ''),
     role: wire?.fields['document.meta.tt_wire.role'].values[0],
     newsvalue: wire?.fields['document.meta.core_newsvalue.value']?.values[0],
     status: getWireStatus(wire),
@@ -35,11 +39,11 @@ export const WirePreview = ({ wire }: {
         <div className='text-sm flex flex-row gap-2'>
           {data?.source && (
             <Badge className='h-6 pointer-events-none'>
-              {data.source}
+              {decodeString(data.source)}
             </Badge>
           )}
 
-          {data?.provider && data.provider !== data.source && data.provider.toLocaleLowerCase() !== data.source && (
+          {data?.provider && data.provider.toLocaleLowerCase() !== data.source?.toLocaleLowerCase() && (
             <Badge className='h-6'>
               {decodeString(data.provider)}
             </Badge>


### PR DESCRIPTION
Display the resolved source/provider title from the index instead of stripping the wires:// URI prefix, so badges show readable names even when the URI scheme changes.