### PR TITLE
fix(documents): derive PATCH context from session, including units

### DIFF
--- a/__tests__/server/documentsPatchContext.test.ts
+++ b/__tests__/server/documentsPatchContext.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import * as Y from 'yjs'
+import type { Request, Response } from 'express'
+
+vi.mock('../../src-srv/lib/logger.js', () => ({
+  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn() }
+}))
+
+import { PATCH } from '../../src-srv/api/documents/[id]/index.js'
+import type { RouteContext } from '../../src-srv/routes.js'
+import type { CollaborationServer } from '../../src-srv/collaboration/CollaborationServer.js'
+import type { Context } from '../../src-srv/lib/context.js'
+import type { Redis } from '../../src-srv/utils/Redis.js'
+import type { Repository } from '@/shared/Repository.js'
+import { toYjsNewsDoc } from '@/shared/transformations/yjsNewsDoc.js'
+import { toGroupedNewsDoc } from '@/shared/transformations/groupedNewsDoc.js'
+import { planning } from '../data/planning-newsdoc.js'
+
+const PLANNING_UUID = '726045e7-a52b-4737-8fba-c8149f7e2c2d'
+const EXISTING_DELIVERABLE = 'f283c9a0-6a2e-4021-a009-087961dd032f'
+
+function makePlanningYDoc(): Y.Doc {
+  const yDoc = new Y.Doc()
+  toYjsNewsDoc(toGroupedNewsDoc(planning), yDoc)
+  return yDoc
+}
+
+function makeHarness(yDoc: Y.Doc, sessionUnits: string[] | undefined) {
+  const transact = vi.fn((cb: (doc: Y.Doc) => void) => {
+    cb(yDoc)
+    return Promise.resolve()
+  })
+  const disconnect = vi.fn(() => Promise.resolve())
+  const openDirectConnection = vi.fn(
+    (_id: string, _context: Context) => Promise.resolve({ transact, disconnect })
+  )
+  const flushDocument = vi.fn(() => Promise.resolve({ version: 2n }))
+
+  const collaborationServer = {
+    server: { openDirectConnection },
+    flushDocument
+  } as unknown as CollaborationServer
+  const repository = {} as unknown as Repository
+  const cache = {} as Redis
+  const res = {
+    locals: {
+      session: {
+        accessToken: 'tok',
+        user: { name: 'Testy', sub: 'user-1' },
+        ...(sessionUnits === undefined ? {} : { units: sessionUnits })
+      }
+    }
+  } as unknown as Response
+
+  const context: RouteContext = { collaborationServer, repository, cache, res }
+
+  return { context, openDirectConnection, flushDocument }
+}
+
+function makeReq(): Request {
+  return {
+    params: { id: PLANNING_UUID },
+    body: {
+      assignment: {
+        deliverableId: EXISTING_DELIVERABLE,
+        type: 'core/article',
+        status: 'withheld',
+        time: '2030-12-31T10:30:00Z'
+      }
+    }
+  } as unknown as Request
+}
+
+describe('PATCH /api/documents/:id context derivation', () => {
+  let yDoc: Y.Doc
+
+  beforeEach(() => {
+    yDoc = makePlanningYDoc()
+  })
+
+  it('passes session.units through to the collaboration context', async () => {
+    const units = ['unit-a', 'unit-b']
+    const h = makeHarness(yDoc, units)
+
+    const result = await PATCH(makeReq(), h.context)
+
+    expect(result).toMatchObject({ statusCode: 200 })
+    expect(h.openDirectConnection).toHaveBeenCalledTimes(1)
+    const passedContext = h.openDirectConnection.mock.calls[0][1]
+    expect(passedContext.units).toEqual(units)
+    expect(passedContext.accessToken).toBe('tok')
+    expect(passedContext.user).toMatchObject({ sub: 'user-1' })
+    expect(passedContext.agent).toBe('server')
+  })
+
+  it('defaults context.units to [] when the session has no units', async () => {
+    const h = makeHarness(yDoc, undefined)
+
+    const result = await PATCH(makeReq(), h.context)
+
+    expect(result).toMatchObject({ statusCode: 200 })
+    expect(h.openDirectConnection).toHaveBeenCalledTimes(1)
+    const passedContext = h.openDirectConnection.mock.calls[0][1]
+    expect(passedContext.units).toEqual([])
+  })
+})

--- a/src-srv/api/documents/[id]/index.ts
+++ b/src-srv/api/documents/[id]/index.ts
@@ -6,10 +6,9 @@ import { fromYjsNewsDoc } from '@/shared/transformations/yjsNewsDoc.js'
 import * as Y from 'yjs'
 import logger from '../../../lib/logger.js'
 
-import { type Context, isContext } from '../../../lib/context.js'
+import { isContext, getSession, getContextFromValidSession } from '../../../lib/context.js'
 import { getValueByYPath, setValueByYPath } from '../../../../shared/yUtils.js'
 import type { EleBlock } from '@/shared/types/index.js'
-import { getSession } from '../../../lib/context.js'
 import { snapshot } from '../../../utils/snapshot.js'
 
 /**
@@ -128,13 +127,10 @@ export const GET: RouteHandler = async (req: Request, { cache, repository, res }
  * - Set start time for draft
  */
 export const PATCH: RouteHandler = async (req: Request, { collaborationServer, res }) => {
-  const { accessToken, user } = getSession(req, res)
-
-  if (!accessToken || !user) {
-    return {
-      statusCode: 401,
-      statusMessage: 'Unauthorized: Session not found, can not snapshot document'
-    }
+  const locals = res.locals as Record<string, unknown> | undefined
+  const context = getContextFromValidSession(locals?.session)
+  if (!isContext(context)) {
+    return context
   }
 
   // Validate incoming data
@@ -159,20 +155,6 @@ export const PATCH: RouteHandler = async (req: Request, { collaborationServer, r
     return {
       statusCode: 400,
       statusMessage: 'Invalid input to document PATCH method'
-    }
-  }
-
-  const context: Context = {
-    accessToken,
-    user,
-    agent: 'server',
-    units: []
-  }
-
-  if (!isContext(context)) {
-    return {
-      statusCode: 500,
-      statusMessage: 'Invalid context provided'
     }
   }
 

--- a/src-srv/routes.ts
+++ b/src-srv/routes.ts
@@ -23,7 +23,7 @@ interface RouteInitContext {
   [key: string]: unknown
 }
 
-interface RouteContext extends RouteInitContext {
+export interface RouteContext extends RouteInitContext {
   res: Response
 }
 


### PR DESCRIPTION
The PATCH handler built `Context` manually with `units: []` instead of deriving it from `res.locals.session`, leaving the new `Context.units` field silently empty. Today PATCH does not call `buildAcl`, so the gap is latent,.
- Swap the bespoke session unpack + manual `Context` literal for `getContextFromValidSession(res.locals.session)`, the same helper the rest of the API uses. The 401 / 500 short-circuits are still produced by that helper, so the external contract is unchanged for valid sessions; the only behavioural delta is that `Context.units` now reflects the session's units.
- Export `RouteContext` from `routes.ts` so the new test can type the mock handler context.
- New `__tests__/server/documentsPatchContext.test.ts` asserts that `session.units` is forwarded into the context handed to `openDirectConnection`, and that an absent `units` field defaults to `[]`.