### PR TITLE
fix(hooks): revalidate orphan deliverable on any planning event

### DIFF
--- a/__tests__/useDeliverableInfo.test.tsx
+++ b/__tests__/useDeliverableInfo.test.tsx
@@ -107,6 +107,62 @@ describe('useDeliverableInfo', () => {
     })
   })
 
+  it('refetches on any planning event after an orphan first fetch (no planning uuid)', async () => {
+    getDeliverableInfo
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ planningUuid: 'plan-adopted' })
+
+    const { result } = renderHook(
+      () => useDeliverableInfo('deliverable-1'),
+      { wrapper }
+    )
+
+    await waitFor(() => {
+      expect(result.current).toEqual({})
+    })
+    expect(getDeliverableInfo).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      lastCallback?.(makeEvent('plan-other'))
+    })
+
+    await waitFor(() => {
+      expect(result.current?.planningUuid).toBe('plan-adopted')
+    })
+    expect(getDeliverableInfo).toHaveBeenCalledTimes(2)
+  })
+
+  it('reverts to strict matching once an orphan deliverable is adopted', async () => {
+    getDeliverableInfo
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ planningUuid: 'plan-1' })
+
+    const { result } = renderHook(
+      () => useDeliverableInfo('deliverable-1'),
+      { wrapper }
+    )
+
+    await waitFor(() => {
+      expect(result.current).toEqual({})
+    })
+
+    act(() => {
+      lastCallback?.(makeEvent('plan-1'))
+    })
+
+    await waitFor(() => {
+      expect(result.current?.planningUuid).toBe('plan-1')
+    })
+    expect(getDeliverableInfo).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      lastCallback?.(makeEvent('plan-other'))
+      await Promise.resolve()
+    })
+
+    expect(getDeliverableInfo).toHaveBeenCalledTimes(2)
+  })
+
   it('skips events while the first fetch has not yet resolved', async () => {
     let resolveFetch!: (v: { planningUuid: string }) => void
     const pending = new Promise<{ planningUuid: string }>((resolve) => {

--- a/src/hooks/useDeliverableInfo.tsx
+++ b/src/hooks/useDeliverableInfo.tsx
@@ -30,12 +30,25 @@ export const useDeliverableInfo = (deliverableId: string): GetDeliverableInfoRes
   )
 
   const planningUuidRef = useRef<string | undefined>(data?.planningUuid)
+  const hasResolvedRef = useRef(data !== undefined)
   useEffect(() => {
     planningUuidRef.current = data?.planningUuid
-  }, [data?.planningUuid])
+    if (data !== undefined) {
+      hasResolvedRef.current = true
+    }
+  }, [data])
 
   const onPlanningEvent = useCallback((event: EventlogItem) => {
-    if (planningUuidRef.current && event.uuid === planningUuidRef.current) {
+    const planningUuid = planningUuidRef.current
+    if (planningUuid) {
+      if (event.uuid === planningUuid) {
+        void mutate()
+      }
+      return
+    }
+    // Orphan deliverable: first fetch resolved without a linked planning.
+    // Any planning event could be the one that adopts us, so revalidate.
+    if (hasResolvedRef.current) {
       void mutate()
     }
   }, [mutate])


### PR DESCRIPTION
useDeliverableInfo filtered planning events by the stored planningUuidRef. When the initial fetch returned no planning (orphan timeless row, race during creation), the ref stayed undefined and the filter never matched, so the row never recovered without a full reload.

Track first-resolve separately; when resolved with no planningUuid, revalidate defensively on any planning event. After adoption the strict match path takes over again. Existing "skip events while pending" behavior is preserved.

Refs ELELOG-689 (I7).