### PR TITLE
fix(wire-preview): make content fill parent panel

### DIFF
--- a/src/views/Wires/index.tsx
+++ b/src/views/Wires/index.tsx
@@ -492,8 +492,8 @@ export const Wires = (): JSX.Element => {
               <div
                 data-wires-preview
                 className={cn(
-                  'relative rounded-lg grid shadow-xl border border-default-foreground/20 mx-1 justify-center',
-                  'grid-rows-[auto_1fr] h-full overflow-hidden',
+                  'relative rounded-lg grid shadow-xl border border-default-foreground/20 mx-1',
+                  'grid-cols-1 grid-rows-[auto_1fr] h-full overflow-hidden',
                   '@7xl/view:ml-0 @7xl/view:w-xl @7xl/view:my-2 @7xl/view:mx-0'
                 )}
               >


### PR DESCRIPTION
The grid wrapper had `justify-center` with no explicit columns, so the implicit column was content-sized (~358px) instead of stretching to the 576px panel width. Add `grid-cols-1` and drop `justify-center`.