### PR TITLE
fix(timeless): treat timeless assignments as non-public

### DIFF
--- a/__tests__/AssignmentTable.handleClose.test.tsx
+++ b/__tests__/AssignmentTable.handleClose.test.tsx
@@ -131,14 +131,22 @@ describe('AssignmentTable.handleClose - timeless isChanged reset', () => {
   })
 
   it('resets isChanged to false after adding a clean timeless assignment', async () => {
-    const setIsChanged = vi.fn()
-    const ydoc = buildYdoc(false, { assignmentType: 'timeless', isChanged: false, setIsChanged })
+    let assignmentCountAtReset: number | undefined
+    const ydoc = buildYdoc(false, { assignmentType: 'timeless', isChanged: false })
+    const rawAssignments = (ydoc.ele.get('meta') as Y.Map<unknown>).get('core/assignment') as Y.Array<unknown>
+    const setIsChanged = vi.fn((_v: boolean) => {
+      assignmentCountAtReset = rawAssignments.length
+    });
+    (ydoc as unknown as { setIsChanged: (v: boolean) => void }).setIsChanged = setIsChanged
 
     render(<AssignmentTable ydoc={ydoc} documentId='planning-uuid' />)
     await userEvent.click(screen.getByTestId('assignment-close'))
 
     expect(setIsChanged).toHaveBeenCalledTimes(1)
     expect(setIsChanged).toHaveBeenCalledWith(false)
+    // The reset must run after the push that the deep observer would react to;
+    // resetting before the push would be silently undone by the observer.
+    expect(assignmentCountAtReset).toBe(1)
   })
 
   it('preserves a pre-existing isChanged when adding a timeless assignment', async () => {

--- a/__tests__/AssignmentTable.handleClose.test.tsx
+++ b/__tests__/AssignmentTable.handleClose.test.tsx
@@ -48,19 +48,22 @@ vi.mock('@/views/Planning/components/Assignment', () => ({
   )
 }))
 
-function buildInProgressAssignment(): Y.Map<unknown> {
+function buildInProgressAssignment(type = 'text'): Y.Map<unknown> {
   const assignment = new Y.Map<unknown>()
   const meta = new Y.Map<unknown>()
   const types = new Y.Array<unknown>()
   const typeBlock = new Y.Map<unknown>()
-  typeBlock.set('value', 'text')
+  typeBlock.set('value', type)
   types.push([typeBlock])
   meta.set('core/assignment-type', types)
   assignment.set('meta', meta)
   return assignment
 }
 
-function buildYdoc(isInProgress: boolean): YDocument<Y.Map<unknown>> {
+function buildYdoc(
+  isInProgress: boolean,
+  options: { assignmentType?: string, isChanged?: boolean, setIsChanged?: (v: boolean) => void } = {}
+): YDocument<Y.Map<unknown>> {
   const doc = new Y.Doc()
   const ele = doc.getMap('ele')
   const ctx = doc.getMap('ctx')
@@ -70,7 +73,7 @@ function buildYdoc(isInProgress: boolean): YDocument<Y.Map<unknown>> {
   ele.set('meta', meta)
 
   const slots = new Y.Map<unknown>()
-  slots.set('test-sub', buildInProgressAssignment())
+  slots.set('test-sub', buildInProgressAssignment(options.assignmentType))
   ctx.set('core/assignment', slots)
 
   return {
@@ -78,6 +81,8 @@ function buildYdoc(isInProgress: boolean): YDocument<Y.Map<unknown>> {
     ele,
     ctx,
     isInProgress,
+    isChanged: options.isChanged ?? false,
+    setIsChanged: options.setIsChanged ?? vi.fn(),
     provider: { document: doc }
   } as unknown as YDocument<Y.Map<unknown>>
 }
@@ -116,5 +121,43 @@ describe('AssignmentTable.handleClose — isInProgress gate', () => {
       { force: true },
       ydoc.provider?.document
     )
+  })
+})
+
+describe('AssignmentTable.handleClose - timeless isChanged reset', () => {
+  beforeEach(() => {
+    mockSnapshotDocument.mockReset()
+    mockSnapshotDocument.mockResolvedValue(undefined)
+  })
+
+  it('resets isChanged to false after adding a clean timeless assignment', async () => {
+    const setIsChanged = vi.fn()
+    const ydoc = buildYdoc(false, { assignmentType: 'timeless', isChanged: false, setIsChanged })
+
+    render(<AssignmentTable ydoc={ydoc} documentId='planning-uuid' />)
+    await userEvent.click(screen.getByTestId('assignment-close'))
+
+    expect(setIsChanged).toHaveBeenCalledTimes(1)
+    expect(setIsChanged).toHaveBeenCalledWith(false)
+  })
+
+  it('preserves a pre-existing isChanged when adding a timeless assignment', async () => {
+    const setIsChanged = vi.fn()
+    const ydoc = buildYdoc(false, { assignmentType: 'timeless', isChanged: true, setIsChanged })
+
+    render(<AssignmentTable ydoc={ydoc} documentId='planning-uuid' />)
+    await userEvent.click(screen.getByTestId('assignment-close'))
+
+    expect(setIsChanged).not.toHaveBeenCalled()
+  })
+
+  it('does not reset isChanged when adding a non-timeless assignment', async () => {
+    const setIsChanged = vi.fn()
+    const ydoc = buildYdoc(false, { assignmentType: 'text', isChanged: false, setIsChanged })
+
+    render(<AssignmentTable ydoc={ydoc} documentId='planning-uuid' />)
+    await userEvent.click(screen.getByTestId('assignment-close'))
+
+    expect(setIsChanged).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/AssignmentType.dropdown.test.tsx
+++ b/__tests__/AssignmentType.dropdown.test.tsx
@@ -67,9 +67,9 @@ describe('AssignmentType dropdown - data.public side effect', () => {
     expect(setAssignmentVisibilityMock).toHaveBeenCalledWith('false')
   })
 
-  it('does not touch data.public when text is selected', async () => {
+  it('restores data.public to "true" when switching to text', async () => {
     render(<AssignmentType assignment={mockAssignment} editable />)
     await userEvent.click(screen.getByTestId('pick-text'))
-    expect(setAssignmentVisibilityMock).not.toHaveBeenCalled()
+    expect(setAssignmentVisibilityMock).toHaveBeenCalledWith('true')
   })
 })

--- a/__tests__/AssignmentType.dropdown.test.tsx
+++ b/__tests__/AssignmentType.dropdown.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type * as Y from 'yjs'
+import type { ReactNode } from 'react'
+import type * as ElephantUi from '@ttab/elephant-ui'
+import { AssignmentType } from '@/components/DataItem/AssignmentType'
+
+const setAssignmentTypeMock = vi.fn()
+const setAssignmentVisibilityMock = vi.fn()
+
+vi.mock('@/modules/yjs/hooks', () => ({
+  useYValue: (_doc: unknown, path: string) => {
+    if (path === 'meta.core/assignment-type') {
+      return [[], setAssignmentTypeMock]
+    }
+    if (path === 'data.public') {
+      return [undefined, setAssignmentVisibilityMock]
+    }
+    return [undefined, vi.fn()]
+  }
+}))
+
+vi.mock('@/hooks/useFeatureFlags', () => ({
+  useFeatureFlags: () => ({ hasHast: false })
+}))
+
+// Replace the Radix Select with a deterministic surrogate so we can drive
+// onValueChange directly without depending on the popover/portal lifecycle.
+vi.mock('@ttab/elephant-ui', async (original) => {
+  const actual = await original<typeof ElephantUi>()
+  return {
+    ...actual,
+    Select: ({ onValueChange, children }: {
+      onValueChange?: (value: string) => void
+      children: ReactNode
+    }) => (
+      <div>
+        <button data-testid='pick-text' onClick={() => onValueChange?.('text')}>text</button>
+        <button data-testid='pick-flash' onClick={() => onValueChange?.('flash')}>flash</button>
+        <button data-testid='pick-timeless' onClick={() => onValueChange?.('timeless')}>timeless</button>
+        {children}
+      </div>
+    ),
+    SelectTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+    SelectContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+    SelectItem: ({ children }: { children: ReactNode }) => <>{children}</>
+  }
+})
+
+const mockAssignment = {} as Y.Map<unknown>
+
+describe('AssignmentType dropdown - data.public side effect', () => {
+  beforeEach(() => {
+    setAssignmentTypeMock.mockClear()
+    setAssignmentVisibilityMock.mockClear()
+  })
+
+  it('flips data.public to "false" when timeless is selected', async () => {
+    render(<AssignmentType assignment={mockAssignment} editable />)
+    await userEvent.click(screen.getByTestId('pick-timeless'))
+    expect(setAssignmentVisibilityMock).toHaveBeenCalledWith('false')
+  })
+
+  it('flips data.public to "false" when flash is selected (regression guard)', async () => {
+    render(<AssignmentType assignment={mockAssignment} editable />)
+    await userEvent.click(screen.getByTestId('pick-flash'))
+    expect(setAssignmentVisibilityMock).toHaveBeenCalledWith('false')
+  })
+
+  it('does not touch data.public when text is selected', async () => {
+    render(<AssignmentType assignment={mockAssignment} editable />)
+    await userEvent.click(screen.getByTestId('pick-text'))
+    expect(setAssignmentVisibilityMock).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/submitTimeless.test.ts
+++ b/__tests__/submitTimeless.test.ts
@@ -50,7 +50,8 @@ describe('submitTimeless', () => {
       expect.objectContaining({
         deliverableId: 'doc-1',
         type: 'timeless',
-        planningId: 'plan-1'
+        planningId: 'plan-1',
+        publicVisibility: false
       })
     )
   })

--- a/__tests__/templates/assignmentPlanningTemplate.test.ts
+++ b/__tests__/templates/assignmentPlanningTemplate.test.ts
@@ -86,6 +86,22 @@ describe('assignmentPlanningTemplate', () => {
     expect(result.links.length).toBe(0)
   })
 
+  it.each([
+    ['text', 'true'],
+    ['picture', 'true'],
+    ['video', 'true'],
+    ['graphic', 'true'],
+    ['flash', 'false'],
+    ['timeless', 'false']
+  ])('sets data.public to %s for %s assignments', (assignmentType, expected) => {
+    const result = assignmentPlanningTemplate({
+      assignmentType,
+      planningDate: '2024-06-01',
+      assignee: null
+    })
+    expect(result.data.public).toBe(expected)
+  })
+
   it('matches snapshot with fixed date', () => {
     const fixedDate = new Date('2024-01-01T10:00:00.000Z')
     vi.setSystemTime(fixedDate)

--- a/shared/templates/assignmentPlanningTemplate.ts
+++ b/shared/templates/assignmentPlanningTemplate.ts
@@ -84,7 +84,9 @@ export function assignmentPlanningTemplate({
       ...(assignmentType === 'text' && { publish_slot: systemHour }),
       start_date: planningDate,
       start: startDateAndTime(assignmentType),
-      public: assignmentType === 'flash'
+      // Flash and timeless assignments are persisted but not part of the
+      // planning's published artifact.
+      public: assignmentType === 'flash' || assignmentType === 'timeless'
         ? 'false'
         : 'true'
     },

--- a/src-srv/api/documents/[id]/replaceDeliverable.ts
+++ b/src-srv/api/documents/[id]/replaceDeliverable.ts
@@ -99,6 +99,11 @@ export const POST: RouteHandler = async (
           typeBlocks?.forEach((block) => {
             block.set('value', newAssignmentType)
           })
+
+          // Keep data.public consistent with the new type: timeless
+          // assignments are not part of the planning's published artifact.
+          const data = assignment.get('data') as Y.Map<unknown> | undefined
+          data?.set('public', newAssignmentType === 'timeless' ? 'false' : 'true')
         }
       })
     })

--- a/src/components/DataItem/AssignmentType.tsx
+++ b/src/components/DataItem/AssignmentType.tsx
@@ -88,6 +88,7 @@ export const AssignmentType = ({ assignment, editable = false, readOnly = false,
               type: 'core/assignment-type',
               value: value
             })])
+            setAssignmentVisibility('true')
         }
       }}
     >

--- a/src/components/DataItem/AssignmentType.tsx
+++ b/src/components/DataItem/AssignmentType.tsx
@@ -74,6 +74,7 @@ export const AssignmentType = ({ assignment, editable = false, readOnly = false,
             ])
             break
           case 'flash':
+          case 'timeless':
             setAssignmentType([Block.create({
               type: 'core/assignment-type',
               value: value

--- a/src/views/Planning/components/AssignmentTable.tsx
+++ b/src/views/Planning/components/AssignmentTable.tsx
@@ -101,12 +101,21 @@ export const AssignmentTable = ({ ydoc, asDialog = false, documentId }: {
       deleteByYPath(assignment, ['meta', 'tt/slugline'])
     }
 
+    // Timeless assignments are persisted but never published, so adding one
+    // should not flip a clean planning into "unpublished changes". Capture
+    // the prior state so we can revert the flag the push observer will set.
+    const wasChanged = ydoc.isChanged
+
     rawAssignments?.push([
       toYStructure(
         fromYStructure(assignment)
       ) as Y.Map<unknown>
     ])
     deleteByYPath(ydoc.ctx, ['core/assignment', session?.user.sub])
+
+    if (assignmentType === 'timeless' && !wasChanged) {
+      ydoc.setIsChanged?.(false)
+    }
 
     if (documentId && ydoc.provider && !ydoc.isInProgress) {
       snapshotDocument(documentId, { force: true }, ydoc.provider.document)

--- a/src/views/TimelessCreation/lib/submitTimeless.ts
+++ b/src/views/TimelessCreation/lib/submitTimeless.ts
@@ -49,7 +49,7 @@ export async function submitTimeless(args: {
     type: 'timeless',
     deliverableId: newId,
     title: args.title,
-    publicVisibility: true,
+    publicVisibility: false,
     localDate: args.localDate,
     isoDateTime: args.isoDateTime,
     author: args.author


### PR DESCRIPTION
Adding a timeless assignment via the +Add UI flipped the planning's status button to "Unpublished changes" even though the assignment is not part of the planning's published artifact. Three related fixes:

- Default `data.public` to 'false' for timeless (same as flash), in the template, the AssignmentType dropdown, and the server-side replaceDeliverable type flip.
- Suppress isChanged in AssignmentTable.handleClose when the new assignment is timeless and the planning was clean. The array push itself still triggers the deep observer regardless of `data.public`.

Article-to-timeless conversion still sets isChanged via the standard observer path (assignment-type and data.public both flip), so the planning correctly advertises republish.

ELELOG-646