### PR TITLE
Buttongroup item box click surface

### DIFF
--- a/src/components/DocumentStatus/StatusMenu.tsx
+++ b/src/components/DocumentStatus/StatusMenu.tsx
@@ -42,7 +42,7 @@ export const StatusMenu = ({ ydoc, onBeforeStatusChange, planningId, embargoUnti
   const { viewId } = useView()
   const { t } = useTranslation()
   const viewElementRef = useRef<HTMLElement | null>(null)
-  const icon = documentTypeValueFormat[documentStatus?.type || 'core/article'].icon
+  const icon = documentTypeValueFormat[(documentStatus?.type || 'core/article') as keyof typeof documentTypeValueFormat].icon
 
   useEffect(() => {
     viewElementRef.current = document.getElementById(viewId)

--- a/src/components/Header/AddButtonGroup.tsx
+++ b/src/components/Header/AddButtonGroup.tsx
@@ -45,8 +45,6 @@ const AddButton = ({
   onClick: (view: ButtonView) => void
   t: TFunction
 }) => {
-  const typeLabel = (t?: string) => t ? addButtonGroupValueFormat[t].label : ''
-
   return (
     <Button
       size='sm'

--- a/src/components/Header/AddButtonGroup.tsx
+++ b/src/components/Header/AddButtonGroup.tsx
@@ -29,8 +29,13 @@ const addButtonTypes = ['core/planning-item', 'core/event', 'core/article', 'cor
 type Variant = VariantProps<typeof buttonVariants>['variant']
 type ButtonView = { name: View, type: string, icon?: { icon?: LucideIcon, color?: string } }
 
-const getViewLabel = (view: ButtonView, hast?: boolean) =>
-  view.name === 'Flash' && hast ? 'HAST' : (view.type ? addButtonGroupValueFormat[view.type].label : '')
+const getViewLabel = (view: ButtonView, hast?: boolean): string => {
+  if (view.name === 'Flash' && hast) {
+    return 'HAST'
+  }
+
+  return addButtonGroupValueFormat[view.type]?.label ?? ''
+}
 
 const AddButton = ({
   variant = 'default',

--- a/src/components/Header/AddButtonGroup.tsx
+++ b/src/components/Header/AddButtonGroup.tsx
@@ -29,19 +29,18 @@ const addButtonTypes = ['core/planning-item', 'core/event', 'core/article', 'cor
 type Variant = VariantProps<typeof buttonVariants>['variant']
 type ButtonView = { name: View, type: string, icon?: { icon?: LucideIcon, color?: string } }
 
+const getViewLabel = (view: ButtonView, hast?: boolean) =>
+  view.name === 'Flash' && hast ? 'HAST' : (view.type ? addButtonGroupValueFormat[view.type].label : '')
+
 const AddButton = ({
-  withNew,
   variant = 'default',
   className,
-  hast,
   view,
   onClick,
   t
 }: {
-  withNew?: boolean
   variant?: Variant
   className?: string
-  hast?: boolean
   view: ButtonView
   onClick: (view: ButtonView) => void
   t: TFunction
@@ -52,11 +51,11 @@ const AddButton = ({
     <Button
       size='sm'
       variant={variant}
-      className={!withNew ? '' : cn('h-8 pr-4', className)}
+      className={cn('h-8 pr-4', className)}
       onClick={() => onClick(view)}
     >
-      {withNew && <PlusIcon size={18} strokeWidth={1.75} />}
-      <span className='pl-0.5'>{`${withNew ? t('common:misc.new') : view.name === 'Flash' && hast ? 'HAST' : typeLabel(view.type)}`}</span>
+      <PlusIcon size={18} strokeWidth={1.75} />
+      <span className='pl-0.5'>{t('common:misc.new')}</span>
     </Button>
   )
 }
@@ -109,7 +108,6 @@ export const AddButtonGroup = ({ docType = 'core/planning-item', query }: { type
     <ButtonGroup>
       <AddButton
         t={t}
-        withNew
         view={firstItem?.type ? firstItem : views[0]}
         onClick={handleCreate}
       />
@@ -127,15 +125,13 @@ export const AddButtonGroup = ({ docType = 'core/planning-item', query }: { type
         </div>
         <DropdownMenuContent>
           {firstItem?.type && (
-            <DropdownMenuItem inset={false} className='py-0 px-1'>
+            <DropdownMenuItem
+              inset={false}
+              className='py-1.5 px-2 cursor-pointer'
+              onSelect={() => handleCreate(firstItem)}
+            >
               {ItemIcon?.icon && <ItemIcon.icon strokeWidth={1.75} size={18} color={ItemIcon.color} />}
-              <AddButton
-                t={t}
-                variant='ghost'
-                className='px-0'
-                view={firstItem}
-                onClick={handleCreate}
-              />
+              <span className='pl-4'>{getViewLabel(firstItem, hasHast)}</span>
             </DropdownMenuItem>
           )}
           <DropdownMenuSeparator />
@@ -143,16 +139,14 @@ export const AddButtonGroup = ({ docType = 'core/planning-item', query }: { type
             const ViewIcon = view.icon
 
             return (
-              <DropdownMenuItem inset={false} className='py-0 px-1' key={view.name}>
+              <DropdownMenuItem
+                inset={false}
+                className='py-1.5 px-2 cursor-pointer'
+                key={view.name}
+                onSelect={() => handleCreate(view)}
+              >
                 {ViewIcon?.icon && <ViewIcon.icon strokeWidth={1.75} size={18} color={ViewIcon.color} />}
-                <AddButton
-                  t={t}
-                  variant='ghost'
-                  className='px-0'
-                  hast={hasHast}
-                  view={view}
-                  onClick={handleCreate}
-                />
+                <span className='pl-4'>{getViewLabel(view, hasHast)}</span>
               </DropdownMenuItem>
             )
           })}

--- a/src/components/Header/AddButtonGroup.tsx
+++ b/src/components/Header/AddButtonGroup.tsx
@@ -27,7 +27,7 @@ import type { TFunction } from 'i18next'
 const addButtonTypes = ['core/planning-item', 'core/event', 'core/article', 'core/factbox', 'core/flash', 'core/article#timeless'] as const
 
 type Variant = VariantProps<typeof buttonVariants>['variant']
-type ButtonView = { name: View, type: string, icon?: { icon?: LucideIcon, color?: string } }
+type ButtonView = { name: View, type: keyof typeof addButtonGroupValueFormat, icon?: { icon?: LucideIcon, color?: string } }
 
 const getViewLabel = (view: ButtonView, hast?: boolean): string => {
   if (view.name === 'Flash' && hast) {

--- a/src/defaults/documentTypeFormats.ts
+++ b/src/defaults/documentTypeFormats.ts
@@ -24,34 +24,34 @@ type DocumentTypeFormat = Record<string, {
   }
 }>
 
-const event: DocumentTypeFormat = {
+const event = {
   'core/event': {
     icon: CalendarPlus2Icon,
     get label() { return i18n.t('views:events.label.singular') },
     key: 'Event',
     color: '#D802FD'
   }
-}
+} satisfies DocumentTypeFormat
 
-const planning: DocumentTypeFormat = {
+const planning = {
   'core/planning-item': {
     icon: CalendarDaysIcon,
     get label() { return i18n.t('views:plannings.label.singular') },
     key: 'Planning',
     color: '#FF971E'
   }
-}
+} satisfies DocumentTypeFormat
 
-const assignment: DocumentTypeFormat = {
+const assignment = {
   'core/assignment': {
     icon: BriefcaseBusinessIcon,
     get label() { return i18n.t('views:assignments.title') },
     key: 'Assignment',
     color: '#006bb3'
   }
-}
+} satisfies DocumentTypeFormat
 
-const article: DocumentTypeFormat = {
+const article = {
   'core/article': {
     icon: PenBoxIcon,
     get label() { return i18n.t('shared:assignmentTypes.text') },
@@ -61,36 +61,36 @@ const article: DocumentTypeFormat = {
       icon: PenOffIcon
     }
   }
-}
+} satisfies DocumentTypeFormat
 
-const editorialInfo: DocumentTypeFormat = {
+const editorialInfo = {
   'core/editorial-info': {
     icon: FileWarningIcon,
     get label() { return i18n.t('shared:assignmentTypes.editorial-info') },
     key: 'EditorialInfo',
     color: '#50BEBF'
   }
-}
+} satisfies DocumentTypeFormat
 
-const factbox: DocumentTypeFormat = {
+const factbox = {
   'core/factbox': {
     icon: BoxesIcon,
     get label() { return i18n.t('factbox:title') },
     key: 'Factbox',
     color: '#99c5c4'
   }
-}
+} satisfies DocumentTypeFormat
 
-const flash: DocumentTypeFormat = {
+const flash = {
   'core/flash': {
     icon: ZapIcon,
     get label() { return i18n.t('flash:title') },
     key: 'Flash',
     color: '#FF5150'
   }
-}
+} satisfies DocumentTypeFormat
 
-const timelessArticle: DocumentTypeFormat = {
+const timelessArticle = {
   'core/article#timeless': {
     icon: BookmarkIcon,
     get label() { return i18n.t('shared:assignmentTypes.timeless') },
@@ -100,25 +100,25 @@ const timelessArticle: DocumentTypeFormat = {
       icon: PenOffIcon
     }
   }
-}
+} satisfies DocumentTypeFormat
 
-const quickArticle: DocumentTypeFormat = {
+const quickArticle = {
   'core/article': {
     icon: NewspaperIcon,
     get label() { return i18n.t('quickArticle:title') },
     key: 'QuickArticle',
     color: '#aabbcc'
   }
-}
+} satisfies DocumentTypeFormat
 
-const printArticle: DocumentTypeFormat = {
+const printArticle = {
   'tt/print-article': {
     icon: LibraryIcon,
     get label() { return i18n.t('print:articles.title') },
     key: 'PrintArticle',
     color: '#aabbcc'
   }
-}
+} satisfies DocumentTypeFormat
 
 
 export const documentTypeValueFormat = {

--- a/src/views/Editor/EditorHeader.tsx
+++ b/src/views/Editor/EditorHeader.tsx
@@ -167,10 +167,11 @@ export const EditorHeader = ({ ydoc, readOnly, readOnlyVersion, planningId: prop
       <ViewHeader.Title
         name='Editor'
         preview={readOnly && !readOnlyVersion}
-        title={documentTypeValueFormat?.[documentType || 'core/article']?.label}
+        title={documentTypeValueFormat?.[(documentType || 'core/article') as keyof typeof documentTypeValueFormat]?.label}
         icon={(() => {
-          const fmt = documentTypeValueFormat?.[documentType || 'core/article']
-          return (readOnly && fmt?.readonly?.icon) || fmt?.icon
+          const fmt = documentTypeValueFormat?.[(documentType || 'core/article') as keyof typeof documentTypeValueFormat]
+          const readonlyIcon = fmt && 'readonly' in fmt ? fmt.readonly?.icon : undefined
+          return (readOnly && readonlyIcon) || fmt?.icon
         })()}
         ydoc={!readOnly ? ydoc : undefined}
         titleClassName='hidden @4xl/view:block'


### PR DESCRIPTION
Makes sure the click surface of each dropdown item in the AddButtonGroup component is the entire item container - not just the text surface.