### PR TITLE
fix(prompt): route click-outside through dismiss fallback

### DIFF
--- a/__tests__/Prompt.clickOutside.test.tsx
+++ b/__tests__/Prompt.clickOutside.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { Prompt } from '@/components/Prompt'
+
+const firePointerDownOutside = async () => {
+  // Radix attaches its document-level pointerdown listener in a setTimeout(0)
+  // inside an effect, so flush a tick before firing the event.
+  await waitFor(() => {
+    expect(screen.getByText('Confirm')).toBeInTheDocument()
+  })
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  fireEvent.pointerDown(document.body, {
+    pointerType: 'mouse',
+    button: 0
+  })
+}
+
+describe('Prompt click-outside', () => {
+  it('calls onCancel when no onSecondary is provided', async () => {
+    const onPrimary = vi.fn()
+    const onCancel = vi.fn()
+
+    render(
+      <Prompt
+        title='Confirm'
+        description='Are you sure?'
+        primaryLabel='OK'
+        onPrimary={onPrimary}
+        onCancel={onCancel}
+      />
+    )
+
+    await firePointerDownOutside()
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onPrimary).not.toHaveBeenCalled()
+  })
+
+  it('calls onSecondary when no onCancel is provided', async () => {
+    const onPrimary = vi.fn()
+    const onSecondary = vi.fn()
+
+    render(
+      <Prompt
+        title='Confirm'
+        description='Are you sure?'
+        primaryLabel='OK'
+        onPrimary={onPrimary}
+        onSecondary={onSecondary}
+      />
+    )
+
+    await firePointerDownOutside()
+
+    expect(onSecondary).toHaveBeenCalledTimes(1)
+    expect(onPrimary).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/Prompt.tsx
+++ b/src/components/Prompt.tsx
@@ -94,9 +94,7 @@ export const Prompt = ({
           className={cn('z-50', 'max-w-lg')}
           style={{ ...dialogStyle, ...(anchorRect && anchorRect.width < 512 && { maxWidth: anchorRect.width }) }}
           onPointerDownOutside={() => {
-            if (onSecondary) {
-              onSecondary()
-            }
+            dismiss?.()
           }}
         >
           <DialogHeader>


### PR DESCRIPTION
The Escape handler in Prompt already falls back to `onCancel` when `onSecondary` is not supplied (via `dismiss = onCancel ?? onSecondary`), but the `onPointerDownOutside` handler still only invoked `onSecondary` and no-op'd otherwise. Consumers like `RemoveHastFromArticle` that pass only `onCancel` saw the dialog close visually while the parent's open state remained stuck, so the trigger button could not reopen the prompt.

Route the pointer-outside handler through the same `dismiss` binding so click-outside behaves identically to Escape.