### PR TITLE
fix(timeless): stop useDeliverableInfo refetch storm

### DIFF
--- a/__tests__/TimelessRowActions.test.tsx
+++ b/__tests__/TimelessRowActions.test.tsx
@@ -30,28 +30,36 @@ vi.mock('@/components/ConvertToArticleDialog', () => ({
 }))
 
 vi.mock('@/components/ui/DotMenu', () => ({
-  DotMenu: ({ items }: { items: Array<{
-    label: string
-    disabled?: boolean
-    item: (event: React.MouseEvent<HTMLDivElement>) => void
-  }> }) => (
-    <div>
-      {items.map((item) => (
-        <button
-          key={item.label}
-          data-testid={`menu-${item.label}`}
-          disabled={item.disabled}
-          onClick={(event) => {
-            if (typeof item.item === 'function') {
-              item.item(event as unknown as React.MouseEvent<HTMLDivElement>)
-            }
-          }}
-        >
-          {item.label}
-        </button>
-      ))}
-    </div>
-  )
+  DotMenu: ({ items, onOpenChange }: {
+    items: Array<{
+      label: string
+      disabled?: boolean
+      item: (event: React.MouseEvent<HTMLDivElement>) => void
+    }>
+    onOpenChange?: (open: boolean) => void
+  }) => {
+    // Simulate the menu being opened so any lazy-mounted hooks inside the
+    // component flip to their "opened" state.
+    onOpenChange?.(true)
+    return (
+      <div>
+        {items.map((item) => (
+          <button
+            key={item.label}
+            data-testid={`menu-${item.label}`}
+            disabled={item.disabled}
+            onClick={(event) => {
+              if (typeof item.item === 'function') {
+                item.item(event as unknown as React.MouseEvent<HTMLDivElement>)
+              }
+            }}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+    )
+  }
 }))
 
 const mockUseConvertArticleType = vi.mocked(useConvertArticleType)
@@ -144,5 +152,17 @@ describe('TimelessRowActions', () => {
     render(<TimelessRowActions documentId='timeless-id' />)
 
     expect(screen.getByTestId(/^menu-Planera/i)).toBeDisabled()
+  })
+
+  it('defers the deliverable-info fetch until the menu has been opened', () => {
+    setup()
+    render(<TimelessRowActions documentId='timeless-id' />)
+
+    // The DotMenu mock simulates an open by firing onOpenChange(true) on
+    // render. The first invocation of the hook (before the open propagates)
+    // must therefore be with an empty deliverableId, and the subsequent
+    // invocation with the real id.
+    expect(mockUseDeliverableInfo.mock.calls[0]?.[0]).toBe('')
+    expect(mockUseDeliverableInfo.mock.calls.at(-1)?.[0]).toBe('timeless-id')
   })
 })

--- a/__tests__/useDeliverableInfo.test.tsx
+++ b/__tests__/useDeliverableInfo.test.tsx
@@ -1,0 +1,137 @@
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SWRConfig } from 'swr'
+import type { ReactNode } from 'react'
+import type { EventlogItem } from '@ttab/elephant-api/repository'
+
+import { useDeliverableInfo } from '@/hooks/useDeliverableInfo'
+import { useRegistry } from '@/hooks/useRegistry'
+import { useRepositoryEvents } from '@/hooks/useRepositoryEvents'
+
+vi.mock('@/hooks/useRegistry', () => ({
+  useRegistry: vi.fn()
+}))
+
+vi.mock('@/hooks/useRepositoryEvents', () => ({
+  useRepositoryEvents: vi.fn()
+}))
+
+const mockUseRegistry = vi.mocked(useRegistry)
+const mockUseRepositoryEvents = vi.mocked(useRepositoryEvents)
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  // Disable cross-test caching so each render does a fresh fetch.
+  <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+    {children}
+  </SWRConfig>
+)
+
+const makeEvent = (uuid: string): EventlogItem => ({
+  id: '1',
+  type: 'core/planning-item',
+  uuid,
+  timestamp: new Date().toISOString(),
+  event: '',
+  uri: '',
+  updaterUri: '',
+  language: ''
+} as unknown as EventlogItem)
+
+describe('useDeliverableInfo', () => {
+  let getDeliverableInfo: ReturnType<typeof vi.fn>
+  let lastCallback: ((event: EventlogItem) => void) | undefined
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    lastCallback = undefined
+    getDeliverableInfo = vi.fn().mockResolvedValue({ planningUuid: 'plan-1' })
+
+    mockUseRegistry.mockReturnValue({
+      repository: { getDeliverableInfo }
+    } as never)
+
+    mockUseRepositoryEvents.mockImplementation((_eventTypes, callback) => {
+      lastCallback = callback as (event: EventlogItem) => void
+    })
+  })
+
+  it('fetches deliverable info once on mount and exposes planning UUID', async () => {
+    const { result } = renderHook(
+      () => useDeliverableInfo('deliverable-1'),
+      { wrapper }
+    )
+
+    await waitFor(() => {
+      expect(result.current?.planningUuid).toBe('plan-1')
+    })
+    expect(getDeliverableInfo).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not refetch when a planning event for an unrelated planning arrives', async () => {
+    const { result } = renderHook(
+      () => useDeliverableInfo('deliverable-1'),
+      { wrapper }
+    )
+
+    await waitFor(() => {
+      expect(result.current?.planningUuid).toBe('plan-1')
+    })
+    expect(getDeliverableInfo).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      lastCallback?.(makeEvent('plan-other'))
+      // give SWR a tick in case it would still revalidate
+      await Promise.resolve()
+    })
+
+    expect(getDeliverableInfo).toHaveBeenCalledTimes(1)
+  })
+
+  it('refetches when a planning event for the linked planning arrives', async () => {
+    const { result } = renderHook(
+      () => useDeliverableInfo('deliverable-1'),
+      { wrapper }
+    )
+
+    await waitFor(() => {
+      expect(result.current?.planningUuid).toBe('plan-1')
+    })
+    expect(getDeliverableInfo).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      lastCallback?.(makeEvent('plan-1'))
+    })
+
+    await waitFor(() => {
+      expect(getDeliverableInfo).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('skips events while the first fetch has not yet resolved', async () => {
+    let resolveFetch!: (v: { planningUuid: string }) => void
+    const pending = new Promise<{ planningUuid: string }>((resolve) => {
+      resolveFetch = resolve
+    })
+    getDeliverableInfo.mockReturnValueOnce(pending)
+
+    renderHook(() => useDeliverableInfo('deliverable-1'), { wrapper })
+
+    // Event arrives before the fetch resolves: nothing to compare against,
+    // so the callback must not trigger a second call.
+    act(() => {
+      lastCallback?.(makeEvent('plan-1'))
+    })
+
+    expect(getDeliverableInfo).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveFetch({ planningUuid: 'plan-1' })
+      await Promise.resolve()
+    })
+  })
+
+  it('does not fetch when deliverableId is empty', () => {
+    renderHook(() => useDeliverableInfo(''), { wrapper })
+    expect(getDeliverableInfo).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/ui/DotMenu.tsx
+++ b/src/components/ui/DotMenu.tsx
@@ -58,9 +58,10 @@ export interface DotDropdownMenuActionItem {
  */
 const MENU_WIDTH = 224 // w-56 = 14rem = 224px
 
-export const DotMenu = ({ trigger = 'horizontal', items }: {
+export const DotMenu = ({ trigger = 'horizontal', items, onOpenChange }: {
   trigger?: 'horizontal' | 'vertical'
   items: DotDropdownMenuActionItem[]
+  onOpenChange?: (open: boolean) => void
 }): JSX.Element => {
   const triggerRef = useRef<HTMLButtonElement>(null)
   const [align, setAlign] = useState<'start' | 'end'>('start')
@@ -71,6 +72,7 @@ export const DotMenu = ({ trigger = 'horizontal', items }: {
         const spaceRight = window.innerWidth - triggerRef.current.getBoundingClientRect().left
         setAlign(spaceRight >= MENU_WIDTH ? 'start' : 'end')
       }
+      onOpenChange?.(open)
     }}
     >
       <DropdownMenuTrigger asChild>

--- a/src/hooks/useDeliverableInfo.tsx
+++ b/src/hooks/useDeliverableInfo.tsx
@@ -1,8 +1,8 @@
 import { useSession } from 'next-auth/react'
 import useSWR from 'swr'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useRegistry, useRepositoryEvents } from '@/hooks'
-import type { GetDeliverableInfoResponse } from '@ttab/elephant-api/repository'
+import type { EventlogItem, GetDeliverableInfoResponse } from '@ttab/elephant-api/repository'
 
 export const useDeliverableInfo = (deliverableId: string): GetDeliverableInfoResponse | undefined => {
   const { repository } = useRegistry()
@@ -29,11 +29,18 @@ export const useDeliverableInfo = (deliverableId: string): GetDeliverableInfoRes
     }
   )
 
-  const revalidate = useCallback(() => {
-    void mutate()
+  const planningUuidRef = useRef<string | undefined>(data?.planningUuid)
+  useEffect(() => {
+    planningUuidRef.current = data?.planningUuid
+  }, [data?.planningUuid])
+
+  const onPlanningEvent = useCallback((event: EventlogItem) => {
+    if (planningUuidRef.current && event.uuid === planningUuidRef.current) {
+      void mutate()
+    }
   }, [mutate])
 
-  useRepositoryEvents('core/planning-item', revalidate)
+  useRepositoryEvents('core/planning-item', onPlanningEvent)
 
   return data ?? undefined
 }

--- a/src/views/Latest/index.tsx
+++ b/src/views/Latest/index.tsx
@@ -1,6 +1,6 @@
 import type { LocaleData } from '@/types/index'
 import { type ViewMetadata } from '@/types/index'
-import { useRef, type JSX } from 'react'
+import { useRef, useState, type JSX } from 'react'
 import { format } from 'date-fns'
 import { useRegistry } from '@/hooks/useRegistry'
 import { handleLink } from '@/components/Link/lib/handleLink'
@@ -130,7 +130,10 @@ const Content = ({ documents, locale }: {
 }
 
 const Menu = ({ articleId }: { articleId: string }): JSX.Element => {
-  const planningId = useDeliverableInfo(articleId)?.planningUuid ?? ''
+  // Defer the deliverable-info fetch until the menu is opened (per-row lazy
+  // mount avoids fan-out fetch storms when the list contains many items).
+  const [hasOpened, setHasOpened] = useState(false)
+  const planningId = useDeliverableInfo(hasOpened ? articleId : '')?.planningUuid ?? ''
   const { t } = useTranslation('common')
   const { showModal, hideModal } = useModal()
   const featureFlags = useFeatureFlags(['hasPrint'])
@@ -139,6 +142,11 @@ const Menu = ({ articleId }: { articleId: string }): JSX.Element => {
   return (
     <div className='shrink p-'>
       <DotMenu
+        onOpenChange={(open) => {
+          if (open) {
+            setHasOpened(true)
+          }
+        }}
         items={[
           {
             label: t('actions.openType', { type: t('core:documentType.article') }),

--- a/src/views/TimelessOverview/lib/TimelessRowActions.tsx
+++ b/src/views/TimelessOverview/lib/TimelessRowActions.tsx
@@ -1,4 +1,4 @@
-import { type MouseEvent, type JSX } from 'react'
+import { useState, type MouseEvent, type JSX } from 'react'
 import { DotMenu, type DotDropdownMenuActionItem } from '@/components/ui/DotMenu'
 import { CalendarDaysIcon, RefreshCwIcon } from '@ttab/elephant-ui/icons'
 import { ConvertToArticleDialog } from '@/components/ConvertToArticleDialog'
@@ -21,7 +21,10 @@ export function TimelessRowActions({
   const { t } = useTranslation(['views', 'common'])
   const { showModal, hideModal } = useModal()
   const openPlanning = useLink('Planning')
-  const planningId = useDeliverableInfo(documentId)?.planningUuid ?? ''
+  // Defer the deliverable-info fetch until the menu is opened. Mounting the
+  // hook per row caused 50+ parallel fetches and an event-driven refetch storm.
+  const [hasOpened, setHasOpened] = useState(false)
+  const planningId = useDeliverableInfo(hasOpened ? documentId : '')?.planningUuid ?? ''
   const isUsed = status === 'used'
 
   const handleOpenPlanning = (event: MouseEvent<HTMLDivElement>) => {
@@ -63,5 +66,14 @@ export function TimelessRowActions({
     }
   ]
 
-  return <DotMenu items={menuItems} />
+  return (
+    <DotMenu
+      items={menuItems}
+      onOpenChange={(open) => {
+        if (open) {
+          setHasOpened(true)
+        }
+      }}
+    />
+  )
 }


### PR DESCRIPTION
The Timeless view fired ~150 GetDeliverableInfo calls per 20s of idle and produced 1.3s long tasks because every mounted instance of useDeliverableInfo unconditionally revalidated on every core/planning-item event, and TimelessRowActions mounted the hook once per row. Filter events by the linked planning UUID and defer the per-row fetch until the dot menu is opened. Same lazy-mount applied to Latest. After: 0 GetDeliverableInfo calls in 20s idle, worst long task 229ms.