### PR TITLE
fix(factbox): surface drag-drop fetch failures instead of inserting a…

### DIFF
--- a/__tests__/factboxConsume.test.ts
+++ b/__tests__/factboxConsume.test.ts
@@ -3,7 +3,10 @@ import { Block } from '@ttab/elephant-api/newsdoc'
 import type { TBElement, TBResource } from '@ttab/textbit'
 import type { Session } from 'next-auth'
 import type { Repository } from '@/shared/Repository'
+import { toast } from 'sonner'
 import { createFactboxConsume } from '../src/plugins/Factboxes/consume'
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }))
 
 type DragPayload = {
   id: string
@@ -256,10 +259,11 @@ describe('createFactboxConsume', () => {
   })
 
   describe('repository failure handling', () => {
-    it('treats a repository.getDocument rejection as no document and uses fallback children', async () => {
+    it('refuses the insert and surfaces a toast when getDocument rejects (standalone)', async () => {
       const { repo, getDocument } = makeRepo()
       getDocument.mockRejectedValue(new Error('boom'))
       const consume = createFactboxConsume(repo, session)
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       const result = await runConsume(consume, {
         id: STANDALONE_ID,
@@ -267,12 +271,30 @@ describe('createFactboxConsume', () => {
         text: 'fallback body line 1\nfallback body line 2'
       })
 
-      // No transformFactbox path → fallbackChildren uses payload.text split on newlines.
-      const body = result?.data.children.find((c) => c.type === 'core/factbox/body')
-      const bodyTexts = (body?.children as TBElement[]).map(
-        (c) => (c.children as { text: string }[])[0].text
-      )
-      expect(bodyTexts).toEqual(['fallback body line 1', 'fallback body line 2'])
+      expect(result).toBeUndefined()
+      expect(toast.error).toHaveBeenCalledTimes(1)
+      expect(consoleError).toHaveBeenCalled()
+
+      consoleError.mockRestore()
+    })
+
+    it('refuses the insert and surfaces a toast when getDocument rejects (embedded)', async () => {
+      const { repo, getDocument } = makeRepo()
+      getDocument.mockRejectedValue(new Error('boom'))
+      const consume = createFactboxConsume(repo, session)
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const result = await runConsume(consume, {
+        id: `${ARTICLE_ID}:embedded:0`,
+        title: 't',
+        text: ''
+      })
+
+      expect(result).toBeUndefined()
+      expect(toast.error).toHaveBeenCalledTimes(1)
+      expect(consoleError).toHaveBeenCalled()
+
+      consoleError.mockRestore()
     })
 
     it('returns a result even when getDocument resolves to null/undefined document (standalone)', async () => {

--- a/src/locales/en/errors.json
+++ b/src/locales/en/errors.json
@@ -68,7 +68,8 @@
     "authorSaveFailure": "Could not save author document: {{errorMessage}}",
     "authorCreateFailure": "Could not create author document: Failed to create author doc",
     "authorCreateUndefinedFailed": "Could not create author document: Failed to fetch author document: undefined",
-    "couldNotOpenEmbeddedFactbox": "Could not open the factbox. Please navigate back to the overview and try again."
+    "couldNotOpenEmbeddedFactbox": "Could not open the factbox. Please navigate back to the overview and try again.",
+    "couldNotLoadFactbox": "Could not load factbox. Please try again."
   },
   "systemMessages": {
     "connectionFailed": "Failed to connect to the messaging service, please reload the window."

--- a/src/locales/nb/errors.json
+++ b/src/locales/nb/errors.json
@@ -68,7 +68,8 @@
     "authorSaveFailure": "Kunne ikke lagre forfatterdokumentet: {{errorMessage}}",
     "authorCreateFailure": "Kunne ikke opprette forfatterdokument: Failed to create author doc",
     "authorCreateUndefinedFailed": "Kunne ikke opprette forfatterdokument: Failed to fetch author document: undefined",
-    "couldNotOpenEmbeddedFactbox": "Kunne ikke åpne den faktaboksen. Vennligst naviger tilbake til oversikten og prøv igjen."
+    "couldNotOpenEmbeddedFactbox": "Kunne ikke åpne den faktaboksen. Vennligst naviger tilbake til oversikten og prøv igjen.",
+    "couldNotLoadFactbox": "Kunne ikke laste faktaboksen. Vennligst prøv igjen."
   },
   "systemMessages": {
     "connectionFailed": "Kunne ikke koble til meldingstjenesten. Last inn vinduet på nytt."

--- a/src/locales/sv/errors.json
+++ b/src/locales/sv/errors.json
@@ -68,7 +68,8 @@
     "authorSaveFailure": "Kunde inte spara författardokument: {{errorMessage}}",
     "authorCreateFailure": "Kunde inte skapa författardokument: Failed to create author doc",
     "authorCreateUndefinedFailed": "Kunde inte skapa författardokument: Failed to fetch author document: undefined",
-    "couldNotOpenEmbeddedFactbox": "Kunde inte ladda faktarutan. Vänligen navigera tillbaka till översikten och försök igen."
+    "couldNotOpenEmbeddedFactbox": "Kunde inte ladda faktarutan. Vänligen navigera tillbaka till översikten och försök igen.",
+    "couldNotLoadFactbox": "Kunde inte ladda faktarutan. Vänligen försök igen."
   },
   "systemMessages": {
     "connectionFailed": "Misslyckades att ansluta till meddelandetjänsten, vänligen ladda om fönstret."

--- a/src/plugins/Factboxes/consume.ts
+++ b/src/plugins/Factboxes/consume.ts
@@ -3,6 +3,8 @@ import type { Block } from '@ttab/elephant-api/newsdoc'
 import type { Session } from 'next-auth'
 import type { Repository } from '@/shared/Repository'
 import { transformFactbox } from '@/shared/transformations/newsdoc/core/factbox'
+import { toast } from 'sonner'
+import i18next from 'i18next'
 
 type FactboxDragPayload = {
   id: string
@@ -40,7 +42,9 @@ const fallbackChildren = (payload: FactboxDragPayload): TBElement[] => [
 /**
  * Returns the core/factbox Block for a dragged factbox, either the full
  * document (standalone factboxes) or the nth core/factbox block inside
- * an article (embedded factboxes). Returns undefined if anything fails.
+ * an article (embedded factboxes). Returns undefined if the document
+ * exists but the requested block is missing; throws if the fetch fails
+ * so the caller can refuse the insert and surface the error.
  */
 const fetchFactboxBlock = async (
   payload: FactboxDragPayload,
@@ -51,9 +55,7 @@ const fetchFactboxBlock = async (
 
   if (embedded) {
     const [, articleId, indexStr] = embedded
-    const response = await repository
-      .getDocument({ uuid: articleId, accessToken })
-      .catch(() => undefined)
+    const response = await repository.getDocument({ uuid: articleId, accessToken })
 
     const block = response?.document?.content
       .filter((b) => b.type === 'core/factbox')[parseInt(indexStr)]
@@ -61,11 +63,11 @@ const fetchFactboxBlock = async (
     return block
   }
 
-  const response = await repository
-    .getDocument({ uuid: payload.id, accessToken })
-    .catch(() => undefined)
+  const response = await repository.getDocument({ uuid: payload.id, accessToken })
 
-  if (!response?.document) return undefined
+  if (!response?.document) {
+    return undefined
+  }
 
   const { document } = response
 
@@ -108,7 +110,13 @@ export const createFactboxConsume = (
   let children: TBElement[] | undefined
 
   if (repository && session?.accessToken) {
-    block = await fetchFactboxBlock(payload, repository, session.accessToken)
+    try {
+      block = await fetchFactboxBlock(payload, repository, session.accessToken)
+    } catch (error) {
+      console.error('Failed to fetch factbox for drag-drop:', error)
+      toast.error(i18next.t('errors:toasts.couldNotLoadFactbox'))
+      return undefined
+    }
 
     if (block) {
       const transformed = transformFactbox(block)


### PR DESCRIPTION
… degraded stub

`fetchFactboxBlock` swallowed repository errors with `.catch(() => undefined)`, causing the consume handler to silently fall back to `fallbackChildren(payload)` on network/auth/5xx failures. The user got a rich-looking but degraded factbox with no source link or rich blocks.

The consume handler now logs the error, shows a `couldNotLoadFactbox` toast and returns undefined so textbit refuses the insert. The pre-existing offline-style fallback (no repository, no session, or fetched-but-empty document) is preserved.