### PR TITLE
fix(planning): remove misleading button affordance from readOnly Assi…

### DIFF
--- a/__tests__/AssignmentType.test.tsx
+++ b/__tests__/AssignmentType.test.tsx
@@ -63,4 +63,25 @@ describe('AssignmentType (readOnly icon swap)', () => {
     )
     expect(container.querySelector('svg.lucide-file-pen')).toBeInTheDocument()
   })
+
+  it('readOnly does not render the icon inside a button or hover surface', () => {
+    setType('flash')
+    const { container } = render(
+      <AssignmentType assignment={mockAssignment} editable={false} readOnly />
+    )
+
+    expect(container.querySelector('button')).toBeNull()
+
+    const hoverable = container.querySelector('[class*="hover:bg-"]')
+    expect(hoverable).toBeNull()
+  })
+
+  it('readOnly renders flash icon (ZapIcon) without button affordance', () => {
+    setType('flash')
+    const { container } = render(
+      <AssignmentType assignment={mockAssignment} editable={false} readOnly />
+    )
+    expect(container.querySelector('svg.lucide-zap')).toBeInTheDocument()
+    expect(container.querySelector('button')).toBeNull()
+  })
 })

--- a/src/components/DataItem/AssignmentType.tsx
+++ b/src/components/DataItem/AssignmentType.tsx
@@ -1,5 +1,5 @@
 import { getAssignmentTypes } from '@/defaults'
-import { Button, Select, SelectContent, SelectItem, SelectTrigger } from '@ttab/elephant-ui'
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@ttab/elephant-ui'
 import { cn } from '@ttab/elephant-ui/utils'
 import { Block } from '@ttab/elephant-api/newsdoc'
 import { BookmarkIcon, BookmarkPlusIcon, FilePenIcon, FilePlus2Icon } from '@ttab/elephant-ui/icons'
@@ -38,9 +38,9 @@ export const AssignmentType = ({ assignment, editable = false, readOnly = false,
 
   if (readOnly) {
     return (
-      <Button
-        variant='icon'
-        className='w-fit px-2 hover:bg-slate-200 dark:hover:bg-table-focused'
+      <span
+        title={t(`assignmentTypes.${selectedOptions[0]?.value}` as TranslationKey)}
+        className='inline-flex items-center justify-center w-fit h-10 px-2'
       >
         {SelectedIcon
           ? (
@@ -50,7 +50,7 @@ export const AssignmentType = ({ assignment, editable = false, readOnly = false,
               />
             )
           : t(`assignmentTypes.${selectedOptions[0]?.value}` as TranslationKey)}
-      </Button>
+      </span>
     )
   }
 


### PR DESCRIPTION
…gnmentType

When opening the move/date-change dialog on a planning item, each assignment row showed its assignment-type icon (e.g. Flash/ZapIcon) rendered inside a `Button variant='icon'` with hover background and focus ring styles. Because the readOnly variant attaches no onClick, the icons looked interactive but did nothing - confusing to users who expected a button to do something on click.

Replace the Button wrapper in the readOnly branch with a plain non- interactive `<span>` that preserves layout/spacing but drops the button semantics, hover background, and focus ring. The aria-label keeps the icon labelled for assistive tech.

Refs ELELOG-487