### PR TITLE
fix(author-init): skip contact-info block when session has no email

### DIFF
--- a/__tests__/initializeAuthor.test.ts
+++ b/__tests__/initializeAuthor.test.ts
@@ -383,6 +383,26 @@ describe('initializeAuthor', () => {
     expect(toast.error).toHaveBeenCalled()
   })
 
+  it('should omit contact-info block when session has no email', async () => {
+    mockSession.user.email = undefined as unknown as string
+    setupMocks({ ok: true, hits: [] }, { status: { code: 'OK' } })
+
+    const result = await initializeAuthor({
+      url: mockUrl,
+      session: mockSession,
+      repository: mockRepository,
+      t: i18n.t
+    })
+
+    expect(result).toBe(true)
+
+    const savedDoc = (mockRepository.saveDocument as Mock).mock.calls[0][0] as {
+      meta: Array<{ type: string, data: Record<string, unknown> }>
+    }
+    const contactInfo = savedDoc.meta.find((m) => m.type === 'core/contact-info')
+    expect(contactInfo).toBeUndefined()
+  })
+
   it('should throw an error when query for authordocs fails', async () => {
     setupMocks({ ok: false, hits: [{}, {}] })
 

--- a/src/components/Init/lib/actions/author.ts
+++ b/src/components/Init/lib/actions/author.ts
@@ -247,19 +247,19 @@ function createAuthorDoc(session: Session, envRole: 'stage' | 'prod', language: 
     uri: `core://author/${uuid}`,
     type: 'core/author',
     title: session.user.name,
-    meta: [{
-      type: 'core/author',
-      data: {
-        firstName,
-        lastName
-      }
-    }, {
-      type: 'core/contact-info',
-      data: {
-        email: session.user.email
-      },
-      role: 'office'
-    }],
+    meta: [
+      Block.create({
+        type: 'core/author',
+        data: { firstName, lastName }
+      }),
+      ...(session.user.email
+        ? [Block.create({
+            type: 'core/contact-info',
+            data: { email: session.user.email },
+            role: 'office'
+          })]
+        : [])
+    ],
     language
   })
 


### PR DESCRIPTION
Keycloak realms that don't emit an email claim left session.user.email undefined, which crashed protobuf-ts JSON serialization with an empty error message and produced a truncated 'Kunde inte spara författardokument: ' toast on every login.

Closes ELELOG-615