### PR TITLE
fix(timeless): carry assignment internal description on conversion

### DIFF
--- a/__tests__/convertArticleType.test.ts
+++ b/__tests__/convertArticleType.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { Block, Document } from '@ttab/elephant-api/newsdoc'
 import {
+  attachArticleAssignment,
   buildFallbackPlanning,
   deriveNewPlanning,
+  findArticleAssignment,
   prepareArticleConversion
 } from '@/shared/convertArticleType'
 import type { Repository } from '@/shared/Repository'
@@ -358,5 +360,157 @@ describe('buildFallbackPlanning', () => {
     expect(result.meta.find((b) => b.type === 'tt/slugline')).toBeDefined()
     expect(result.meta.find((b) => b.type === 'core/newsvalue')).toBeDefined()
     expect(result.links).toHaveLength(0)
+  })
+})
+
+describe('attachArticleAssignment', () => {
+  const makePlanning = () =>
+    Document.create({
+      uuid: 'planning-uuid',
+      type: 'core/planning-item',
+      uri: 'core://newscoverage/planning-uuid',
+      language: 'sv-se',
+      title: 'Planning',
+      meta: [
+        Block.create({ type: 'tt/slugline', value: 'feature-x' }),
+        Block.create({ type: 'core/newsvalue', value: '3' })
+      ]
+    })
+
+  const makeSourceAssignment = (internalText: string) =>
+    Block.create({
+      type: 'core/assignment',
+      meta: [
+        Block.create({
+          type: 'core/description',
+          role: 'internal',
+          data: { text: internalText }
+        })
+      ]
+    })
+
+  const findAssignment = (doc: Document) =>
+    doc.meta.find((block) => block.type === 'core/assignment' && block.links.length > 0)
+
+  it('inherits the internal description from the source assignment', () => {
+    const result = attachArticleAssignment({
+      planning: makePlanning(),
+      articleId: 'article-uuid',
+      articleTitle: 'Test',
+      targetDate: '2026-05-15',
+      sourceAssignment: makeSourceAssignment('Carry me over')
+    })
+
+    const assignment = findAssignment(result)
+    const internal = assignment?.meta.find(
+      (m) => m.type === 'core/description' && m.role === 'internal'
+    )
+    expect(internal?.data.text).toBe('Carry me over')
+  })
+
+  it('drops the empty internal description placeholder when no source assignment provided', () => {
+    const result = attachArticleAssignment({
+      planning: makePlanning(),
+      articleId: 'article-uuid',
+      articleTitle: 'Test',
+      targetDate: '2026-05-15'
+    })
+
+    const assignment = findAssignment(result)
+    expect(assignment?.meta.find((m) => m.type === 'core/description')).toBeUndefined()
+  })
+
+  it('drops the placeholder when the source description is whitespace-only', () => {
+    const result = attachArticleAssignment({
+      planning: makePlanning(),
+      articleId: 'article-uuid',
+      articleTitle: 'Test',
+      targetDate: '2026-05-15',
+      sourceAssignment: makeSourceAssignment('   ')
+    })
+
+    const assignment = findAssignment(result)
+    expect(assignment?.meta.find((m) => m.type === 'core/description')).toBeUndefined()
+  })
+
+  it('drops the placeholder when the source assignment has no description block', () => {
+    const result = attachArticleAssignment({
+      planning: makePlanning(),
+      articleId: 'article-uuid',
+      articleTitle: 'Test',
+      targetDate: '2026-05-15',
+      sourceAssignment: Block.create({
+        type: 'core/assignment',
+        meta: [Block.create({ type: 'core/description', role: 'public', data: { text: 'Pub' } })]
+      })
+    })
+
+    const assignment = findAssignment(result)
+    expect(assignment?.meta.find((m) => m.type === 'core/description')).toBeUndefined()
+  })
+
+  it('trims whitespace from the inherited description', () => {
+    const result = attachArticleAssignment({
+      planning: makePlanning(),
+      articleId: 'article-uuid',
+      articleTitle: 'Test',
+      targetDate: '2026-05-15',
+      sourceAssignment: makeSourceAssignment('  padded  ')
+    })
+
+    const internal = findAssignment(result)?.meta.find(
+      (m) => m.type === 'core/description' && m.role === 'internal'
+    )
+    expect(internal?.data.text).toBe('padded')
+  })
+
+  it('attaches a deliverable link pointing at the article', () => {
+    const result = attachArticleAssignment({
+      planning: makePlanning(),
+      articleId: 'article-uuid',
+      articleTitle: 'Test',
+      targetDate: '2026-05-15'
+    })
+
+    const assignment = findAssignment(result)
+    expect(assignment?.links.find((l) => l.rel === 'deliverable')).toMatchObject({
+      type: 'core/article',
+      uuid: 'article-uuid'
+    })
+  })
+})
+
+describe('findArticleAssignment', () => {
+  it('returns the assignment whose deliverable points at the article', () => {
+    const planning = Document.create({
+      uuid: 'p',
+      type: 'core/planning-item',
+      uri: 'core://newscoverage/p',
+      meta: [
+        Block.create({
+          type: 'core/assignment',
+          id: 'a1',
+          links: [Block.create({ type: 'core/article', rel: 'deliverable', uuid: 'other' })]
+        }),
+        Block.create({
+          type: 'core/assignment',
+          id: 'a2',
+          links: [Block.create({ type: 'core/article', rel: 'deliverable', uuid: 'target' })]
+        })
+      ]
+    })
+
+    expect(findArticleAssignment(planning, 'target')?.id).toBe('a2')
+  })
+
+  it('returns undefined when no assignment matches', () => {
+    const planning = Document.create({
+      uuid: 'p',
+      type: 'core/planning-item',
+      uri: 'core://newscoverage/p',
+      meta: []
+    })
+
+    expect(findArticleAssignment(planning, 'missing')).toBeUndefined()
   })
 })

--- a/__tests__/useConvertArticleType.test.tsx
+++ b/__tests__/useConvertArticleType.test.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner'
 
 import { useConvertArticleType } from '@/hooks/useConvertArticleType'
 import { useRegistry } from '@/hooks/useRegistry'
+import { snapshotDocument } from '@/lib/snapshotDocument'
 import {
   attachArticleAssignment,
   buildFallbackPlanning,
@@ -38,12 +39,17 @@ vi.mock('sonner', () => ({
   }
 }))
 
+vi.mock('@/lib/snapshotDocument', () => ({
+  snapshotDocument: vi.fn().mockResolvedValue(undefined)
+}))
+
 const mockUseRegistry = vi.mocked(useRegistry)
 const mockUseSession = vi.mocked(useSession)
 const mockPrepareArticleConversion = vi.mocked(prepareArticleConversion)
 const mockDeriveNewPlanning = vi.mocked(deriveNewPlanning)
 const mockBuildFallbackPlanning = vi.mocked(buildFallbackPlanning)
 const mockAttachArticleAssignment = vi.mocked(attachArticleAssignment)
+const mockSnapshotDocument = vi.mocked(snapshotDocument)
 
 const TIMELESS_ID = '11111111-1111-1111-8111-111111111111'
 const ARTICLE_ID = '22222222-2222-2222-8222-222222222222'
@@ -51,11 +57,12 @@ const PLANNING_ID = '33333333-3333-3333-8333-333333333333'
 const NEW_ARTICLE_UUID = '44444444-4444-4444-8444-444444444444'
 const NEW_PLANNING_UUID = '55555555-5555-5555-8555-555555555555'
 
-function planningReferencing(articleId: string) {
+function planningReferencing(articleId: string, assignmentMeta: unknown[] = []) {
   return {
     uuid: PLANNING_ID,
     meta: [{
       type: 'core/assignment',
+      meta: assignmentMeta,
       links: [{ type: 'core/article', rel: 'deliverable', uuid: articleId }]
     }]
   }
@@ -295,6 +302,89 @@ describe('useConvertArticleType', () => {
     expect(toast.success).toHaveBeenCalledWith(
       'Artikel planerad',
       expect.objectContaining<{ action: unknown }>({ action: expect.anything() })
+    )
+  })
+
+  it('flushes the timeless and source planning before reading them', async () => {
+    const { getDocument } = primeRegistryWithRepository()
+    getDocument.mockImplementation(({ uuid }: { uuid: string }) => {
+      if (uuid === TIMELESS_ID) {
+        return Promise.resolve({
+          document: { uuid: TIMELESS_ID, type: 'core/article#timeless', title: 'T' }
+        })
+      }
+      return Promise.resolve({ document: planningReferencing(TIMELESS_ID) })
+    })
+
+    const fakeDoc = {} as Parameters<typeof snapshotDocument>[2]
+
+    const { result } = renderHook(() => useConvertArticleType())
+    await act(async () => {
+      await result.current.convert(TIMELESS_ID, {
+        targetType: 'core/article',
+        targetDate: '2026-05-15',
+        sourcePlanningId: PLANNING_ID,
+        sourceDocument: fakeDoc
+      })
+    })
+
+    expect(mockSnapshotDocument).toHaveBeenCalledWith(TIMELESS_ID, undefined, fakeDoc)
+    expect(mockSnapshotDocument).toHaveBeenCalledWith(PLANNING_ID)
+  })
+
+  it('aborts conversion when a pre-read snapshot fails', async () => {
+    const { getDocument, createDerivedDocument } = primeRegistryWithRepository()
+    getDocument.mockResolvedValue({
+      document: { uuid: TIMELESS_ID, type: 'core/article#timeless' }
+    })
+    mockSnapshotDocument.mockRejectedValueOnce(new Error('snapshot down'))
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { result } = renderHook(() => useConvertArticleType())
+    let outcome!: Awaited<ReturnType<typeof result.current.convert>>
+    await act(async () => {
+      outcome = await result.current.convert(TIMELESS_ID, {
+        targetType: 'core/article',
+        targetDate: '2026-05-15',
+        sourcePlanningId: PLANNING_ID
+      })
+    })
+
+    expect(outcome).toEqual({ success: false })
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('snapshot down'))
+    expect(createDerivedDocument).not.toHaveBeenCalled()
+  })
+
+  it('copies the source assignment internal description onto the new planning', async () => {
+    const { getDocument } = primeRegistryWithRepository()
+    getDocument.mockImplementation(({ uuid }: { uuid: string }) => {
+      if (uuid === TIMELESS_ID) {
+        return Promise.resolve({
+          document: { uuid: TIMELESS_ID, type: 'core/article#timeless', title: 'T' }
+        })
+      }
+      return Promise.resolve({
+        document: planningReferencing(TIMELESS_ID, [
+          { type: 'core/description', role: 'internal', data: { text: 'Carry me over' } },
+          { type: 'core/description', role: 'public', data: { text: 'Public' } }
+        ])
+      })
+    })
+
+    const { result } = renderHook(() => useConvertArticleType())
+
+    await act(async () => {
+      await result.current.convert(TIMELESS_ID, {
+        targetType: 'core/article',
+        targetDate: '2026-05-15',
+        sourcePlanningId: PLANNING_ID
+      })
+    })
+
+    expect(mockAttachArticleAssignment).toHaveBeenCalledWith(
+      expect.objectContaining<{ sourceAssignment: unknown }>({
+        sourceAssignment: expect.objectContaining<{ type: string }>({ type: 'core/assignment' })
+      })
     )
   })
 

--- a/shared/convertArticleType.ts
+++ b/shared/convertArticleType.ts
@@ -196,16 +196,19 @@ export function attachArticleAssignment({
   })
 
   // bulkUpdate bypasses stripEmptyValidatedMetaBlocks, so drop the
-  // template's empty description and re-add it only when we have text.
-  const metaWithoutDescription = assignment.meta.filter((block) => block.type !== 'core/description')
-  const descriptionMeta = inheritedInternalDescription
+  // template's empty internal description and re-add it only when we
+  // have text. Public descriptions and other meta blocks are left alone.
+  const metaWithoutInternal = assignment.meta.filter(
+    (block) => !(block.type === 'core/description' && block.role === 'internal')
+  )
+  const internalDescription = inheritedInternalDescription
     ? [Block.create({
         type: 'core/description',
         role: 'internal',
         data: { text: inheritedInternalDescription }
       })]
     : []
-  const cleanedMeta = [...metaWithoutDescription, ...descriptionMeta]
+  const cleanedMeta = [...metaWithoutInternal, ...internalDescription]
 
   const assignmentWithDeliverable = Block.create({
     ...assignment,

--- a/shared/convertArticleType.ts
+++ b/shared/convertArticleType.ts
@@ -159,23 +159,26 @@ export function deriveNewPlanning({
 /**
  * Append a `core/assignment` block to the planning that owns the article as a
  * `rel='deliverable'`. Returns a new Document proto; does not mutate.
+ *
+ * When `sourceAssignment` is provided, the new assignment inherits its
+ * internal description so manually entered context survives conversion.
  */
 export function attachArticleAssignment({
   planning,
   articleId,
   articleTitle,
-  targetDate
+  targetDate,
+  sourceAssignment
 }: {
   planning: Document
   articleId: string
   articleTitle: string
   targetDate: string
+  sourceAssignment?: Block
 }): Document {
   const assignmentIso = `${targetDate}T09:00:00Z`
-  // Inherit the planning's slugline onto the assignment. If the planning has
-  // no slugline the Repository will reject — that's the correct failure mode,
-  // since every planning is supposed to carry one.
   const slugline = planning.meta.find((m) => m.type === 'tt/slugline')?.value
+  const inheritedInternalDescription = getInternalDescription(sourceAssignment)
 
   const assignment = assignmentPlanningTemplate({
     assignmentType: 'text',
@@ -192,12 +195,17 @@ export function attachArticleAssignment({
     }
   })
 
-  // The template seeds a blank core/description placeholder; Repository
-  // validation rejects empty text — strip it and let it be added later via
-  // the UI if needed.
-  const cleanedMeta = assignment.meta.filter((block) =>
-    !(block.type === 'core/description' && !block.data?.text?.trim())
-  )
+  // bulkUpdate bypasses stripEmptyValidatedMetaBlocks, so drop the
+  // template's empty description and re-add it only when we have text.
+  const metaWithoutDescription = assignment.meta.filter((block) => block.type !== 'core/description')
+  const descriptionMeta = inheritedInternalDescription
+    ? [Block.create({
+        type: 'core/description',
+        role: 'internal',
+        data: { text: inheritedInternalDescription }
+      })]
+    : []
+  const cleanedMeta = [...metaWithoutDescription, ...descriptionMeta]
 
   const assignmentWithDeliverable = Block.create({
     ...assignment,
@@ -219,12 +227,19 @@ export function attachArticleAssignment({
 }
 
 /**
- * Does this planning own `articleId` as a deliverable via any assignment?
+ * Find the assignment in `planning` that owns `articleId` as a deliverable.
  */
-export function planningReferencesArticle(planning: Document, articleId: string): boolean {
-  return planning.meta.some((block) =>
+export function findArticleAssignment(planning: Document, articleId: string): Block | undefined {
+  return planning.meta.find((block) =>
     block.type === 'core/assignment'
     && block.links.some((link) => link.rel === 'deliverable' && link.uuid === articleId)
   )
+}
+
+function getInternalDescription(block: Block | undefined): string | undefined {
+  const text = block?.meta
+    .find((m) => m.type === 'core/description' && m.role === 'internal')
+    ?.data?.text?.trim()
+  return text || undefined
 }
 

--- a/src/components/ArticleTypeConversion.tsx
+++ b/src/components/ArticleTypeConversion.tsx
@@ -37,6 +37,7 @@ export const ArticleTypeConversion = ({ ydoc, documentType }: {
     showModal(
       <ConvertToArticleDialog
         timelessId={ydoc.id}
+        timelessDoc={ydoc.provider?.document}
         onClose={(result) => {
           hideModal()
           if (result?.articleId) {

--- a/src/components/ConvertToArticleDialog.tsx
+++ b/src/components/ConvertToArticleDialog.tsx
@@ -17,6 +17,7 @@ import { useConvertArticleType } from '@/hooks/useConvertArticleType'
 import { useDocuments } from '@/hooks/index/useDocuments'
 import { useRegistry } from '@/hooks/useRegistry'
 import type { Planning, PlanningFields } from '@/shared/schemas/planning'
+import type * as Y from 'yjs'
 
 interface ConversionPayload {
   articleId: string
@@ -25,10 +26,11 @@ interface ConversionPayload {
 
 interface Props {
   timelessId: string
+  timelessDoc?: Y.Doc
   onClose: (result?: ConversionPayload) => void
 }
 
-export function ConvertToArticleDialog({ timelessId, onClose }: Props): JSX.Element {
+export function ConvertToArticleDialog({ timelessId, timelessDoc, onClose }: Props): JSX.Element {
   const { t } = useTranslation()
   const { locale } = useRegistry()
   const { convert, isConverting } = useConvertArticleType()
@@ -57,7 +59,8 @@ export function ConvertToArticleDialog({ timelessId, onClose }: Props): JSX.Elem
     void convert(timelessId, {
       targetType: 'core/article',
       targetDate: formattedTarget,
-      ...(sourcePlanningId ? { sourcePlanningId } : {})
+      sourcePlanningId,
+      sourceDocument: timelessDoc
     }).then((result) => {
       if (result.success && result.kind === 'article') {
         onClose({

--- a/src/hooks/useConvertArticleType.tsx
+++ b/src/hooks/useConvertArticleType.tsx
@@ -5,17 +5,18 @@ import {
   attachArticleAssignment,
   buildFallbackPlanning,
   deriveNewPlanning,
-  planningReferencesArticle,
+  findArticleAssignment,
   prepareArticleConversion
 } from '@/shared/convertArticleType'
-import type { Document } from '@ttab/elephant-api/newsdoc'
+import type { Block, Document } from '@ttab/elephant-api/newsdoc'
 import { replaceDeliverable } from '@/lib/index/replaceDeliverable'
+import { snapshotDocument } from '@/lib/snapshotDocument'
 import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
 import { CalendarDaysIcon, PenBoxIcon } from '@ttab/elephant-ui/icons'
 import { ToastAction } from '@/components/ToastAction'
-import type { Block } from '@ttab/elephant-api/newsdoc'
 import type { ValidationResult } from '@ttab/elephant-api/repository'
+import type * as Y from 'yjs'
 
 function warnOnPruneErrors(errors: ValidationResult[]): void {
   if (!errors.length) {
@@ -31,6 +32,7 @@ export type ConvertArgs
       targetType: 'core/article'
       targetDate: string
       sourcePlanningId?: string
+      sourceDocument?: Y.Doc
     }
 
 export type ConversionResult
@@ -75,10 +77,21 @@ export function useConvertArticleType(): UseConvertArticleTypeResult {
 
     try {
       if (args.targetType === 'core/article') {
-        const sourceResponse = await repository.getDocument({
-          uuid: documentId,
-          accessToken
-        })
+        const snapshotJobs: Array<Promise<unknown>> = [
+          snapshotDocument(documentId, undefined, args.sourceDocument)
+        ]
+        if (args.sourcePlanningId) {
+          snapshotJobs.push(snapshotDocument(args.sourcePlanningId))
+        }
+        await Promise.all(snapshotJobs)
+
+        const [sourceResponse, planningResponse] = await Promise.all([
+          repository.getDocument({ uuid: documentId, accessToken }),
+          args.sourcePlanningId
+            ? repository.getDocument({ uuid: args.sourcePlanningId, accessToken })
+            : Promise.resolve(undefined)
+        ])
+
         if (!sourceResponse?.document) {
           toast.error(t('views:timeless.toasts.documentNotFound'))
           return { success: false }
@@ -92,18 +105,16 @@ export function useConvertArticleType(): UseConvertArticleTypeResult {
 
         const newPlanningUuid = crypto.randomUUID()
         let basePlanning: Document
+        let sourceAssignment: Block | undefined
         if (args.sourcePlanningId) {
-          const planningResponse = await repository.getDocument({
-            uuid: args.sourcePlanningId,
-            accessToken
-          })
           if (!planningResponse?.document) {
             toast.error(t('views:timeless.toasts.conversionFailed', {
               message: 'source planning not found'
             }))
             return { success: false }
           }
-          if (!planningReferencesArticle(planningResponse.document, documentId)) {
+          sourceAssignment = findArticleAssignment(planningResponse.document, documentId)
+          if (!sourceAssignment) {
             toast.error(t('views:timeless.toasts.conversionFailed', {
               message: 'source planning does not reference the timeless article'
             }))
@@ -134,7 +145,8 @@ export function useConvertArticleType(): UseConvertArticleTypeResult {
           planning: basePlanning,
           articleId: newArticle.uuid,
           articleTitle: sourceResponse.document.title ?? '',
-          targetDate: args.targetDate
+          targetDate: args.targetDate,
+          sourceAssignment
         })
 
         await repository.createDerivedDocument({


### PR DESCRIPTION
When converting a timeless article into a planned article, copy the internal description from the source planning's assignment onto the new planning's assignment so it is not silently lost. Also snapshot the timeless and the source planning before reading them so freshly edited fields are not missed because Hocuspocus has not yet flushed.

ELELOG-641