### PR TITLE
fix(editor): show platform-aware keyboard shortcut legend

### DIFF
--- a/__tests__/formatHotkey.test.ts
+++ b/__tests__/formatHotkey.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { formatHotkey } from '@/lib/formatHotkey'
+
+describe('formatHotkey', () => {
+  describe('on Mac', () => {
+    const isMac = true
+
+    it('renders modifier glyphs joined without separator', () => {
+      expect(formatHotkey('mod+option+1', isMac)).toBe('⌘⌥1')
+    })
+
+    it('maps mod to command glyph', () => {
+      expect(formatHotkey('mod+b', isMac)).toBe('⌘B')
+    })
+
+    it('maps option/alt to option glyph', () => {
+      expect(formatHotkey('mod+option+1', isMac)).toBe('⌘⌥1')
+      expect(formatHotkey('mod+alt+1', isMac)).toBe('⌘⌥1')
+    })
+
+    it('maps shift and ctrl to their glyphs', () => {
+      expect(formatHotkey('shift+ctrl+a', isMac)).toBe('⇧⌃A')
+    })
+
+    it('maps arrow keys to arrow glyphs', () => {
+      expect(formatHotkey('mod+option+up', isMac)).toBe('⌘⌥↑')
+      expect(formatHotkey('mod+option+down', isMac)).toBe('⌘⌥↓')
+    })
+  })
+
+  describe('on non-Mac (Windows/Linux/Chromebook)', () => {
+    const isMac = false
+
+    it('renders modifier names joined by plus signs', () => {
+      expect(formatHotkey('mod+option+1', isMac)).toBe('Ctrl+Alt+1')
+    })
+
+    it('maps mod and ctrl to "Ctrl"', () => {
+      expect(formatHotkey('mod+b', isMac)).toBe('Ctrl+B')
+      expect(formatHotkey('ctrl+b', isMac)).toBe('Ctrl+B')
+    })
+
+    it('maps option/alt to "Alt"', () => {
+      expect(formatHotkey('mod+option+1', isMac)).toBe('Ctrl+Alt+1')
+      expect(formatHotkey('mod+alt+1', isMac)).toBe('Ctrl+Alt+1')
+    })
+
+    it('uppercases letter keys', () => {
+      expect(formatHotkey('mod+i', isMac)).toBe('Ctrl+I')
+      expect(formatHotkey('mod+u', isMac)).toBe('Ctrl+U')
+    })
+
+    it('passes digits through unchanged', () => {
+      expect(formatHotkey('mod+option+0', isMac)).toBe('Ctrl+Alt+0')
+      expect(formatHotkey('mod+option+3', isMac)).toBe('Ctrl+Alt+3')
+    })
+
+    it('maps arrow keys to arrow glyphs', () => {
+      expect(formatHotkey('mod+option+up', isMac)).toBe('Ctrl+Alt+↑')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns empty string for undefined', () => {
+      expect(formatHotkey(undefined, false)).toBe('')
+      expect(formatHotkey(undefined, true)).toBe('')
+    })
+
+    it('returns empty string for empty input', () => {
+      expect(formatHotkey('', false)).toBe('')
+      expect(formatHotkey('', true)).toBe('')
+    })
+
+    it('handles a single key without modifiers', () => {
+      expect(formatHotkey('b', false)).toBe('B')
+      expect(formatHotkey('b', true)).toBe('B')
+    })
+
+    it('is case-insensitive on input tokens', () => {
+      expect(formatHotkey('MOD+OPTION+1', false)).toBe('Ctrl+Alt+1')
+      expect(formatHotkey('MOD+OPTION+1', true)).toBe('⌘⌥1')
+    })
+  })
+
+  describe('default isMac argument (uses isMacOs)', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('renders Mac glyphs when the current platform is detected as Mac', () => {
+      vi.stubGlobal('navigator', { platform: 'MacIntel' })
+      expect(formatHotkey('mod+option+1')).toBe('⌘⌥1')
+    })
+
+    it('renders Ctrl+Alt+... when the current platform is not Mac', () => {
+      vi.stubGlobal('navigator', { platform: 'Win32' })
+      expect(formatHotkey('mod+option+1')).toBe('Ctrl+Alt+1')
+    })
+  })
+})

--- a/__tests__/isMacOs.test.ts
+++ b/__tests__/isMacOs.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { isMacOs } from '@/lib/isMacOs'
+
+describe('isMacOs', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('userAgentData.platform (modern API)', () => {
+    it('returns true when userAgentData.platform reports macOS', () => {
+      vi.stubGlobal('navigator', {
+        userAgentData: { platform: 'macOS' },
+        platform: 'Win32',
+        userAgent: 'Mozilla/5.0 (irrelevant)'
+      })
+      expect(isMacOs()).toBe(true)
+    })
+
+    it('returns false when userAgentData.platform reports Windows even if userAgent contains "Mac"', () => {
+      vi.stubGlobal('navigator', {
+        userAgentData: { platform: 'Windows' },
+        platform: 'MacIntel',
+        userAgent: 'Macintosh; misleading'
+      })
+      expect(isMacOs()).toBe(false)
+    })
+  })
+
+  describe('navigator.platform fallback', () => {
+    it('returns true when navigator.platform is MacIntel and userAgentData is absent', () => {
+      vi.stubGlobal('navigator', {
+        platform: 'MacIntel',
+        userAgent: 'irrelevant'
+      })
+      expect(isMacOs()).toBe(true)
+    })
+
+    it('returns false when navigator.platform is Win32', () => {
+      vi.stubGlobal('navigator', {
+        platform: 'Win32',
+        userAgent: 'irrelevant'
+      })
+      expect(isMacOs()).toBe(false)
+    })
+
+    it('returns false when navigator.platform is Linux', () => {
+      vi.stubGlobal('navigator', {
+        platform: 'Linux x86_64',
+        userAgent: 'irrelevant'
+      })
+      expect(isMacOs()).toBe(false)
+    })
+  })
+
+  describe('userAgent fallback', () => {
+    it('returns true when only userAgent mentions Macintosh', () => {
+      vi.stubGlobal('navigator', {
+        platform: '',
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)'
+      })
+      expect(isMacOs()).toBe(true)
+    })
+
+    it('returns false when userAgent is a Windows UA', () => {
+      vi.stubGlobal('navigator', {
+        platform: '',
+        userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+      })
+      expect(isMacOs()).toBe(false)
+    })
+  })
+
+  describe('navigator absent', () => {
+    it('returns false when navigator is undefined', () => {
+      vi.stubGlobal('navigator', undefined)
+      expect(isMacOs()).toBe(false)
+    })
+  })
+})

--- a/src/components/Editor/ContentMenuItem.tsx
+++ b/src/components/Editor/ContentMenuItem.tsx
@@ -3,6 +3,7 @@ import {
   type TBPluginRegistryAction
 } from '@ttab/textbit'
 import type { JSX } from 'react'
+import { formatHotkey } from '@/lib/formatHotkey'
 
 export const ContentMenuItem = ({ action }: { action: TBPluginRegistryAction }): JSX.Element => {
   return (
@@ -12,7 +13,9 @@ export const ContentMenuItem = ({ action }: { action: TBPluginRegistryAction }):
     >
       <Menu.Icon className="flex justify-self-end self-center group-data-[state='active']:font-semibold" />
       <Menu.Label className="self-center text-sm group-data-[state='active']:font-semibold" />
-      <Menu.Hotkey className='justify-self-end self-center pl-6 pr-3 text-sm opacity-70' />
+      <Menu.Hotkey className='justify-self-end self-center pl-6 pr-3 text-sm opacity-70'>
+        {formatHotkey(action.hotkey)}
+      </Menu.Hotkey>
     </Menu.Item>
   )
 }

--- a/src/hooks/useNavigationKeys.tsx
+++ b/src/hooks/useNavigationKeys.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useCallback } from 'react'
 import { useView } from './useView'
+import { isMacOs } from '@/lib/isMacOs'
 
 type NavigationKey = 'alt+ArrowLeft' | 'ArrowLeft' | 'alt+ArrowRight' | 'ArrowRight' | 'ArrowUp' | 'ArrowDown' | 'Enter' | 'Escape' | ' ' | 's' | 'r' | 'c' | 'u'
 
@@ -117,24 +118,4 @@ function isEditableElement(element: Element | null): element is HTMLInputElement
   }
 
   return false
-}
-
-
-function isMacOs(): boolean {
-  const navigatorModernApi = navigator as Navigator & { userAgentData?: { platform?: string } }
-  let platform: string | undefined
-
-  if ('userAgentData' in navigatorModernApi && typeof navigatorModernApi.userAgentData?.platform === 'string') {
-    platform = navigatorModernApi.userAgentData.platform
-  }
-
-  if (!platform && typeof navigator.platform === 'string') {
-    platform = navigator.platform
-  }
-
-  if (!platform) {
-    platform = navigator.userAgent
-  }
-
-  return /\bmac/i.test(platform)
 }

--- a/src/lib/formatHotkey.ts
+++ b/src/lib/formatHotkey.ts
@@ -1,0 +1,41 @@
+import { isMacOs } from '@/lib/isMacOs'
+
+const SHARED: Record<string, string> = {
+  up: '↑',
+  down: '↓',
+  right: '→',
+  left: '←'
+}
+
+const MAC: Record<string, string> = {
+  mod: '⌘',
+  shift: '⇧',
+  ctrl: '⌃',
+  control: '⌃',
+  alt: '⌥',
+  opt: '⌥',
+  option: '⌥'
+}
+
+const PC: Record<string, string> = {
+  mod: 'Ctrl',
+  ctrl: 'Ctrl',
+  control: 'Ctrl',
+  shift: 'Shift',
+  alt: 'Alt',
+  opt: 'Alt',
+  option: 'Alt'
+}
+
+export function formatHotkey(hotkey: string | undefined, isMac = isMacOs()): string {
+  if (!hotkey) return ''
+  const tokens = hotkey.split('+').map((token) => formatToken(token, isMac))
+  return tokens.join(isMac ? '' : '+')
+}
+
+function formatToken(token: string, isMac: boolean): string {
+  const t = token.toLowerCase()
+  const mapped = (isMac ? MAC : PC)[t] ?? SHARED[t]
+  if (mapped) return mapped
+  return token.length === 1 ? token.toUpperCase() : token
+}

--- a/src/lib/isMacOs.ts
+++ b/src/lib/isMacOs.ts
@@ -1,0 +1,35 @@
+/**
+ * Best-effort detection of whether the current browser is running on macOS.
+ *
+ * Prefers the modern `navigator.userAgentData.platform` (where available),
+ * then falls back to the deprecated `navigator.platform`, and finally to
+ * `navigator.userAgent` so we still get a reasonable answer in older
+ * Chromium and non-Chromium engines.
+ */
+export function isMacOs(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false
+  }
+
+  const navigatorModernApi = navigator as Navigator & {
+    userAgentData?: { platform?: string }
+  }
+  let platform: string | undefined
+
+  if (
+    'userAgentData' in navigatorModernApi
+    && typeof navigatorModernApi.userAgentData?.platform === 'string'
+  ) {
+    platform = navigatorModernApi.userAgentData.platform
+  }
+
+  if (!platform && typeof navigator.platform === 'string') {
+    platform = navigator.platform
+  }
+
+  if (!platform) {
+    platform = navigator.userAgent
+  }
+
+  return /\bmac/i.test(platform)
+}


### PR DESCRIPTION
Textbit's built-in hotkey renderer hardcodes Mac glyphs (⌘ ⌥ ⌃ ⇧) for every platform, so Windows, Linux and Chromebook editors see opaque labels like ⌘⌥1 next to menu items even though the shortcut they need to press is Ctrl+Alt+1.

Introduce a small formatter and pass platform-aware children into Menu.Hotkey. Mac users keep the Unicode glyphs; everyone else now sees the spelled-out modifier names joined by "+", e.g. "Ctrl+Alt+1", "Ctrl+B", "Ctrl+Alt+Up".

Refs ELELOG-624