### PR TITLE
perf(factboxes): cap merged list at size

### DIFF
--- a/__tests__/withArticleFactboxes.test.ts
+++ b/__tests__/withArticleFactboxes.test.ts
@@ -355,5 +355,56 @@ describe('withArticleFactboxes', () => {
         'Older'
       ])
     })
+
+    it('caps merged result length, keeping the freshest items across both sources', async () => {
+      const standaloneOld = {
+        id: 'fb-old',
+        fields: {
+          'document.title': { values: ['Old standalone'] },
+          modified: { values: ['2026-01-01T00:00:00Z'] }
+        }
+      } as unknown as HitV1
+      const standaloneNew = {
+        id: 'fb-new',
+        fields: {
+          'document.title': { values: ['New standalone'] },
+          modified: { values: ['2026-05-10T00:00:00Z'] }
+        }
+      } as unknown as HitV1
+
+      vi.mocked(fetchMock).mockResolvedValue([
+        makeArticleHit('article', ['Article A', 'Article B'], '2026-05-01T00:00:00Z')
+      ] as unknown as HitV1[])
+      getDocumentsMock.mockResolvedValueOnce({
+        items: [makeBulkItem('article', [makeBlock(), makeBlock()])]
+      })
+
+      const out = await withArticleFactboxes<HitV1>({
+        hits: [standaloneOld, standaloneNew],
+        session,
+        index,
+        repository,
+        size: 2
+      })
+
+      expect(out).toHaveLength(2)
+      expect(out.map((r) => r.fields['document.title']?.values[0])).toEqual([
+        'New standalone',
+        'Article A'
+      ])
+    })
+
+    it('does not cap when cap is undefined', async () => {
+      vi.mocked(fetchMock).mockResolvedValue([
+        makeArticleHit('a', ['One', 'Two', 'Three'])
+      ] as unknown as HitV1[])
+      getDocumentsMock.mockResolvedValueOnce({
+        items: [makeBulkItem('a', [makeBlock(), makeBlock(), makeBlock()])]
+      })
+
+      const out = await withArticleFactboxes<HitV1>({ hits: [], session, index, repository })
+
+      expect(out).toHaveLength(3)
+    })
   })
 })

--- a/src/hooks/index/useDocuments/index.ts
+++ b/src/hooks/index/useDocuments/index.ts
@@ -21,6 +21,9 @@ import { useTranslation } from 'react-i18next'
  * @property {boolean} withPlannings - Append `_relatedPlannings` to the result.
  * @property {boolean} setTableData - Set the data in the table context.
  * @property {boolean} subscribe - Subscribe to document changes.
+ * @property {boolean | 'only'} withArticleFactboxes - Merge article-embedded
+ *   factboxes into the result. `true` runs both queries; `'only'` skips the
+ *   standalone fetch and returns article-side rows alone.
  */
 export interface useDocumentsFetchOptions {
   aggregatePages?: boolean
@@ -29,7 +32,7 @@ export interface useDocumentsFetchOptions {
   asAssignments?: boolean
   setTableData?: boolean
   subscribe?: boolean
-  withArticleFactboxes?: boolean
+  withArticleFactboxes?: boolean | 'only'
 }
 
 class AbortError extends Error { }
@@ -71,12 +74,17 @@ export const useDocuments = <T extends HitV1, F>({ documentType, query, size, pa
   const optionsRef = useRef(options)
   const { t } = useTranslation('common')
 
+  // Options that change the fetch shape are part of the cache key so toggling
+  // them (e.g. the Factboxes "Original / From article" radio) refetches
+  // instead of reusing cached data filtered client-side.
+  const articleFactboxesMode = options?.withArticleFactboxes ?? false
   const key = useMemo(() => {
     if (disabled) return null
-    return query
+    const base = query
       ? `${documentType}/${JSON.stringify(query, (_, v: unknown) => typeof v === 'bigint' ? v.toString() : v)}${page ? `/${page}` : ''}`
       : documentType
-  }, [disabled, query, page, documentType])
+    return `${base}/${articleFactboxesMode}`
+  }, [disabled, query, page, documentType, articleFactboxesMode])
 
   // When the key changes, the old server-side subscription is no longer valid.
   // Clear subscriptions so the polling effect doesn't restart with stale references.

--- a/src/hooks/index/useDocuments/lib/fetch.ts
+++ b/src/hooks/index/useDocuments/lib/fetch.ts
@@ -40,26 +40,34 @@ export async function fetch<T extends HitV1, F>({
     throw new Error('Index or access token is missing')
   }
 
-  const { ok, hits, errorMessage, subscriptions } = await index.query<T, F>({
-    documentType,
-    fields,
-    accessToken: session.accessToken,
-    query,
-    size,
-    page,
-    sort,
-    options
-  })
+  // 'only' mode skips the standalone index query and returns article-embedded
+  // factboxes alone. No standalone hits, no standalone subscription.
+  const skipStandalone = options?.withArticleFactboxes === 'only'
 
-  if (!ok) {
-    throw new Error(errorMessage || 'Unknown error while fetching data')
+  let result: T[] = []
+
+  if (!skipStandalone) {
+    const { ok, hits, errorMessage, subscriptions } = await index.query<T, F>({
+      documentType,
+      fields,
+      accessToken: session.accessToken,
+      query,
+      size,
+      page,
+      sort,
+      options
+    })
+
+    if (!ok) {
+      throw new Error(errorMessage || 'Unknown error while fetching data')
+    }
+
+    if (subscriptions && subscriptions.length) {
+      setSubscriptions?.(subscriptions)
+    }
+
+    result = hits
   }
-
-  if (subscriptions && subscriptions.length) {
-    setSubscriptions?.(subscriptions)
-  }
-
-  let result = hits
 
   // Format planning result as assignments
   if (options?.asAssignments && query) {

--- a/src/hooks/index/useDocuments/lib/fetch.ts
+++ b/src/hooks/index/useDocuments/lib/fetch.ts
@@ -77,7 +77,7 @@ export async function fetch<T extends HitV1, F>({
   }
 
   if (options?.withArticleFactboxes) {
-    result = await withArticleFactboxes<T>({ hits: result, session, index, query, repository, page })
+    result = await withArticleFactboxes<T>({ hits: result, session, index, query, repository, page, size })
   }
 
 

--- a/src/hooks/index/useDocuments/lib/withArticleFactboxes.ts
+++ b/src/hooks/index/useDocuments/lib/withArticleFactboxes.ts
@@ -163,13 +163,17 @@ const fetchFactboxData = async (
   return dataByRowId
 }
 
-export const withArticleFactboxes = async <T extends HitV1>({ hits, session, index, query, repository, page }: {
+export const withArticleFactboxes = async <T extends HitV1>({ hits, session, index, query, repository, page, size }: {
   hits: T[]
   session: Session | null
   index?: Index
   query?: QueryV1
   repository?: Repository
   page?: number
+  /** Caller's requested page size. Drives both the article-side fetch budget
+   * and the final cap after merging + sorting by `modified`. Without it the
+   * article fetch falls back to a baseline and the merged result is uncapped. */
+  size?: number
 }): Promise<T[]> => {
   if (!session || !index || !repository) return hits
 
@@ -182,11 +186,14 @@ export const withArticleFactboxes = async <T extends HitV1>({ hits, session, ind
     fields: { ...hit.fields, _document_origin: { values: ['core/factbox'] } }
   })) as T[]
 
+  // Article fetch size mirrors the caller's size so the top-N is correct even
+  // in the worst case where each article contributes one factbox block. Each
+  // article typically expands to several rows, so this is a safe over-fetch.
   const articles = await fetch<HitV1, typeof ARTICLE_FIELDS>({
     documentType: 'core/article',
     index,
     session,
-    size: 100,
+    size: size ?? 30,
     page,
     fields: [...ARTICLE_FIELDS],
     query: buildArticleQuery(searchTerm)
@@ -238,6 +245,10 @@ export const withArticleFactboxes = async <T extends HitV1>({ hits, session, ind
     const bTitle = b.fields['document.title']?.values[0] ?? ''
     return aTitle.localeCompare(bTitle)
   })
+
+  if (size !== undefined && result.length > size) {
+    result.length = size
+  }
 
   return result
 }

--- a/src/hooks/index/useDocuments/lib/withArticleFactboxes.ts
+++ b/src/hooks/index/useDocuments/lib/withArticleFactboxes.ts
@@ -193,7 +193,7 @@ export const withArticleFactboxes = async <T extends HitV1>({ hits, session, ind
     documentType: 'core/article',
     index,
     session,
-    size: size ?? 30,
+    size: size ?? 50,
     page,
     fields: [...ARTICLE_FIELDS],
     query: buildArticleQuery(searchTerm)

--- a/src/views/Factboxes/FactboxList.tsx
+++ b/src/views/Factboxes/FactboxList.tsx
@@ -14,7 +14,19 @@ export const FactboxList = ({ columns }: {
 }): JSX.Element => {
   const [{ page }] = useQuery()
   const [filter] = useQuery(['query'])
+  const [{ documentOrigin }] = useQuery(['documentOrigin'])
   const currentPage = typeof page === 'string' ? parseInt(page) : 1
+
+  // Drive the fetch from the QuickFilter radio (synced to URL via TableProvider).
+  // Default (no value) shows both sources; selecting one skips the other fetch
+  // entirely instead of relying on a client-side row filter.
+  const origin = Array.isArray(documentOrigin) ? documentOrigin[0] : documentOrigin
+  const withArticleFactboxes: boolean | 'only'
+    = origin === 'core/factbox'
+      ? false
+      : origin === 'core/article'
+        ? 'only'
+        : true
 
   useDocuments<Factbox, FactboxFields>({
     documentType: 'core/factbox',
@@ -26,7 +38,7 @@ export const FactboxList = ({ columns }: {
     options: {
       subscribe: true,
       setTableData: true,
-      withArticleFactboxes: true
+      withArticleFactboxes
     }
   })
 

--- a/src/views/Factboxes/FactboxList.tsx
+++ b/src/views/Factboxes/FactboxList.tsx
@@ -21,7 +21,7 @@ export const FactboxList = ({ columns }: {
     fields,
     query: constructQuery(filter),
     sort: [{ field: 'modified', desc: true }],
-    size: 100,
+    size: 50,
     page: currentPage,
     options: {
       subscribe: true,

--- a/src/views/Factboxes/index.tsx
+++ b/src/views/Factboxes/index.tsx
@@ -10,6 +10,7 @@ import { factboxColumns } from './FactboxColumns'
 import type { Factbox } from '@/shared/schemas/factbox'
 import { FactboxList } from './FactboxList'
 import { useRegistry } from '@/hooks/useRegistry'
+import { useInitFilters } from '@/hooks/useInitFilters'
 import { useTranslation } from 'react-i18next'
 
 const meta: ViewMetadata = {
@@ -36,11 +37,17 @@ export const Factboxes = (): JSX.Element => {
   const columns = useMemo(() =>
     factboxColumns({ locale, timeZone, t }), [locale, timeZone, t])
 
+  const columnFilters = useInitFilters<Factbox>({
+    path: 'filters.Factboxes.current',
+    columns
+  })
+
   return (
     <View.Root tab={currentTab} onTabChange={setCurrentTab}>
       <TableProvider<Factbox>
         columns={columns}
         type={meta.name}
+        initialState={{ columnFilters }}
       >
         <TableCommandMenu heading='Factboxes'>
           <Commands />


### PR DESCRIPTION
useDocuments({size: N, withArticleFactboxes: true}) now returns at most N rows total. Previously the standalone fetch respected size but the article-side fetch ran independently and expanded one row per factbox block per article, producing 100+ rows even with size: 10 and bloating the DOM to 6k+ elements (LCP 3.15s on stage).

withArticleFactboxes now takes size, drives both the article fetch budget and the post-merge cap from it, and slices the sorted result to size. With FactboxList at size: 50, the worst case (1 block per article) still yields 50 candidates per side so top-N by modified desc is correct.