### PR TITLE
feat(timeless): show plus-icon when assignment has no deliverable

### DIFF
--- a/__tests__/AssignmentType.test.tsx
+++ b/__tests__/AssignmentType.test.tsx
@@ -1,0 +1,66 @@
+import { render } from '@testing-library/react'
+import { Block } from '@ttab/elephant-api/newsdoc'
+import type * as Y from 'yjs'
+import { AssignmentType } from '@/components/DataItem/AssignmentType'
+
+let mockAssignmentType: Block[] = []
+
+vi.mock('@/modules/yjs/hooks', () => ({
+  useYValue: (_doc: unknown, path: string) => {
+    if (path === 'meta.core/assignment-type') {
+      return [mockAssignmentType, vi.fn()]
+    }
+    return [undefined, vi.fn()]
+  }
+}))
+
+vi.mock('@/hooks/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({ hasHast: false })
+}))
+
+const mockAssignment = {} as Y.Map<unknown>
+
+function setType(value: string) {
+  mockAssignmentType = [Block.create({ type: 'core/assignment-type', value })]
+}
+
+describe('AssignmentType (readOnly icon swap)', () => {
+  beforeEach(() => {
+    mockAssignmentType = []
+  })
+
+  it('renders BookmarkPlusIcon for timeless when no deliverable (editable)', () => {
+    setType('timeless')
+    const { container } = render(
+      <AssignmentType assignment={mockAssignment} editable readOnly />
+    )
+    expect(container.querySelector('svg.lucide-bookmark-plus')).toBeInTheDocument()
+    expect(container.querySelector('svg.lucide-bookmark:not(.lucide-bookmark-plus)')).toBeNull()
+  })
+
+  it('renders BookmarkIcon for timeless when deliverable exists (not editable)', () => {
+    setType('timeless')
+    const { container } = render(
+      <AssignmentType assignment={mockAssignment} editable={false} readOnly />
+    )
+    expect(container.querySelector('svg.lucide-bookmark:not(.lucide-bookmark-plus)')).toBeInTheDocument()
+    expect(container.querySelector('svg.lucide-bookmark-plus')).toBeNull()
+  })
+
+  it('renders FilePlus2Icon for text when no deliverable (editable) - regression guard', () => {
+    setType('text')
+    const { container } = render(
+      <AssignmentType assignment={mockAssignment} editable readOnly />
+    )
+    // lucide-react >=0.400 renamed FilePlus2Icon → class "lucide-file-plus-corner"
+    expect(container.querySelector('svg.lucide-file-plus-corner')).toBeInTheDocument()
+  })
+
+  it('renders FilePenIcon for text when deliverable exists (not editable) - regression guard', () => {
+    setType('text')
+    const { container } = render(
+      <AssignmentType assignment={mockAssignment} editable={false} readOnly />
+    )
+    expect(container.querySelector('svg.lucide-file-pen')).toBeInTheDocument()
+  })
+})

--- a/src/components/DataItem/AssignmentType.tsx
+++ b/src/components/DataItem/AssignmentType.tsx
@@ -2,7 +2,7 @@ import { getAssignmentTypes } from '@/defaults'
 import { Button, Select, SelectContent, SelectItem, SelectTrigger } from '@ttab/elephant-ui'
 import { cn } from '@ttab/elephant-ui/utils'
 import { Block } from '@ttab/elephant-api/newsdoc'
-import { FilePenIcon, FilePlus2Icon } from '@ttab/elephant-ui/icons'
+import { BookmarkIcon, BookmarkPlusIcon, FilePenIcon, FilePlus2Icon } from '@ttab/elephant-ui/icons'
 import type { DefaultValueOption } from '@/types/index'
 import type { FormProps } from '../Form/Root'
 import { useYValue } from '@/modules/yjs/hooks'
@@ -117,12 +117,14 @@ export const AssignmentType = ({ assignment, editable = false, readOnly = false,
 }
 
 function getIcon(selectedOptions: Omit<DefaultValueOption, 'label'>[], editable: boolean, readOnly = false) {
-  if (selectedOptions[0]?.value !== 'text') {
-    return selectedOptions[0]?.icon
+  const value = selectedOptions[0]?.value
+
+  if (value === 'text' && readOnly) {
+    return editable ? FilePlus2Icon : FilePenIcon
   }
 
-  if (readOnly) {
-    return editable ? FilePlus2Icon : FilePenIcon
+  if (value === 'timeless' && readOnly) {
+    return editable ? BookmarkPlusIcon : BookmarkIcon
   }
 
   return selectedOptions[0]?.icon


### PR DESCRIPTION
Mirror the existing text-assignment pattern (FilePlus2Icon / FilePenIcon) for timeless so the create-deliverable affordance on AssignmentRow is discoverable.

ELELOG-642