### PR TITLE
fix(redis): exit on cache reconnect exhaustion

### DIFF
--- a/__tests__/server/Redis.test.ts
+++ b/__tests__/server/Redis.test.ts
@@ -121,6 +121,47 @@ describe('Redis', () => {
       expect(strategy(10)).not.toBeInstanceOf(Error)
       expect(strategy(11)).toBeInstanceOf(Error)
     })
+
+    test('reconnectStrategy fires onUnrecoverable once when retries exhausted', async () => {
+      vi.mocked(createClient).mockClear()
+      const onUnrecoverable = vi.fn()
+
+      const redis = new Redis('redis://cache:6379', onUnrecoverable)
+      await redis.connect()
+
+      const args = vi.mocked(createClient).mock.calls[0][0]
+      const strategy = (args!.socket as { reconnectStrategy: (n: number) => number | Error }).reconnectStrategy
+
+      // Within the budget - callback must not fire
+      strategy(5)
+      strategy(10)
+      await new Promise((resolve) => queueMicrotask(() => resolve(undefined)))
+      expect(onUnrecoverable).not.toHaveBeenCalled()
+
+      // Exhausted - callback fires (via queueMicrotask)
+      strategy(11)
+      await new Promise((resolve) => queueMicrotask(() => resolve(undefined)))
+      expect(onUnrecoverable).toHaveBeenCalledTimes(1)
+
+      // Subsequent exhausted calls do not fire it again
+      strategy(12)
+      strategy(13)
+      await new Promise((resolve) => queueMicrotask(() => resolve(undefined)))
+      expect(onUnrecoverable).toHaveBeenCalledTimes(1)
+    })
+
+    test('reconnectStrategy still returns Error when no callback provided', async () => {
+      vi.mocked(createClient).mockClear()
+
+      const redis = new Redis('redis://cache:6379')
+      await redis.connect()
+
+      const args = vi.mocked(createClient).mock.calls[0][0]
+      const strategy = (args!.socket as { reconnectStrategy: (n: number) => number | Error }).reconnectStrategy
+
+      expect(() => strategy(11)).not.toThrow()
+      expect(strategy(11)).toBeInstanceOf(Error)
+    })
   })
 
   describe('get', () => {

--- a/src-srv/index.ts
+++ b/src-srv/index.ts
@@ -71,8 +71,13 @@ export async function runServer(): Promise<string> {
 
   const routes = await mapRoutes(apiDir)
 
-  // Connect to Redis
-  const redis = new RedisCache(REDIS_URL)
+  // Exit on cache reconnect exhaustion so Kubernetes restarts the pod. The
+  // cache is the durable backstop for the 15-120s repo debounce window;
+  // continuing to serve with a dead cache silently no-ops new writes.
+  const redis = new RedisCache(REDIS_URL, () => {
+    logger.fatal('redis cache reconnect attempts exhausted, exiting')
+    process.exit(1)
+  })
 
   await redis.connect().catch((ex) => {
     throw new Error('connect to redis cache', { cause: ex })

--- a/src-srv/utils/Redis.ts
+++ b/src-srv/utils/Redis.ts
@@ -6,10 +6,13 @@ const BASE_PREFIX = 'elc::hp'
 
 export class Redis {
   readonly #url: string
+  readonly #onUnrecoverable?: () => void
+  #unrecoverableFired = false
   #redisClient?: RedisClientType
 
-  constructor(url: string) {
+  constructor(url: string, onUnrecoverable?: () => void) {
     this.#url = url
+    this.#onUnrecoverable = onUnrecoverable
     this.#redisClient = undefined
   }
 
@@ -22,6 +25,10 @@ export class Redis {
       socket: {
         reconnectStrategy: (retries: number) => {
           if (retries > 10) {
+            if (!this.#unrecoverableFired) {
+              this.#unrecoverableFired = true
+              queueMicrotask(() => this.#onUnrecoverable?.())
+            }
             return new Error('Redis cache reconnect attempts exhausted')
           }
           return Math.min(retries * 100, 2000)


### PR DESCRIPTION
Add optional onUnrecoverable callback to the Redis class. The reconnectStrategy invokes it once, deferred via queueMicrotask, before returning its terminal Error after 10 failed attempts. Wire the callback in index.ts to log fatal and process.exit(1).

Refs ELELOG-657