### PR TITLE
Prevent multiple rerenders when navigating between views. Stable spel…

### DIFF
--- a/__tests__/useQuery.test.tsx
+++ b/__tests__/useQuery.test.tsx
@@ -36,7 +36,8 @@ vi.mock('@/hooks/useView', () => ({
 }))
 
 vi.mocked(useView).mockReturnValue({
-  viewId: 'eddbfe39-57d4-4b32-b9a1-a555e39139ea'
+  viewId: 'eddbfe39-57d4-4b32-b9a1-a555e39139ea',
+  isActive: true
 } as ViewProviderState)
 
 describe('useQuery hook', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@ttab/elephant-api": "^0.22.1",
         "@ttab/elephant-tt-api": "^0.4.2",
         "@ttab/elephant-ui": "^1.4.5",
-        "@ttab/textbit": "^1.4.1",
+        "@ttab/textbit": "^1.4.2",
         "@ttab/textbit-plugins": "^1.6.1",
         "class-variance-authority": "^0.7.1",
         "cors": "^2.8.6",
@@ -6132,9 +6132,9 @@
       }
     },
     "node_modules/@ttab/textbit": {
-      "version": "1.4.1",
-      "resolved": "https://npm.pkg.github.com/download/@ttab/textbit/1.4.1/0cfd6829eb32f16c272eae563297c17730fe26b0",
-      "integrity": "sha512-QSUQp68mF5L7YY0TgwqnTistImLwPx4m2PJMUFQImCtrN97szn5d9og6Mir5Rn8hL6o9NQQapSuEnjlUuUdiEA==",
+      "version": "1.4.2",
+      "resolved": "https://npm.pkg.github.com/download/@ttab/textbit/1.4.2/724cb2bbd7d0bc9bd082a84e9627e9400ee6d7f0",
+      "integrity": "sha512-Pvek2V59j9kslQbE6NyHGiX7w8/OndyZUek0PyNM4rmxzFrCy1dYPZpn0KGvKMUdnOISSNcXpupVUwyRlFjDvw==",
       "license": "MIT",
       "dependencies": {
         "is-hotkey": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@ttab/elephant-api": "^0.22.1",
     "@ttab/elephant-tt-api": "^0.4.2",
     "@ttab/elephant-ui": "^1.4.5",
-    "@ttab/textbit": "^1.4.1",
+    "@ttab/textbit": "^1.4.2",
     "@ttab/textbit-plugins": "^1.6.1",
     "class-variance-authority": "^0.7.1",
     "cors": "^2.8.6",

--- a/src/components/Link/lib/handleLink.ts
+++ b/src/components/Link/lib/handleLink.ts
@@ -7,7 +7,7 @@ import {
   NavigationActionType
 } from '@/types'
 import { toQueryString } from './toQueryString'
-import type { HistoryInterface } from '@/navigation/hooks/useHistory'
+import type { HistoryInterface, HistoryState } from '@/navigation/hooks/useHistory'
 
 export type Target = 'self' | 'blank' | 'last'
 interface LinkClick {
@@ -45,10 +45,13 @@ export function handleLink({
   event?.preventDefault()
   event?.stopPropagation()
 
-  // Get current state from history
-  const content: ContentState[] = [...history.state?.contentState || []]
-  const currentViewId = history.state?.viewId
-  const currentPath = history.state?.contentState.find((c) => c.viewId === currentViewId)
+  // Read from window.history.state directly: setActiveView updates the URL
+  // and viewId via a silent replaceState (no popstate), so the React-tracked
+  // history.state may briefly lag here. window.history.state is always fresh.
+  const liveHistoryState = window.history.state as HistoryState | null
+  const content: ContentState[] = [...liveHistoryState?.contentState || []]
+  const currentViewId = liveHistoryState?.viewId
+  const currentPath = liveHistoryState?.contentState.find((c) => c.viewId === currentViewId)
 
   // Create next (wanted) content state (props can not be functions!)
   const newContent: ContentState = {

--- a/src/datastore/contexts/SupportedLanguagesProvider.tsx
+++ b/src/datastore/contexts/SupportedLanguagesProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useEffect, useState } from 'react'
+import { createContext, useCallback, useEffect, useMemo, useState } from 'react'
 import { useIndexedDB } from '../hooks/useIndexedDB'
 import { useSession } from 'next-auth/react'
 import { useRegistry } from '@/hooks/useRegistry'
@@ -6,10 +6,15 @@ import { type IDBLanguage, type SupportedLanguage } from '../types'
 
 interface SupportedLanguagesProviderState {
   languages: IDBLanguage[]
+  // Pre-computed list of language codes. Kept on the context so consumers
+  // share a single stable reference - re-mapping in the hook would hand
+  // every textbit a fresh array on every render.
+  languageCodes: string[]
 }
 
 export const SupportedLanguagesContext = createContext<SupportedLanguagesProviderState>({
-  languages: []
+  languages: [],
+  languageCodes: []
 })
 
 export const SupportedLanguagesProvider = ({ children }: {
@@ -65,8 +70,11 @@ export const SupportedLanguagesProvider = ({ children }: {
     void getOrRefreshCache()
   }, [getOrRefreshCache])
 
+  const languageCodes = useMemo(() => languages.map((l) => l.id), [languages])
+  const value = useMemo(() => ({ languages, languageCodes }), [languages, languageCodes])
+
   return (
-    <SupportedLanguagesContext.Provider value={{ languages }}>
+    <SupportedLanguagesContext.Provider value={value}>
       {children}
     </SupportedLanguagesContext.Provider>
   )

--- a/src/hooks/useQuery.tsx
+++ b/src/hooks/useQuery.tsx
@@ -71,15 +71,17 @@ export const useQuery = (keys?: string[], allParams?: boolean): [QueryParams, (p
 
   const [queryParams, setQueryParams] = useState<QueryParams>(parseQueryString)
 
-  // Update queryParams state when historyState changes
+  // Update queryParams state when historyState changes. Gate on isActive
+  // rather than historyState.viewId so the active view doesn't depend on
+  // the cached history snapshot, which lags behind silent setActiveView.
   useEffect(() => {
-    if (historyState?.viewId === viewId) {
+    if (isActive) {
       setQueryParams(parseQueryString())
     }
-  }, [historyState, viewId, parseQueryString])
+  }, [historyState, isActive, parseQueryString])
 
   const setQueryString = useCallback((params: QueryParams): void => {
-    if (!historyState?.contentState || historyState.viewId !== viewId) {
+    if (!historyState?.contentState || !isActive) {
       return
     }
 
@@ -107,7 +109,7 @@ export const useQuery = (keys?: string[], allParams?: boolean): [QueryParams, (p
 
     const newHistoryState = { ...historyState }
     newHistoryState.contentState.forEach((cs) => {
-      if (historyState.viewId !== cs.viewId) {
+      if (viewId !== cs.viewId) {
         return
       }
 
@@ -124,7 +126,7 @@ export const useQuery = (keys?: string[], allParams?: boolean): [QueryParams, (p
 
     replaceState(newUrl.href, newHistoryState)
     setQueryParams(parseQueryString())
-  }, [historyState, replaceState, viewId, parseQueryString])
+  }, [historyState, isActive, replaceState, viewId, parseQueryString])
 
   if (allParams && keys?.length) {
     const allQueries = historyState?.contentState.filter((c) => {

--- a/src/hooks/useSupportedLanguages.tsx
+++ b/src/hooks/useSupportedLanguages.tsx
@@ -1,9 +1,6 @@
 import { useContext } from 'react'
 import { SupportedLanguagesContext } from '../datastore/contexts/SupportedLanguagesProvider'
-import { type IDBLanguage } from '../datastore/types'
 
 export const useSupportedLanguages = (): string[] => {
-  const { languages } = useContext(SupportedLanguagesContext)
-  const supportedLanguages = languages.map((language: IDBLanguage) => language.id)
-  return supportedLanguages
+  return useContext(SupportedLanguagesContext).languageCodes
 }

--- a/src/navigation/NavigationProvider.tsx
+++ b/src/navigation/NavigationProvider.tsx
@@ -1,6 +1,5 @@
 import {
   useReducer,
-  useLayoutEffect,
   type PropsWithChildren,
   useEffect,
   type JSX
@@ -14,7 +13,7 @@ import {
   initializeNavigationState
 } from '@/navigation/lib'
 import { NavigationContext } from './NavigationContext'
-import type { HistoryEvent } from './hooks/useHistory'
+import type { HistoryEvent, HistoryState } from './hooks/useHistory'
 
 const initialState = initializeNavigationState()
 
@@ -24,20 +23,30 @@ export const NavigationProvider = ({ children }: PropsWithChildren & {
   const history = useHistory()
 
   /*
-   * Handle user navigating browser history back and forth
+   * Sync the reducer with window.history on real navigation events
+   * (browser back/forward, plus the synthetic popstate dispatched by
+   * pushState / non-silent replaceState). Silent replaceState - used by
+   * setActiveView to update the URL without a navigation - intentionally
+   * does not dispatch popstate; the activeview listener below handles it.
    */
-  useLayoutEffect(() => {
-    if (history.state) {
-      dispatch({
-        type: NavigationActionType.SET,
-        active: history.state.viewId,
-        content: history.state.contentState
-      })
+  useEffect(() => {
+    const handlePopState = (): void => {
+      const state = window.history.state as HistoryState | null
+      if (state) {
+        dispatch({
+          type: NavigationActionType.SET,
+          active: state.viewId,
+          content: state.contentState
+        })
+      }
     }
-  }, [history.state])
+
+    window.addEventListener('popstate', handlePopState)
+    return () => window.removeEventListener('popstate', handlePopState)
+  }, [])
 
   /*
-   * Handle swith between active views
+   * Handle switch between active views
    */
   useEffect(() => {
     const handleSetActive = (e: HistoryEvent): void => {

--- a/src/navigation/hooks/useHistory.tsx
+++ b/src/navigation/hooks/useHistory.tsx
@@ -24,14 +24,28 @@ export interface HistoryInterface {
 }
 
 
+// Cache the snapshot so React only observes history changes from real
+// popstate events (native back/forward, or synthetic events dispatched by
+// pushState / replaceState). Reading window.history.state on every render
+// would otherwise leak silent replaceState mutations (e.g. setActiveView)
+// into useSyncExternalStore and trigger extra renders.
+//
+// The cache is refreshed on subscribe to catch direct window.history.state
+// mutations that happen before React mounts the hook - notably
+// initializeNavigationState's replaceState during module init.
+let cachedSnapshot: HistoryState | null = (window.history.state as HistoryState | null) ?? null
+
 const subscribe = (callback: () => void): (() => void) => {
-  window.addEventListener('popstate', callback)
-  return () => window.removeEventListener('popstate', callback)
+  cachedSnapshot = (window.history.state as HistoryState | null) ?? null
+  const handler = (): void => {
+    cachedSnapshot = (window.history.state as HistoryState | null) ?? null
+    callback()
+  }
+  window.addEventListener('popstate', handler)
+  return () => window.removeEventListener('popstate', handler)
 }
 
-const getSnapshot = (): HistoryState | null => {
-  return window.history.state as HistoryState | null
-}
+const getSnapshot = (): HistoryState | null => cachedSnapshot
 
 const getServerSnapshot = (): null => null
 


### PR DESCRIPTION
…lcheck references to prevent unnecessary rerenders of editors. As this originated from experimenting it is two separate fixes here: history handling and stable ref for languages to editors.

Used together with https://github.com/ttab/textbit/pull/364 should remove most issues in focus handling of editor fields.