### PR TITLE
fix(documents): dedupe error logs (ELELOG-621)

### DIFF
--- a/__tests__/useDocuments.test.tsx
+++ b/__tests__/useDocuments.test.tsx
@@ -1,0 +1,105 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import { SWRConfig } from 'swr'
+import type { ReactNode } from 'react'
+import { useDocuments } from '@/hooks/index/useDocuments'
+
+const { fetchMock, toastErrorMock } = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+  toastErrorMock: vi.fn()
+}))
+
+vi.mock('@/hooks/index/useDocuments/lib/fetch', () => ({
+  fetch: fetchMock
+}))
+
+vi.mock('@/hooks/useRegistry', () => ({
+  useRegistry: () => ({
+    index: {},
+    repository: {}
+  })
+}))
+
+vi.mock('@/hooks/useTable', () => ({
+  useTable: () => ({ setData: vi.fn() })
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: toastErrorMock }
+}))
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <SWRConfig value={{ provider: () => new Map(), errorRetryCount: 0, dedupingInterval: 0 }}>
+    {children}
+  </SWRConfig>
+)
+
+describe('useDocuments error logging', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('logs the failure once per failed fetch, not on every re-render', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    fetchMock.mockRejectedValue(
+      new Error('Unable to query index: invalid authorization: invalid token: token has invalid claims: token is expired')
+    )
+
+    const { rerender } = renderHook(
+      ({ type }: { type: string }) => useDocuments({ documentType: type }),
+      { wrapper, initialProps: { type: 'core/article' } }
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled()
+    })
+
+    rerender({ type: 'core/article' })
+    rerender({ type: 'core/article' })
+    rerender({ type: 'core/article' })
+
+    const documentFetchErrors = consoleErrorSpy.mock.calls.filter((args) =>
+      typeof args[0] === 'string' && args[0].includes('Document fetch failed')
+    )
+
+    expect(documentFetchErrors).toHaveLength(1)
+    expect(toastErrorMock).toHaveBeenCalledTimes(1)
+
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('logs once across multiple consumers sharing the same cache key', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    fetchMock.mockRejectedValue(new Error('boom'))
+
+    const cache = new Map()
+    const sharedWrapper = ({ children }: { children: ReactNode }) => (
+      <SWRConfig value={{ provider: () => cache, errorRetryCount: 0, dedupingInterval: 0 }}>
+        {children}
+      </SWRConfig>
+    )
+
+    renderHook(
+      () => {
+        useDocuments({ documentType: 'core/article' })
+        useDocuments({ documentType: 'core/article' })
+        useDocuments({ documentType: 'core/article' })
+      },
+      { wrapper: sharedWrapper }
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled()
+    })
+
+    const documentFetchErrors = consoleErrorSpy.mock.calls.filter((args) =>
+      typeof args[0] === 'string' && args[0].includes('Document fetch failed')
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(documentFetchErrors).toHaveLength(1)
+    expect(toastErrorMock).toHaveBeenCalledTimes(1)
+
+    consoleErrorSpy.mockRestore()
+  })
+})

--- a/src/hooks/index/useDocuments/index.ts
+++ b/src/hooks/index/useDocuments/index.ts
@@ -104,7 +104,12 @@ export const useDocuments = <T extends HitV1, F>({ documentType, query, size, pa
     }),
   [index, repository, session, page, size, documentType, query, fields, sort, options])
 
-  const { data, error, mutate, isLoading, isValidating } = useSWR<T[], Error>(key, fetcher)
+  const { data, error, mutate, isLoading, isValidating } = useSWR<T[], Error>(key, fetcher, {
+    onError: (err) => {
+      console.error('Document fetch failed:', err)
+      toast.error(t('errors:messages.failedFetchingDocument'))
+    }
+  })
 
   // Keep refs up to date for polling
   useEffect(() => {
@@ -112,11 +117,6 @@ export const useDocuments = <T extends HitV1, F>({ documentType, query, size, pa
     mutateRef.current = mutate
     dataRef.current = data
   }, [subscriptions, mutate, data])
-
-  if (error) {
-    console.error('Document fetch failed:', error)
-    toast.error(t('errors:messages.failedFetchingDocument'))
-  }
 
   // Set table data after fetch
   useEffect(() => {


### PR DESCRIPTION
useDocuments called console.error and toast.error from the render body whenever the SWR error was set. Each consuming list view re-ran the side effect on every render, multiplying a single failed fetch into a flood of identical Faro entries and stacked toasts — particularly visible on pages where multiple list-style consumers (e.g. PlanningList + DuplicatesTable) are mounted at once.

Move the side effects into useSWR's onError option so they fire once per failed fetch attempt, regardless of consumer count or re-render frequency.