### PR TITLE
Localize missing plugin labels in editors

### DIFF
--- a/src/components/QuickDocument/DialogEditor.tsx
+++ b/src/components/QuickDocument/DialogEditor.tsx
@@ -15,7 +15,7 @@ export const DialogEditor = ({ ydoc, setTitle, onValidation, validateStateRef, t
   setTitle: (value: string | undefined) => void
   type: 'article' | 'flash' | 'hast'
 } & FormProps): JSX.Element => {
-  const plugins = [UnorderedList, OrderedList, Bold, Italic, LocalizedQuotationMarks]
+  const plugins = [Bold, Italic, LocalizedQuotationMarks]
   const [content] = getValueByYPath<Y.XmlText>(ydoc.ele, 'content', true)
   const [documentLanguage] = getValueByYPath<string>(ydoc.ele, 'root.language')
   const { t } = useTranslation('flash')
@@ -51,6 +51,8 @@ export const DialogEditor = ({ ydoc, setTitle, onValidation, validateStateRef, t
         content={content}
         lang={documentLanguage}
         plugins={[
+          UnorderedList({ title: t('editor:contentMenu.unorderedList') }),
+          OrderedList({ title: t('editor:contentMenu.orderedList') }),
           ...plugins.map((initPlugin) => initPlugin()),
           Text({
             countCharacters,

--- a/src/views/Editor/index.tsx
+++ b/src/views/Editor/index.tsx
@@ -149,8 +149,8 @@ function EditorWrapper(props: ViewProps & {
       FactboxPlugin({ openFactboxes }),
       Table(),
       LocalizedQuotationMarks(),
-      OrderedList(),
-      UnorderedList(),
+      OrderedList({ title: t('editor:contentMenu.orderedList') }),
+      UnorderedList({ title: t('editor:contentMenu.unorderedList') }),
       TTVisual({
         captionLabel: t('editor:image.captionLabel'),
         bylineLabel: t('editor:image.bylineLabel'),

--- a/src/views/PrintEditor/index.tsx
+++ b/src/views/PrintEditor/index.tsx
@@ -135,8 +135,8 @@ function EditorWrapper(props: ViewProps & {
           const details = await repository!.getAttachmentDetails(uploadId, data?.accessToken || '')
           return details?.downloadLink ?? ''
         },
-        captionLabel: 'Text',
-        bylineLabel: 'Byline'
+        captionLabel: t('editor:image.captionLabel'),
+        bylineLabel: t('editor:image.bylineLabel')
       }),
       TVListing({
         channelComponent: () => ChannelComboBox()
@@ -149,7 +149,11 @@ function EditorWrapper(props: ViewProps & {
       Factbox({
         headerTitle: t('editor:factbox.headerTitle'),
         modifiedLabel: t('editor:factbox.modifiedLabel'),
+        createdLabel: t('editor:factbox.createdLabel'),
+        lastModifiedLabel: t('editor:factbox.lastModifiedLabel'),
         footerTitle: t('editor:factbox.footerTitle'),
+        factboxNewTitle: t('editor:factbox.factboxNewTitle'),
+        addSingleLabel: t('editor:factbox.addSingleLabel'),
         onEditOriginal: (id: string) => {
           openFactboxEditor(undefined, { id })
         },


### PR DESCRIPTION
Pass translated titles to UnorderedList/OrderedList in Editor and DialogEditor, and fill in missing Factbox and Image labels in PrintEditor so they no longer fall back to English defaults.