### PR TITLE
fix: remove onRowSelected callback

### DIFF
--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -1,6 +1,5 @@
 import {
   type MouseEvent,
-  useEffect,
   useCallback,
   useMemo,
   type JSX
@@ -38,7 +37,6 @@ const BASE_URL = import.meta.env.BASE_URL
 interface TableProps<TData, TValue> {
   columns: Array<ColumnDef<TData, TValue>>
   type: 'Planning' | 'Event' | 'Assignments' | 'Search' | 'Factbox' | 'Print' | 'PrintEditor' | 'Timeless'
-  onRowSelected?: (row?: TData) => void
 }
 
 function getNextTableIndex(
@@ -75,7 +73,6 @@ function getNextTableIndex(
 export const Table = <TData, TValue>({
   columns,
   type,
-  onRowSelected,
   searchType
 }: TableProps<TData, TValue> & { searchType?: View }): JSX.Element => {
   const { state, dispatch } = useNavigation()
@@ -89,10 +86,6 @@ export const Table = <TData, TValue>({
   const handleOpen = useCallback((event: MouseEvent<HTMLTableRowElement> | KeyboardEvent, row: RowType<unknown>): void => {
     const target = event.target as HTMLElement
     if (target && 'dataset' in target && !target.dataset.rowAction) {
-      if (!onRowSelected) {
-        return
-      }
-
       const originalRow = row.original as { _id: string | undefined, id: string, fields?: Record<string, string[]> }
       const id = originalRow._id ?? originalRow.id
 
@@ -120,7 +113,7 @@ export const Table = <TData, TValue>({
         })
       })
     }
-  }, [dispatch, state.viewRegistry, onRowSelected, origin, type, history, searchType])
+  }, [dispatch, state.viewRegistry, origin, type, history, searchType])
 
   useNavigationKeys({
     keys: ['ArrowUp', 'ArrowDown', 'Enter', 'Escape', ' '],
@@ -163,14 +156,6 @@ export const Table = <TData, TValue>({
       }
     }
   })
-
-  useEffect(() => {
-    if (onRowSelected) {
-      const selectedRows = table.getSelectedRowModel()
-      // @ts-expect-error unknown type
-      onRowSelected(selectedRows?.rows[0]?.original)
-    }
-  }, [table, onRowSelected])
 
   const rows = table.getRowModel().rows
   const rowSelection = table.getState().rowSelection

--- a/src/views/Assignments/AssignmentsList.tsx
+++ b/src/views/Assignments/AssignmentsList.tsx
@@ -40,13 +40,6 @@ export const AssignmentsList = ({ columns, date }: {
     <Table
       type='Planning'
       columns={columns}
-      onRowSelected={(row): void => {
-        if (row) {
-          console.info(`Selected assignment item ${row.id}`)
-        } else {
-          console.info('Deselected row')
-        }
-      }}
     />
   )
 }

--- a/src/views/EventsOverview/EventsList.tsx
+++ b/src/views/EventsOverview/EventsList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, type JSX } from 'react'
+import { useMemo, type JSX } from 'react'
 import { useOrganisers, useQuery, useRegistry, useSections } from '@/hooks'
 import type { EventFields } from '@/shared/schemas/event'
 import { type Event, fields } from '@/shared/schemas/event'
@@ -41,15 +41,6 @@ export const EventsList = (): JSX.Element => {
 
   const columns = useMemo(() => eventTableColumns({ sections, organisers, locale }, t), [sections, organisers, locale, t])
 
-  const onRowSelected = useCallback((row?: Event) => {
-    if (row) {
-      console.info(`Selected planning item ${row.id}`)
-    } else {
-      console.info('Deselected row')
-    }
-    return row
-  }, [])
-
   if (error) {
     console.error('Error fetching event items:', error)
     toast.error(t('errors:toasts.getEventsFailed'))
@@ -59,7 +50,6 @@ export const EventsList = (): JSX.Element => {
     <Table
       type='Event'
       columns={columns}
-      onRowSelected={onRowSelected}
     />
   )
 }

--- a/src/views/PlanningOverview/PlanningList.tsx
+++ b/src/views/PlanningOverview/PlanningList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, type JSX } from 'react'
+import { useMemo, type JSX } from 'react'
 
 import { Table } from '@/components/Table'
 import { useDocuments } from '@/hooks/index/useDocuments'
@@ -38,16 +38,6 @@ export const PlanningList = ({ columns }: {
     }
   })
 
-  const onRowSelected = useCallback((row?: Planning) => {
-    if (row) {
-      console.info(`Selected planning item ${row.id}`)
-    } else {
-      console.info('Deselected row')
-    }
-    return row
-  }, [])
-
-
   if (error) {
     console.error('Error fetching planning items:', error)
     toast.error(t('errors:toasts.getPlanningsFailed'))
@@ -58,7 +48,6 @@ export const PlanningList = ({ columns }: {
     <Table
       type='Planning'
       columns={columns}
-      onRowSelected={onRowSelected}
     />
   )
 }

--- a/src/views/PrintArticles/PrintArticlesList.tsx
+++ b/src/views/PrintArticles/PrintArticlesList.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from 'react'
 import { useQuery } from '@/hooks'
 import { Table } from '@/components/Table'
 import type { PrintArticle } from '@/hooks/baboon/lib/printArticles'
@@ -15,7 +14,7 @@ import type { JSX } from 'react'
  * This component renders a list of print articles using a table. It utilizes the
  * `usePrintArticles` hook to fetch and manage the state of print articles based on
  * the provided filter query. The component also includes a toolbar for additional
- * actions and a callback function to handle row selection in the table.
+ * actions.
  *
  * @param props - The component props.
  * @param props.columns - The column definitions for the table.
@@ -23,7 +22,6 @@ import type { JSX } from 'react'
  *
  * @remarks
  * The component uses the `useQuery` hook to extract filter parameters from the query string.
- * It also defines a `onRowSelected` callback to log the selected or deselected row information.
  */
 
 export const PrintArticleList = ({ columns }: {
@@ -46,21 +44,11 @@ export const PrintArticleList = ({ columns }: {
     }
   })
 
-  const onRowSelected = useCallback((row?: PrintArticle) => {
-    if (row) {
-      console.info(`Selected planning item ${row.id}`)
-    } else {
-      console.info('Deselected row')
-    }
-    return row
-  }, [])
-
   return (
     <>
       <Table
         type='PrintEditor'
         columns={columns}
-        onRowSelected={onRowSelected}
       />
     </>
   )

--- a/src/views/SearchOverview/SearchResult.tsx
+++ b/src/views/SearchOverview/SearchResult.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, type JSX } from 'react'
+import { useMemo, type JSX } from 'react'
 import { Table } from '@/components/Table'
 import { useRegistry } from '@/hooks/useRegistry'
 import { useSections } from '@/hooks/useSections'
@@ -30,15 +30,6 @@ export const SearchResult = ({ searchType, page }: {
   const { locale, timeZone } = useRegistry()
 
   const getType = (searchType: SearchKeys) => searchType === 'events' ? 'Event' : searchType === 'articles' ? 'Editor' : 'Planning'
-
-  const onRowSelected = useCallback((row?: Planning | Event) => {
-    if (row) {
-      console.info(`Selected planning item ${row.id}`)
-    } else {
-      console.info('Deselected row')
-    }
-    return row
-  }, [])
 
   const searchParams = search[searchType].params(filter)
 
@@ -78,7 +69,6 @@ export const SearchResult = ({ searchType, page }: {
                 type='Search'
                 searchType={getType(searchType)}
                 columns={columns as ColumnDef<Planning | Event>[]}
-                onRowSelected={onRowSelected}
               />
             </>
           )}

--- a/src/views/TimelessOverview/TimelessList.tsx
+++ b/src/views/TimelessOverview/TimelessList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, type JSX } from 'react'
+import { useEffect, type JSX } from 'react'
 import { useQuery, type QueryParams } from '@/hooks/useQuery'
 import { Table } from '@/components/Table'
 import { Pagination } from '@/components/Table/Pagination'
@@ -31,15 +31,12 @@ export const TimelessList = ({ columns }: {
     }
   })
 
-  const onRowSelected = useCallback(() => {}, [])
-
   return (
     <>
       <Table
         type='Timeless'
         searchType='Editor'
         columns={columns as ColumnDef<TimelessArticle>[]}
-        onRowSelected={onRowSelected}
       />
       <Pagination />
     </>


### PR DESCRIPTION
The onRowSelected callback effectively prevented Table items from being opened, if not provided from the parent component. As no current handler did anything other than to log the current row selected, this should be removed.