### PR TITLE
fix(factboxes): surface bulk-get batch failures instead of silently d…

### DIFF
--- a/__tests__/withArticleFactboxes.test.ts
+++ b/__tests__/withArticleFactboxes.test.ts
@@ -319,6 +319,49 @@ describe('withArticleFactboxes', () => {
     })
   })
 
+  describe('batch failure handling', () => {
+    it('logs a warning with the batch\'s article ids when the bulk-get rejects', async () => {
+      vi.mocked(fetchMock).mockResolvedValue([
+        makeArticleHit('a1', ['Standalone-search hit']),
+        makeArticleHit('a2', ['Other'])
+      ] as unknown as HitV1[])
+
+      getDocumentsMock.mockRejectedValueOnce(new Error('repository down'))
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const out = await withArticleFactboxes<HitV1>({ hits: [], session, index, repository })
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      const payload = warnSpy.mock.calls[0][1] as { articleIds: string[], reason: Error }
+      expect(payload).toMatchObject({ articleIds: ['a1', 'a2'] })
+      expect(payload.reason).toBeInstanceOf(Error)
+      // Rows still emitted from indexed titles, just without text/source uuid.
+      expect(out).toHaveLength(2)
+      expect(out.every((r) => r.fields._document_origin_id?.values[0] === '')).toBe(true)
+
+      warnSpy.mockRestore()
+    })
+
+    it('logs a warning when the bulk-get resolves to null (silent-drop scenario)', async () => {
+      vi.mocked(fetchMock).mockResolvedValue([
+        makeArticleHit('a1', ['Only'])
+      ] as unknown as HitV1[])
+
+      getDocumentsMock.mockResolvedValueOnce(null)
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      await withArticleFactboxes<HitV1>({ hits: [], session, index, repository })
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy.mock.calls[0][1]).toMatchObject({
+        articleIds: ['a1'],
+        reason: 'null response'
+      })
+
+      warnSpy.mockRestore()
+    })
+  })
+
   describe('result shape', () => {
     it('passes standalone hits through and tags origin', async () => {
       const standalone = { id: 'fb1', fields: {} } as unknown as HitV1

--- a/src/hooks/index/useDocuments/lib/withArticleFactboxes.ts
+++ b/src/hooks/index/useDocuments/lib/withArticleFactboxes.ts
@@ -133,7 +133,11 @@ const fetchFactboxData = async (
     batches.push(articleIds.slice(i, i + BATCH_SIZE))
   }
 
-  const batchResponses = await Promise.all(
+  // allSettled isolates per-batch failures so one bad batch doesn't drop the
+  // rest. Both rejection and a null response are treated as failures and
+  // logged with the batch's article ids - previously they vanished silently
+  // and embedded factboxes for those articles disappeared from search.
+  const batchResults = await Promise.allSettled(
     batches.map((batch) => repository.getDocuments({
       documents: batch.map((uuid) => ({ uuid })),
       accessToken,
@@ -141,7 +145,22 @@ const fetchFactboxData = async (
     }))
   )
 
-  const allItems: BulkGetItem[] = batchResponses.flatMap((response) => response?.items ?? [])
+  const allItems: BulkGetItem[] = []
+
+  batchResults.forEach((result, i) => {
+    if (result.status === 'fulfilled' && result.value) {
+      allItems.push(...result.value.items)
+      return
+    }
+
+    const reason: Error | string = result.status === 'rejected'
+      ? (result.reason instanceof Error ? result.reason : new Error(String(result.reason)))
+      : 'null response'
+    console.warn(
+      '[withArticleFactboxes] bulk-get batch failed, embedded factboxes dropped:',
+      { articleIds: batches[i], reason }
+    )
+  })
 
   for (const item of allItems) {
     const articleId = item.uuid


### PR DESCRIPTION
…ropping rows

Switch the per-article bulk-get to Promise.allSettled and log a warning with the batch's article ids when a batch rejects or resolves to null. Previously the defensive `response?.items ?? []` collapsed a failed batch into an empty list, so embedded factboxes for those articles vanished from search without any signal to devs or users. Standalone factboxes and successful batches still merge in as before.