### PR TITLE
fix(image): expose link url as properties.src for read-only render

### DIFF
--- a/__tests__/transformations/image.test.ts
+++ b/__tests__/transformations/image.test.ts
@@ -35,6 +35,7 @@ const imageSlate: TBElement = {
     rel: 'image',
     uri: 'core://image/abc-def-123',
     url: '',
+    src: '',
     type: 'core/image',
     text: 'A test image caption',
     html_caption: undefined,
@@ -339,6 +340,23 @@ describe('Image transformations', () => {
     expect(imageLink?.uuid).toBe('')
     expect(reverted.data.text).toBe('NTB photo caption')
     expect(reverted.data.credit).toBe('NTB Photographer')
+  })
+
+  it('exposes link url as properties.src so the Image plugin can render', () => {
+    const ntbNewsDoc = Block.create({
+      ...imageNewsDoc,
+      links: [
+        {
+          ...imageNewsDoc.links[0],
+          type: 'mediamanager/image',
+          uri: 'mediamanager://image/ntb/abc',
+          url: 'https://preview-cdn.example/image.jpg'
+        }
+      ]
+    })
+
+    const transformed = transformImage(ntbNewsDoc)
+    expect(transformed.properties?.src).toBe('https://preview-cdn.example/image.jpg')
   })
 
   it('handles uri without image id', () => {

--- a/shared/transformations/newsdoc/core/image.ts
+++ b/shared/transformations/newsdoc/core/image.ts
@@ -18,6 +18,7 @@ export const transformImage = (element: Block): TBElement => {
     height: data.height,
     uploadId: links[0].uri.split('/').at(-1) || '',
     url: links[0].url,
+    src: links[0].url,
     ...transformSoftcrop(meta) || {}
   }
 


### PR DESCRIPTION
The textbit-plugins Image plugin renders <img src={properties.src}>. The plugin's consume() sets src on drop, so live editing works, but transformImage never restored it from the persisted link. Read-only views (PlainEditor, post-publish) reconstructed Slate without src and showed a blank image while caption and byline still rendered.