### PR TITLE
fix(timeless): block convert-to-timeless for published articles

### DIFF
--- a/__tests__/ArticleTypeConversion.test.tsx
+++ b/__tests__/ArticleTypeConversion.test.tsx
@@ -7,6 +7,7 @@ import { ArticleTypeConversion } from '@/components/ArticleTypeConversion'
 import { useConvertArticleType } from '@/hooks/useConvertArticleType'
 import { useLink } from '@/hooks/useLink'
 import { useModal } from '@/components/Modal/useModal'
+import { useWorkflowStatus } from '@/hooks/useWorkflowStatus'
 import type * as Y from 'yjs'
 import type { YDocument } from '@/modules/yjs/hooks'
 
@@ -22,6 +23,10 @@ vi.mock('@/components/Modal/useModal', () => ({
   useModal: vi.fn()
 }))
 
+vi.mock('@/hooks/useWorkflowStatus', () => ({
+  useWorkflowStatus: vi.fn()
+}))
+
 vi.mock('@/components/ConvertToArticleDialog', () => ({
   ConvertToArticleDialog: () => null
 }))
@@ -33,6 +38,7 @@ vi.mock('@/components/ConvertToTimelessDialog', () => ({
 const mockUseConvertArticleType = vi.mocked(useConvertArticleType)
 const mockUseLink = vi.mocked(useLink)
 const mockUseModal = vi.mocked(useModal)
+const mockUseWorkflowStatus = vi.mocked(useWorkflowStatus)
 
 const mockYdoc = {
   id: 'doc-id',
@@ -53,6 +59,11 @@ function setup() {
   mockUseConvertArticleType.mockReturnValue({ isConverting: false } as never)
   mockUseLink.mockReturnValue(openEditor)
   mockUseModal.mockReturnValue({ showModal, hideModal } as never)
+  mockUseWorkflowStatus.mockReturnValue([
+    { name: 'draft', checkpoint: 'draft' },
+    vi.fn(),
+    vi.fn()
+  ] as never)
 
   return { openEditor, showModal, hideModal }
 }
@@ -132,8 +143,66 @@ describe('ArticleTypeConversion', () => {
     mockUseConvertArticleType.mockReturnValue({ isConverting: true } as never)
     mockUseLink.mockReturnValue(openEditor)
     mockUseModal.mockReturnValue({ showModal, hideModal } as never)
+    mockUseWorkflowStatus.mockReturnValue([
+      { name: 'draft', checkpoint: 'draft' },
+      vi.fn(),
+      vi.fn()
+    ] as never)
 
     render(<ArticleTypeConversion ydoc={mockYdoc} documentType='core/article#timeless' />)
     expect(screen.getByRole('button')).toBeDisabled()
   })
+
+  it('disables the convert-to-timeless button when the article has been published', () => {
+    setup()
+    mockUseWorkflowStatus.mockReturnValue([
+      { name: 'usable', checkpoint: 'usable' },
+      vi.fn(),
+      vi.fn()
+    ] as never)
+
+    render(<ArticleTypeConversion ydoc={mockYdoc} documentType='core/article' />)
+    expect(screen.getByRole('button', { name: /tidlös/i })).toBeDisabled()
+  })
+
+  it('disables the convert-to-timeless button for an unpublished article whose checkpoint reached usable', () => {
+    setup()
+    mockUseWorkflowStatus.mockReturnValue([
+      { name: 'unpublished', checkpoint: 'usable' },
+      vi.fn(),
+      vi.fn()
+    ] as never)
+
+    render(<ArticleTypeConversion ydoc={mockYdoc} documentType='core/article' />)
+    expect(screen.getByRole('button', { name: /tidlös/i })).toBeDisabled()
+  })
+
+  it('does not open the timeless dialog when the article has been published', async () => {
+    const { showModal } = setup()
+    mockUseWorkflowStatus.mockReturnValue([
+      { name: 'usable', checkpoint: 'usable' },
+      vi.fn(),
+      vi.fn()
+    ] as never)
+
+    render(<ArticleTypeConversion ydoc={mockYdoc} documentType='core/article' />)
+    await userEvent.click(screen.getByRole('button', { name: /tidlös/i }))
+
+    expect(showModal).not.toHaveBeenCalled()
+  })
+
+  it.each(['draft', 'done', 'approved'])(
+    'enables the convert-to-timeless button when checkpoint is %s',
+    (checkpoint) => {
+      setup()
+      mockUseWorkflowStatus.mockReturnValue([
+        { name: checkpoint, checkpoint },
+        vi.fn(),
+        vi.fn()
+      ] as never)
+
+      render(<ArticleTypeConversion ydoc={mockYdoc} documentType='core/article' />)
+      expect(screen.getByRole('button', { name: /tidlös/i })).toBeEnabled()
+    }
+  )
 })

--- a/src/components/ArticleTypeConversion.tsx
+++ b/src/components/ArticleTypeConversion.tsx
@@ -7,6 +7,7 @@ import type * as Y from 'yjs'
 import { useConvertArticleType } from '@/hooks/useConvertArticleType'
 import { useLink } from '@/hooks/useLink'
 import { useModal } from '@/components/Modal/useModal'
+import { useWorkflowStatus } from '@/hooks/useWorkflowStatus'
 import { ConvertToArticleDialog } from './ConvertToArticleDialog'
 import { ConvertToTimelessDialog } from './ConvertToTimelessDialog'
 
@@ -23,6 +24,8 @@ export const ArticleTypeConversion = ({ ydoc, documentType }: {
   const { isConverting } = useConvertArticleType()
   const { showModal, hideModal } = useModal()
   const openEditor = useLink('Editor')
+  const [status] = useWorkflowStatus({ documentId: ydoc.id })
+  const isPublished = status?.checkpoint === 'usable'
 
   if (documentType !== 'core/article' && documentType !== 'core/article#timeless') {
     return null
@@ -73,16 +76,21 @@ export const ArticleTypeConversion = ({ ydoc, documentType }: {
         </Button>
       )}
       {documentType === 'core/article' && (
-        <Button
-          variant='outline'
-          size='sm'
-          className='gap-1.5 text-muted-foreground'
-          disabled={isConverting}
-          onClick={openToTimeless}
+        <span
+          title={isPublished ? t('convertToTimeless.publishedDisabled') : undefined}
+          className='inline-flex'
         >
-          <RefreshCwIcon size={14} strokeWidth={1.75} className={iconClassName} />
-          {t('actions.convertToTimeless')}
-        </Button>
+          <Button
+            variant='outline'
+            size='sm'
+            className='gap-1.5 text-muted-foreground w-full'
+            disabled={isConverting || isPublished}
+            onClick={openToTimeless}
+          >
+            <RefreshCwIcon size={14} strokeWidth={1.75} className={iconClassName} />
+            {t('actions.convertToTimeless')}
+          </Button>
+        </span>
       )}
     </>
   )

--- a/src/locales/en/metaSheet.json
+++ b/src/locales/en/metaSheet.json
@@ -31,7 +31,8 @@
     "noPlanningHint": "No original planning was found — a new planning will be created from the timeless."
   },
   "convertToTimeless": {
-    "description": "Pick a subject category for the new timeless. The article remains in place."
+    "description": "Pick a subject category for the new timeless. The article remains in place.",
+    "publishedDisabled": "Published articles cannot be saved as timeless."
   },
   "removeHastPrompt": {
     "title": "Remove HAST from article",

--- a/src/locales/nb/metaSheet.json
+++ b/src/locales/nb/metaSheet.json
@@ -31,7 +31,8 @@
     "noPlanningHint": "Ingen opprinnelig plan ble funnet — en ny plan opprettes fra den tidløse."
   },
   "convertToTimeless": {
-    "description": "Velg kategori for den nye tidløse artikkelen. Den opprinnelige artikkelen er fortsatt tilgjengelig."
+    "description": "Velg kategori for den nye tidløse artikkelen. Den opprinnelige artikkelen er fortsatt tilgjengelig.",
+    "publishedDisabled": "Publiserte artikler kan ikke lagres som tidløse."
   },
   "removeHastPrompt": {
     "title": "Fjern HAST fra artikkelen",

--- a/src/locales/sv/metaSheet.json
+++ b/src/locales/sv/metaSheet.json
@@ -31,7 +31,8 @@
     "noPlanningHint": "Ingen ursprunglig planering hittades — en ny planering skapas från tidlös."
   },
   "convertToTimeless": {
-    "description": "Välj kategori för den nya tidlösa artikeln. Den ursprungliga artikeln finns kvar."
+    "description": "Välj kategori för den nya tidlösa artikeln. Den ursprungliga artikeln finns kvar.",
+    "publishedDisabled": "Publicerade artiklar kan inte sparas som tidlösa."
   },
   "removeHastPrompt": {
     "title": "Ta bort HAST från artikeln",

--- a/src/views/Planning/components/AssignmentRow.tsx
+++ b/src/views/Planning/components/AssignmentRow.tsx
@@ -320,7 +320,7 @@ export const AssignmentRow = ({ ydoc, index, onSelect, isFocused = false, asDial
     ...(assignmentType === 'text' && documentId
       ? [{
           label: t('planning:assignment.convertToTimeless'),
-          disabled: isConverting || articleStatus?.meta?.workflowState === 'used',
+          disabled: isConverting || articleStatus?.meta?.workflowState === 'used' || isUsable,
           icon: RefreshCwIcon,
           item: () => {
             showModal(


### PR DESCRIPTION
Disable the Convert -> Timeless action in the meta sheet and the planning row menu when the article's workflowCheckpoint is 'usable'. Adds a tooltip explaining why the action is unavailable.