### PR TITLE
fix(assignments): disable action menu open when deliverable missing

### DIFF
--- a/src/views/Assignments/AssignmentColumns.tsx
+++ b/src/views/Assignments/AssignmentColumns.tsx
@@ -385,7 +385,7 @@ export function assignmentColumns<Ns extends Namespace>({ authors = [], locale, 
           ? t('common:actions.openType', { type: typeLabel })
           : t('views:assignments.actionMenu.openArticle')
         return (
-          <div className='shrink p-'>
+          <div className='shrink'>
             <DotMenu
               items={[
                 {

--- a/src/views/Assignments/AssignmentColumns.tsx
+++ b/src/views/Assignments/AssignmentColumns.tsx
@@ -373,22 +373,34 @@ export function assignmentColumns<Ns extends Namespace>({ authors = [], locale, 
         className: 'flex-none p-0'
       },
       cell: ({ row }) => {
-        const deliverableUuid = row.original?.fields['document.meta.core_assignment.rel.deliverable.uuid']?.values[0] || ''
+        const deliverableUuid = row.original?.fields['document.meta.core_assignment.rel.deliverable.uuid']?.values[0]
         const planningId = row.original.id
+        const assignmentTypeValue = row.original?.fields[
+          'document.meta.core_assignment.meta.core_assignment_type.value'
+        ]?.values?.[0]
+        const typeLabel = assignmentTypeValue
+          ? t(`shared:assignmentTypes.${assignmentTypeValue}` as TranslationKey)
+          : undefined
+        const openDeliverableLabel = typeLabel
+          ? t('common:actions.openType', { type: typeLabel })
+          : t('views:assignments.actionMenu.openArticle')
         return (
           <div className='shrink p-'>
             <DotMenu
               items={[
                 {
-                  label: t('views:assignments.actionMenu.openArticle'),
-                  item: (
-                    <Link to='Editor' target='last' props={{ id: deliverableUuid }} className='flex flex-row gap-5'>
-                      <div className='pt-1'>
-                        <PenIcon size={14} strokeWidth={1.5} className='shrink' />
-                      </div>
-                      <div className='grow'>{t('views:assignments.actionMenu.openArticle')}</div>
-                    </Link>
-                  )
+                  label: openDeliverableLabel,
+                  disabled: !deliverableUuid,
+                  item: deliverableUuid
+                    ? (
+                        <Link to='Editor' target='last' props={{ id: deliverableUuid }} className='flex flex-row gap-5'>
+                          <div className='pt-1'>
+                            <PenIcon size={14} strokeWidth={1.5} className='shrink' />
+                          </div>
+                          <div className='grow'>{openDeliverableLabel}</div>
+                        </Link>
+                      )
+                    : () => {}
                 },
                 {
 

--- a/src/views/Assignments/AssignmentColumns.tsx
+++ b/src/views/Assignments/AssignmentColumns.tsx
@@ -31,7 +31,7 @@ import type { Assignment } from '@/shared/schemas/assignments'
 import { parseISO } from 'date-fns'
 import { DotMenu } from '@/components/ui/DotMenu'
 import { Link } from '@/components'
-import { PenIcon, CalendarDaysIcon } from '@ttab/elephant-ui/icons'
+import { PenIcon, CalendarDaysIcon, BanIcon } from '@ttab/elephant-ui/icons'
 import { DocumentStatus } from '@/components/Table/Items/DocumentStatus'
 import { getDocumentStatuses } from '@/defaults/documentStatuses'
 import { selectableStatuses } from '../Planning/components/AssignmentStatus'
@@ -400,7 +400,14 @@ export function assignmentColumns<Ns extends Namespace>({ authors = [], locale, 
                           <div className='grow'>{openDeliverableLabel}</div>
                         </Link>
                       )
-                    : () => {}
+                    : (
+                        <div className='flex flex-row gap-5'>
+                          <div className='pt-1'>
+                            <BanIcon size={14} strokeWidth={1.5} className='shrink' />
+                          </div>
+                          <div className='grow'>{openDeliverableLabel}</div>
+                        </div>
+                      )
                 },
                 {
 
@@ -415,7 +422,14 @@ export function assignmentColumns<Ns extends Namespace>({ authors = [], locale, 
                           <div className='grow'>{t('views:assignments.actionMenu.openPlanning')}</div>
                         </Link>
                       )
-                    : () => {}
+                    : (
+                        <div className='flex flex-row gap-5'>
+                          <div className='pt-1'>
+                            <BanIcon size={14} strokeWidth={1.5} className='shrink' />
+                          </div>
+                          <div className='grow'>{t('views:assignments.actionMenu.openPlanning')}</div>
+                        </div>
+                      )
                 }
               ]}
             />


### PR DESCRIPTION
Show a type-aware label (Öppna bild/video/flash etc.) and disable the item when the row has no deliverable uuid — opening with an empty id landed the Editor on a missing-document error.