### PR TITLE
fix(timeless): open planning after converting from assignment row

### DIFF
--- a/src/views/Planning/components/AssignmentRow.tsx
+++ b/src/views/Planning/components/AssignmentRow.tsx
@@ -63,6 +63,7 @@ export const AssignmentRow = ({ ydoc, index, onSelect, isFocused = false, asDial
 }): JSX.Element => {
   const openArticle = useLink('Editor')
   const openFlash = useLink('Flash')
+  const openPlanning = useLink('Planning')
 
   const openDocuments = useOpenDocuments({ idOnly: true, name: 'Editor' })
   const { repository } = useRegistry()
@@ -308,8 +309,8 @@ export const AssignmentRow = ({ ydoc, index, onSelect, isFocused = false, asDial
                 timelessId={documentId}
                 onClose={(result) => {
                   hideModal()
-                  if (result?.articleId) {
-                    openArticle(undefined, { id: result.articleId })
+                  if (result?.planningId) {
+                    openPlanning(undefined, { id: result.planningId })
                   }
                 }}
               />


### PR DESCRIPTION
When converting a timeless to an article from an assignment row in the Planning view, navigate to the target planning rather than the new article. This matches the existing behavior from TimelessRowActions and keeps the user in their planning context.

MetaSheet's ArticleTypeConversion still opens the new article via useLink mode 'self' on purpose - that path replaces the now-stale timeless view the user was looking at.