### PR TITLE
fix(timeless): strip empty sluglines on article conversion

### DIFF
--- a/__tests__/convertArticleType.test.ts
+++ b/__tests__/convertArticleType.test.ts
@@ -171,6 +171,62 @@ describe('prepareArticleConversion', () => {
     expect(result.newDocument.links.find((l) => l.rel === 'subject')?.uuid).toBe('story-uuid')
     expect(result.newDocument.links.find((l) => l.rel === 'source-document')?.uuid).toBe('source-uuid')
   })
+
+  it('strips empty slugline blocks from the pruned document meta', async () => {
+    const sourceDoc = Document.create({
+      uuid: 'timeless-uuid',
+      type: 'core/article#timeless',
+      uri: 'core://article/timeless-uuid',
+      language: 'sv-se',
+      title: 'Timeless',
+      meta: [
+        Block.create({ type: 'tt/slugline', value: '' }),
+        Block.create({ type: 'core/newsvalue', value: '3' })
+      ],
+      links: []
+    })
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    vi.mocked(mockRepository.pruneDocument).mockImplementation((doc) =>
+      Promise.resolve({ document: doc, errors: [] })
+    )
+
+    const result = await prepareArticleConversion({
+      sourceDocument: sourceDoc,
+      targetType: 'core/article',
+      repository: mockRepository,
+      accessToken: 'token'
+    })
+
+    expect(result.newDocument.meta.find((b) => b.type === 'tt/slugline')).toBeUndefined()
+    expect(result.newDocument.meta.find((b) => b.type === 'core/newsvalue')?.value).toBe('3')
+  })
+
+  it('keeps non-empty slugline blocks in the pruned document meta', async () => {
+    const sourceDoc = Document.create({
+      uuid: 'timeless-uuid',
+      type: 'core/article#timeless',
+      uri: 'core://article/timeless-uuid',
+      language: 'sv-se',
+      title: 'Timeless',
+      meta: [Block.create({ type: 'tt/slugline', value: 'kept' })],
+      links: []
+    })
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    vi.mocked(mockRepository.pruneDocument).mockImplementation((doc) =>
+      Promise.resolve({ document: doc, errors: [] })
+    )
+
+    const result = await prepareArticleConversion({
+      sourceDocument: sourceDoc,
+      targetType: 'core/article',
+      repository: mockRepository,
+      accessToken: 'token'
+    })
+
+    expect(result.newDocument.meta.find((b) => b.type === 'tt/slugline')?.value).toBe('kept')
+  })
 })
 
 describe('deriveNewPlanning', () => {
@@ -295,6 +351,28 @@ describe('deriveNewPlanning', () => {
     expect(result.links.find((l) => l.rel === 'story')?.uuid).toBe('story-uuid')
     expect(result.links).toHaveLength(2)
   })
+
+  it('strips empty slugline blocks from the source planning meta', () => {
+    const source = makeSourcePlanning({
+      meta: [
+        Block.create({
+          type: 'core/planning-item',
+          data: { start_date: '2026-04-01', end_date: '2026-04-01' }
+        }),
+        Block.create({ type: 'tt/slugline', value: '' }),
+        Block.create({ type: 'core/newsvalue', value: '3' })
+      ]
+    })
+
+    const result = deriveNewPlanning({
+      sourcePlanning: source,
+      targetDate: '2026-05-15',
+      newUuid: 'fresh-planning-uuid'
+    })
+
+    expect(result.meta.find((b) => b.type === 'tt/slugline')).toBeUndefined()
+    expect(result.meta.find((b) => b.type === 'core/newsvalue')?.value).toBe('3')
+  })
 })
 
 describe('buildFallbackPlanning', () => {
@@ -350,16 +428,31 @@ describe('buildFallbackPlanning', () => {
     expect(result.links[0]).toMatchObject({ type: 'core/section', uuid: 'section-uuid' })
   })
 
-  it('emits empty slugline/newsvalue when the timeless has none', () => {
+  it('omits the slugline block but emits an empty newsvalue when the timeless has none', () => {
     const result = buildFallbackPlanning({
       sourceTimeless: makeTimeless({ meta: [], links: [] }),
       targetDate: '2026-05-15',
       newUuid: 'fresh-uuid'
     })
 
-    expect(result.meta.find((b) => b.type === 'tt/slugline')).toBeDefined()
+    expect(result.meta.find((b) => b.type === 'tt/slugline')).toBeUndefined()
     expect(result.meta.find((b) => b.type === 'core/newsvalue')).toBeDefined()
     expect(result.links).toHaveLength(0)
+  })
+
+  it('omits the slugline block when the timeless slugline value is empty', () => {
+    const result = buildFallbackPlanning({
+      sourceTimeless: makeTimeless({
+        meta: [
+          Block.create({ type: 'tt/slugline', value: '' }),
+          Block.create({ type: 'core/newsvalue', value: '4' })
+        ]
+      }),
+      targetDate: '2026-05-15',
+      newUuid: 'fresh-uuid'
+    })
+
+    expect(result.meta.find((b) => b.type === 'tt/slugline')).toBeUndefined()
   })
 })
 
@@ -477,6 +570,60 @@ describe('attachArticleAssignment', () => {
       type: 'core/article',
       uuid: 'article-uuid'
     })
+  })
+
+  it('drops the slugline block when the planning slugline is empty', () => {
+    const planning = Document.create({
+      uuid: 'planning-uuid',
+      type: 'core/planning-item',
+      uri: 'core://newscoverage/planning-uuid',
+      language: 'sv-se',
+      title: 'Planning',
+      meta: [Block.create({ type: 'tt/slugline', value: '' })]
+    })
+
+    const result = attachArticleAssignment({
+      planning,
+      articleId: 'article-uuid',
+      articleTitle: 'Test',
+      targetDate: '2026-05-15'
+    })
+
+    const assignment = findAssignment(result)
+    expect(assignment?.meta.find((m) => m.type === 'tt/slugline')).toBeUndefined()
+  })
+
+  it('drops the slugline block when the planning has no slugline at all', () => {
+    const planning = Document.create({
+      uuid: 'planning-uuid',
+      type: 'core/planning-item',
+      uri: 'core://newscoverage/planning-uuid',
+      language: 'sv-se',
+      title: 'Planning',
+      meta: []
+    })
+
+    const result = attachArticleAssignment({
+      planning,
+      articleId: 'article-uuid',
+      articleTitle: 'Test',
+      targetDate: '2026-05-15'
+    })
+
+    const assignment = findAssignment(result)
+    expect(assignment?.meta.find((m) => m.type === 'tt/slugline')).toBeUndefined()
+  })
+
+  it('keeps the slugline block when the planning carries a value', () => {
+    const result = attachArticleAssignment({
+      planning: makePlanning(),
+      articleId: 'article-uuid',
+      articleTitle: 'Test',
+      targetDate: '2026-05-15'
+    })
+
+    const assignment = findAssignment(result)
+    expect(assignment?.meta.find((m) => m.type === 'tt/slugline')?.value).toBe('feature-x')
   })
 })
 

--- a/shared/convertArticleType.ts
+++ b/shared/convertArticleType.ts
@@ -11,6 +11,16 @@ export interface ArticleConversionResult {
   errors: ValidationResult[]
 }
 
+// Repository rejects `tt/slugline` blocks whose value is empty. With the
+// `hasLooseSlugline` feature flag the editor leaves these blocks in the source
+// document, so we have to strip them before persisting anything derived from
+// it.
+const isEmptySlugline = (block: Block): boolean =>
+  block.type === 'tt/slugline' && !block.value?.trim()
+
+const withoutEmptySluglines = (blocks: Block[]): Block[] =>
+  blocks.filter((block) => !isEmptySlugline(block))
+
 /**
  * Prune the source document against the target type and build a new document
  * with a fresh UUID plus a rel='source' link back to the original. The caller
@@ -52,6 +62,7 @@ export async function prepareArticleConversion({
       ...prunedDoc,
       uuid: newUuid,
       uri: `core://article/${newUuid}`,
+      meta: withoutEmptySluglines(prunedDoc.meta),
       links: [
         ...prunedDoc.links,
         Block.create({
@@ -97,7 +108,7 @@ export function buildFallbackPlanning({
       }
     }),
     newsvalue ? Block.create({ ...newsvalue }) : Block.create({ type: 'core/newsvalue' }),
-    slugline ? Block.create({ ...slugline }) : Block.create({ type: 'tt/slugline' }),
+    ...(slugline && !isEmptySlugline(slugline) ? [Block.create({ ...slugline })] : []),
     Block.create({
       type: 'core/description',
       data: { text: '' },
@@ -136,7 +147,7 @@ export function deriveNewPlanning({
   newUuid: string
 }): Document {
   const updatedMeta = sourcePlanning.meta
-    .filter((block) => block.type !== 'core/assignment')
+    .filter((block) => block.type !== 'core/assignment' && !isEmptySlugline(block))
     .map((block) => {
       if (block.type !== 'core/planning-item') {
         return block
@@ -197,9 +208,13 @@ export function attachArticleAssignment({
 
   // bulkUpdate bypasses stripEmptyValidatedMetaBlocks, so drop the
   // template's empty internal description and re-add it only when we
-  // have text. Public descriptions and other meta blocks are left alone.
+  // have text. The template also always emits a `tt/slugline` block, so
+  // drop it when empty (hasLooseSlugline allows that). Public descriptions
+  // and other meta blocks are left alone.
   const metaWithoutInternal = assignment.meta.filter(
-    (block) => !(block.type === 'core/description' && block.role === 'internal')
+    (block) =>
+      !(block.type === 'core/description' && block.role === 'internal')
+      && !isEmptySlugline(block)
   )
   const internalDescription = inheritedInternalDescription
     ? [Block.create({


### PR DESCRIPTION
Filter empty tt/slugline blocks from the pruned article meta, the fallback and derived planning meta, and the new assignment meta. Cover each strip site with a test and update the fallback-planning test that asserted the old behavior.