### PR TITLE
fix(timeless): sync document.title from heading-1

### DIFF
--- a/__tests__/transformations/document.test.ts
+++ b/__tests__/transformations/document.test.ts
@@ -237,3 +237,41 @@ describe('Description and slugline handling in planning', () => {
     })
   })
 })
+
+
+describe('document.title derived from heading-1 on serialize', () => {
+  function buildResponse(type: string): GetDocumentResponse {
+    if (!article.document) {
+      throw new Error('article fixture missing document')
+    }
+    return {
+      ...article,
+      document: {
+        ...article.document,
+        type,
+        title: 'stale title from creation',
+        content: article.document.content.map((block) => (
+          block.role === 'heading-1'
+            ? { ...block, data: { ...block.data, text: 'edited heading' } }
+            : block
+        ))
+      }
+    }
+  }
+
+  it('uses heading-1 text as title for core/article', () => {
+    const yDoc = new Y.Doc()
+    toYjsNewsDoc(toGroupedNewsDoc(buildResponse('core/article')), yDoc)
+
+    const { document } = fromYjsNewsDoc(yDoc)
+    expect(document?.title).toBe('edited heading')
+  })
+
+  it('uses heading-1 text as title for core/article#timeless', () => {
+    const yDoc = new Y.Doc()
+    toYjsNewsDoc(toGroupedNewsDoc(buildResponse('core/article#timeless')), yDoc)
+
+    const { document } = fromYjsNewsDoc(yDoc)
+    expect(document?.title).toBe('edited heading')
+  })
+})

--- a/shared/transformations/yjsNewsDoc.ts
+++ b/shared/transformations/yjsNewsDoc.ts
@@ -56,7 +56,7 @@ export function fromYjsNewsDoc(yDoc: Y.Doc): EleDocumentResponse {
 
   const links = (yEle.get('links') as Y.Map<unknown>).toJSON() || {}
 
-  const isTextDocument = ['core/article', 'core/editorial-info', 'core/flash'].includes(type)
+  const isTextDocument = ['core/article', 'core/article#timeless', 'core/editorial-info', 'core/flash'].includes(type)
   const yContent = yEle.get('content') as Y.XmlText
   const content = yContent.length
     ? removeConsecutiveEmptyTextNodes(yTextToSlateElement(yContent).children)


### PR DESCRIPTION
Add core/article#timeless to the isTextDocument list in fromYjsNewsDoc so heading-1 text becomes document.title on serialize.

Cover both core/article and core/article#timeless in document.test.ts.