### PR TITLE
fix(print): clear stuck unpublished status after status transitions

### DIFF
--- a/__tests__/views/PrintArticles/PrintArticlesListColumns.test.tsx
+++ b/__tests__/views/PrintArticles/PrintArticlesListColumns.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { ColumnDef, Row } from '@tanstack/react-table'
+import type { ReactElement } from 'react'
+
+import { printArticlesListColumns } from '@/views/PrintArticles/PrintArticlesListColumns'
+import type { PrintArticle } from '@/hooks/baboon/lib/printArticles'
+
+type AccessorOf<T> = (data: T) => string | undefined
+type ColumnWithAccessor<T> = ColumnDef<T> & { accessorFn?: AccessorOf<T> }
+
+vi.mock('@/components/Table/Items/DocumentStatus', () => ({
+  DocumentStatus: ({ type, status }: { type: string, status: string }) => (
+    <span data-testid='document-status-mock'>{`${type}:${status}`}</span>
+  )
+}))
+
+vi.mock('@/components/Commands/FacetedFilter', () => ({
+  FacetedFilter: () => <div data-testid='faceted-filter-mock' />
+}))
+
+function buildRow(fields: Partial<PrintArticle['fields']>): PrintArticle {
+  return {
+    id: 'doc-1',
+    score: 1,
+    fields: fields as PrintArticle['fields'],
+    source: {},
+    sort: []
+  }
+}
+
+function buildColumns(): Array<ColumnDef<PrintArticle>> {
+  return printArticlesListColumns({ printFlows: [] })
+}
+
+function getColumn(id: string): ColumnDef<PrintArticle> {
+  const column = buildColumns().find((c) => c.id === id)
+  if (!column) {
+    throw new Error(`Column "${id}" not found`)
+  }
+  return column
+}
+
+// A stand-in `row` that backs `row.getValue(id)` via the column's accessorFn
+// and exposes `row.original` for cell renderers that read raw fields.
+function buildRowProxy(data: PrintArticle): Row<PrintArticle> {
+  const columns = buildColumns() as Array<ColumnWithAccessor<PrintArticle>>
+  const proxy = {
+    original: data,
+    getValue: (columnId: string) => {
+      const column = columns.find((c) => c.id === columnId)
+      return column?.accessorFn ? column.accessorFn(data) : undefined
+    }
+  }
+  return proxy as unknown as Row<PrintArticle>
+}
+
+function renderCell(column: ColumnDef<PrintArticle>, data: PrintArticle): void {
+  if (typeof column.cell !== 'function') {
+    throw new Error(`Column "${column.id ?? '?'}" has no cell renderer`)
+  }
+  const row = buildRowProxy(data)
+  const cell = column.cell as (ctx: { row: Row<PrintArticle> }) => ReactElement
+  render(cell({ row }))
+}
+
+describe('printArticlesListColumns workflowState column', () => {
+  const column = () => getColumn('workflowState')
+
+  it('accessorFn returns workflow_state', () => {
+    const data = buildRow({ workflow_state: { values: ['done'] } })
+    const accessor = (column() as ColumnWithAccessor<PrintArticle>).accessorFn!
+    expect(accessor(data)).toBe('done')
+  })
+
+  it('accessorFn falls back to draft when workflow_state is missing', () => {
+    const accessor = (column() as ColumnWithAccessor<PrintArticle>).accessorFn!
+    expect(accessor(buildRow({}))).toBe('draft')
+  })
+
+  it('cell renders the workflow_state value', () => {
+    const data = buildRow({ workflow_state: { values: ['done'] } })
+    renderCell(column(), data)
+    expect(screen.getByTestId('document-status-mock')).toHaveTextContent(
+      'tt/print-article:done'
+    )
+  })
+
+  it('cell renders unpublished when workflow_state is unpublished', () => {
+    const data = buildRow({ workflow_state: { values: ['unpublished'] } })
+    renderCell(column(), data)
+    expect(screen.getByTestId('document-status-mock')).toHaveTextContent(
+      'tt/print-article:unpublished'
+    )
+  })
+
+  // Regression for ELELOG-403: previously the cell preferred workflow_checkpoint
+  // over workflow_state, so a stale checkpoint left over by the optimistic
+  // subscription merge kept the row visually pinned to "unpublished" after a
+  // usable -> unpublish -> done transition.
+  it('cell ignores a stale workflow_checkpoint and follows workflow_state', () => {
+    const data = buildRow({
+      workflow_state: { values: ['done'] },
+      workflow_checkpoint: { values: ['unpublished'] }
+    })
+    renderCell(column(), data)
+    expect(screen.getByTestId('document-status-mock')).toHaveTextContent(
+      'tt/print-article:done'
+    )
+  })
+})

--- a/src/views/PrintArticles/PrintArticlesListColumns.tsx
+++ b/src/views/PrintArticles/PrintArticlesListColumns.tsx
@@ -40,10 +40,9 @@ export function printArticlesListColumns({ printFlows = [] }: {
           </span>
         )
       },
-      accessorFn: (data) => (data.fields['workflow_state'].values[0]),
+      accessorFn: (data) => data.fields['workflow_state']?.values[0] || 'draft',
       cell: ({ row }) => {
-        const status = row.original.fields['workflow_checkpoint']?.values[0]
-          || row.original.fields['workflow_state']?.values[0] || 'draft'
+        const status = row.getValue<string>('workflowState') || 'draft'
         return <DocumentStatus type='tt/print-article' status={status} />
       },
       filterFn: (row, id, value: string[]) =>


### PR DESCRIPTION
The print articles workflow status column read workflow_checkpoint with workflow_state as a fallback in its cell renderer, while the accessor read workflow_state only. The subscription polling in useDocuments applies optimistic field updates by spreading the payload over the existing fields object, so a workflow_checkpoint='unpublished' set during an unpublish step is preserved across subsequent transitions (usable -> unpublish -> done) unless the index update happens to echo the field back. The result was a row pinned to "unpublished" even though its underlying workflow_state had advanced.

Align the cell with the accessor: both now read workflow_state. The "unpublished" visual still renders because workflow_state itself is 'unpublished' when a document is unpublished (already covered by getStatusFromMeta).

Refs ELELOG-403.