### PR TITLE
feat(imagesearch): add NTB distributor filter

### DIFF
--- a/__tests__/ImageSearchDistributorDefault.test.tsx
+++ b/__tests__/ImageSearchDistributorDefault.test.tsx
@@ -1,0 +1,73 @@
+import type { JSX, ReactNode } from 'react'
+import { render, waitFor } from '@testing-library/react'
+import type { SearchRequest } from '@ttab/elephant-tt-api/ntb'
+import { ImageSearch } from '@/views/ImageSearch'
+
+const { ntbSearch, units } = vi.hoisted(() => ({
+  ntbSearch: vi.fn((_request: SearchRequest, _accessToken: string) =>
+    Promise.resolve({ response: { data: [], page: { total: 0 } } })
+  ),
+  units: { current: [] as string[] }
+}))
+
+vi.mock('@/hooks/useRegistry', () => ({
+  useRegistry: () => ({
+    server: { imageSearchUrl: new URL('https://example.com/image-search') },
+    envs: { imageSearchProvider: 'ntb' },
+    ntb: { search: ntbSearch }
+  })
+}))
+
+// Mock only useHasUnit: the real `@/hooks` barrel re-exports navigation hooks,
+// which would trigger navigation registry init on import.
+vi.mock('@/hooks', () => ({
+  useHasUnit: (unit: string) => units.current.includes(unit)
+}))
+
+// Stub the layout barrel so importing the view doesn't pull in navigation either.
+vi.mock('@/components', () => {
+  const Pass = ({ children }: { children?: ReactNode }): JSX.Element => <>{children}</>
+  return {
+    View: { Root: Pass, Content: Pass },
+    ViewHeader: { Root: Pass, Title: Pass, Content: Pass, Action: Pass }
+  }
+})
+
+class NoopObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  vi.stubGlobal('IntersectionObserver', NoopObserver)
+  vi.stubGlobal('ResizeObserver', NoopObserver)
+})
+
+function firstRequest(): SearchRequest {
+  return ntbSearch.mock.calls[0][0]
+}
+
+describe('ImageSearch distributor default', () => {
+  beforeEach(() => {
+    ntbSearch.mockClear()
+  })
+
+  it('defaults NPK-unit users to the NPK distributor with outsideSubscription on', async () => {
+    units.current = ['/redaktionen-npk']
+    render(<ImageSearch />)
+
+    await waitFor(() => expect(ntbSearch).toHaveBeenCalled())
+    expect(firstRequest().distributorNames).toEqual(['NPK'])
+    expect(firstRequest().outsideSubscription).toBe(true)
+  })
+
+  it('defaults other users to no distributor and outsideSubscription off', async () => {
+    units.current = []
+    render(<ImageSearch />)
+
+    await waitFor(() => expect(ntbSearch).toHaveBeenCalled())
+    expect(firstRequest().distributorNames).toEqual([])
+    expect(firstRequest().outsideSubscription).toBe(false)
+  })
+})

--- a/__tests__/ntbFetcher.test.ts
+++ b/__tests__/ntbFetcher.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { Session } from 'next-auth'
+import type { SearchRequest } from '@ttab/elephant-tt-api/ntb'
+import { createNTBFetcher } from '@/views/ImageSearch/lib/ntbFetcher'
+import type { NTB } from '@/shared/NTB'
+
+vi.mock('sonner')
+
+const session = { accessToken: 'token' } as Session
+
+function makeNtb() {
+  const search = vi.fn((_request: SearchRequest, _accessToken: string) =>
+    Promise.resolve({ response: { data: [], page: { total: 0 } } })
+  )
+  return { ntb: { search } as unknown as NTB, search }
+}
+
+function requestFrom(search: ReturnType<typeof makeNtb>['search']): SearchRequest {
+  return search.mock.calls[0][0]
+}
+
+describe('createNTBFetcher distributor handling', () => {
+  it('omits the distributor filter and keeps outsideSubscription off by default', async () => {
+    const { ntb, search } = makeNtb()
+    await createNTBFetcher(ntb, session, 'ntb')(['cats', 0, 10, 'image', []])
+
+    const request = requestFrom(search)
+    expect(request.distributorNames).toEqual([])
+    expect(request.outsideSubscription).toBe(false)
+  })
+
+  it('forces outsideSubscription on when a distributor is selected', async () => {
+    const { ntb, search } = makeNtb()
+    await createNTBFetcher(ntb, session, 'ntb')(['cats', 0, 10, 'image', ['NPK']])
+
+    const request = requestFrom(search)
+    expect(request.distributorNames).toEqual(['NPK'])
+    expect(request.outsideSubscription).toBe(true)
+  })
+
+  it('defaults distributorNames to empty when the key omits it', async () => {
+    const { ntb, search } = makeNtb()
+    await createNTBFetcher(ntb, session, 'ntb')(['cats', 0, 10, 'image'])
+
+    const request = requestFrom(search)
+    expect(request.distributorNames).toEqual([])
+    expect(request.outsideSubscription).toBe(false)
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@tanstack/react-table": "^8.21.3",
         "@ttab/api-client": "^2.11.1",
         "@ttab/elephant-api": "^0.22.1",
-        "@ttab/elephant-tt-api": "^0.4.2",
+        "@ttab/elephant-tt-api": "^0.5.2",
         "@ttab/elephant-ui": "^1.4.5",
         "@ttab/textbit": "^1.5.0",
         "@ttab/textbit-plugins": "^1.6.1",
@@ -6052,9 +6052,9 @@
       }
     },
     "node_modules/@ttab/elephant-tt-api": {
-      "version": "0.4.2",
-      "resolved": "https://npm.pkg.github.com/download/@ttab/elephant-tt-api/0.4.2/6fa45d30d3addc5cc010a27af4db43810f036e88",
-      "integrity": "sha512-lfdu7VEelNMUsf+crMm1G5scvIWy7DmTytbNdkY7mB2Wb7cdKnbd2GEbV8LGIwXdi8jgXOgly12otNHcMXEsfA==",
+      "version": "0.5.2",
+      "resolved": "https://npm.pkg.github.com/download/@ttab/elephant-tt-api/0.5.2/fbe34b40d1a1c440d3435933141caa09a093ba54",
+      "integrity": "sha512-0lpecpiFCx/YWGofqpVvsWKiMfC8CAuXVOZhczLmC4Gf7qIXOeo651PxHv/iFe4/+85T6U2F7R+AfhwlD7vIsg==",
       "license": "MIT",
       "dependencies": {
         "@protobuf-ts/runtime": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@tanstack/react-table": "^8.21.3",
     "@ttab/api-client": "^2.11.1",
     "@ttab/elephant-api": "^0.22.1",
-    "@ttab/elephant-tt-api": "^0.4.2",
+    "@ttab/elephant-tt-api": "^0.5.2",
     "@ttab/elephant-ui": "^1.4.5",
     "@ttab/textbit": "^1.5.0",
     "@ttab/textbit-plugins": "^1.6.1",

--- a/src/locales/en/views.json
+++ b/src/locales/en/views.json
@@ -117,6 +117,8 @@
     "title": "Images",
     "labels": {
       "mediaType": "Media type",
+      "distributor": "Distributor",
+      "allDistributors": "All distributors",
       "image": "Image",
       "graphic": "Graphic",
       "close": "Close",

--- a/src/locales/nb/views.json
+++ b/src/locales/nb/views.json
@@ -117,6 +117,8 @@
     "title": "Bilder",
     "labels": {
       "mediaType": "Medietype",
+      "distributor": "Distributør",
+      "allDistributors": "Alle distributører",
       "image": "Bild",
       "graphic": "Grafikk",
       "close": "Lukk",

--- a/src/locales/sv/views.json
+++ b/src/locales/sv/views.json
@@ -117,6 +117,8 @@
     "title": "Bilder",
     "labels": {
       "mediaType": "Medietyp",
+      "distributor": "Distributör",
+      "allDistributors": "Alla distributörer",
       "image": "Bild",
       "graphic": "Grafik",
       "close": "Stäng",

--- a/src/views/ImageSearch/SearchInput/index.tsx
+++ b/src/views/ImageSearch/SearchInput/index.tsx
@@ -2,11 +2,22 @@ import { SearchInput } from '@/components/SearchInput'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@ttab/elephant-ui'
 import React, { useState, type Dispatch, type SetStateAction, type JSX } from 'react'
 import type { MediaTypes } from '..'
+import { NTB_DISTRIBUTORS, type NTBDistributor } from '../lib/ntbFetcher'
 import { useTranslation } from 'react-i18next'
 
-export const ImageSearchInput = ({ setQueryString, setMediaType, isNtb }: {
+const ALL_DISTRIBUTORS = 'all'
+
+export const ImageSearchInput = ({
+  setQueryString,
+  setMediaType,
+  distributorNames,
+  setDistributorNames,
+  isNtb
+}: {
   setQueryString: Dispatch<SetStateAction<string>>
   setMediaType: Dispatch<SetStateAction<MediaTypes>>
+  distributorNames: NTBDistributor[]
+  setDistributorNames: Dispatch<SetStateAction<NTBDistributor[]>>
   isNtb: boolean
 }): JSX.Element => {
   const [query, setQuery] = useState('')
@@ -28,17 +39,39 @@ export const ImageSearchInput = ({ setQueryString, setMediaType, isNtb }: {
         name='imagesearch'
         onChange={(e) => setQuery(e.currentTarget.value)}
       />
-      {!isNtb && (
-        <Select onValueChange={(option) => setMediaType(option as MediaTypes)}>
-          <SelectTrigger className='w-fit shrink-0'>
-            <SelectValue placeholder={t('views:imageSearch.labels.mediaType')} />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value='image'>{t('views:imageSearch.labels.image')}</SelectItem>
-            <SelectItem value='graphic'>{t('views:imageSearch.labels.graphic')}</SelectItem>
-          </SelectContent>
-        </Select>
-      )}
+      {isNtb
+        ? (
+            <Select
+              value={distributorNames[0] ?? ALL_DISTRIBUTORS}
+              onValueChange={(value) =>
+                setDistributorNames(value === ALL_DISTRIBUTORS ? [] : [value as NTBDistributor])}
+            >
+              <SelectTrigger className='w-fit shrink-0'>
+                <SelectValue placeholder={t('views:imageSearch.labels.distributor')} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ALL_DISTRIBUTORS}>
+                  {t('views:imageSearch.labels.allDistributors')}
+                </SelectItem>
+                {NTB_DISTRIBUTORS.map((distributor) => (
+                  <SelectItem key={distributor} value={distributor}>
+                    {distributor}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )
+        : (
+            <Select onValueChange={(option) => setMediaType(option as MediaTypes)}>
+              <SelectTrigger className='w-fit shrink-0'>
+                <SelectValue placeholder={t('views:imageSearch.labels.mediaType')} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value='image'>{t('views:imageSearch.labels.image')}</SelectItem>
+                <SelectItem value='graphic'>{t('views:imageSearch.labels.graphic')}</SelectItem>
+              </SelectContent>
+            </Select>
+          )}
     </form>
   )
 }

--- a/src/views/ImageSearch/index.tsx
+++ b/src/views/ImageSearch/index.tsx
@@ -9,10 +9,11 @@ import { Thumbnail } from './Thumbnail'
 import { ImageSearchInput } from './SearchInput'
 import { SWRConfig } from 'swr'
 import { createTTFetcher } from './lib/ttFetcher'
-import { createNTBFetcher } from './lib/ntbFetcher'
+import { createNTBFetcher, NPK_DISTRIBUTOR, NPK_UNIT, type NTBDistributor } from './lib/ntbFetcher'
 import { useRegistry } from '@/hooks/useRegistry'
+import { useHasUnit } from '@/hooks'
 import { useSession } from 'next-auth/react'
-import type { ImageSearchResult as SearchResult } from './lib/types'
+import type { ImageSearchKey, ImageSearchResult as SearchResult } from './lib/types'
 import { Error } from '../Error'
 import { useTranslation } from 'react-i18next'
 
@@ -86,13 +87,17 @@ const ImageSearchContent = ({
   mediaType: MediaTypes
   isNtb: boolean
 }): JSX.Element => {
+  const isNpkUser = useHasUnit(NPK_UNIT)
   const [queryString, setQueryString] = useState('')
+  const [distributorNames, setDistributorNames] = useState<NTBDistributor[]>(
+    isNpkUser ? [NPK_DISTRIBUTOR] : []
+  )
   const SIZE = 10
   const { t } = useTranslation('views')
 
   const swr = useSWRInfinite<SearchResult, Error>(
-    (index) => {
-      return [queryString, index, SIZE, mediaType]
+    (index): ImageSearchKey => {
+      return [queryString, index, SIZE, mediaType, distributorNames]
     },
     {
       revalidateFirstPage: false
@@ -111,6 +116,8 @@ const ImageSearchContent = ({
           <ImageSearchInput
             setQueryString={setQueryString}
             setMediaType={setMediaType}
+            distributorNames={distributorNames}
+            setDistributorNames={setDistributorNames}
             isNtb={isNtb}
           />
         </ViewHeader.Content>

--- a/src/views/ImageSearch/lib/ntbFetcher.ts
+++ b/src/views/ImageSearch/lib/ntbFetcher.ts
@@ -3,13 +3,27 @@ import { toast } from 'sonner'
 import type { NTB } from '@/shared/NTB'
 import { PreviewType, SearchRequest, type MediaItem } from '@ttab/elephant-tt-api/ntb'
 
+export const NPK_DISTRIBUTOR = 'NPK'
+
+/**
+ * Distributors whose catalogue sits outside the normal subscription. Selecting
+ * one forces `outsideSubscription` on, since those items are otherwise filtered
+ * out of the results.
+ */
+export const NTB_DISTRIBUTORS = [NPK_DISTRIBUTOR, 'NTB tema'] as const
+
+export type NTBDistributor = (typeof NTB_DISTRIBUTORS)[number]
+
+/** Keycloak unit marking a user as belonging to NPK (Nynorsk Pressekontor). */
+export const NPK_UNIT = '/redaktionen-npk'
+
 interface NTBPreview {
   width: number
   height: number
   url: string
   type: PreviewType
 }
-import type { ImageSearchHit, ImageSearchResult } from './types'
+import type { ImageSearchHit, ImageSearchKey, ImageSearchResult } from './types'
 
 function findPreviewByWidth(
   previews: NTBPreview[],
@@ -77,7 +91,7 @@ export const createNTBFetcher = (
   session: Session | null,
   archive: string
 ) =>
-  async ([queryString, index, SIZE]: [string, number, number]
+  async ([queryString, index, SIZE, , distributorNames = []]: ImageSearchKey
   ): Promise<ImageSearchResult> => {
     if (!session) {
       toast.error('Kan inte autentisera mot bildtjänsten')
@@ -91,7 +105,9 @@ export const createNTBFetcher = (
             archive,
             query: queryString,
             limit: SIZE,
-            offset: index * SIZE
+            offset: index * SIZE,
+            distributorNames,
+            outsideSubscription: distributorNames.length > 0
           }),
           session.accessToken
         )

--- a/src/views/ImageSearch/lib/ttFetcher.ts
+++ b/src/views/ImageSearch/lib/ttFetcher.ts
@@ -4,7 +4,7 @@ import type { Session } from 'next-auth'
 import { toast } from 'sonner'
 import { productCodes } from './productCodes'
 import type { MediaTypes } from '..'
-import type { ImageSearchHit, ImageSearchResult } from './types'
+import type { ImageSearchHit, ImageSearchKey, ImageSearchResult } from './types'
 import { findRenditionByUsageAndVariant, type renditions } from './find-rendition'
 
 const BASE_URL = import.meta.env.BASE_URL || ''
@@ -59,7 +59,7 @@ export const createTTFetcher = (
   session: Session | null,
   mediaType: MediaTypes
 ) =>
-  async ([queryString, index, SIZE]: [string, number, number]): Promise<ImageSearchResult> => {
+  async ([queryString, index, SIZE]: ImageSearchKey): Promise<ImageSearchResult> => {
     if (!session) {
       toast.error('Kan inte autentisera mot bildtjänsten')
       throw new Error('ImageSearch Error: No session for user')

--- a/src/views/ImageSearch/lib/types.ts
+++ b/src/views/ImageSearch/lib/types.ts
@@ -1,3 +1,18 @@
+import type { MediaTypes } from '..'
+import type { NTBDistributor } from './ntbFetcher'
+
+/**
+ * SWR key shared by the TT and NTB fetchers. The TT fetcher reads only the
+ * first three slots; `distributorNames` is NTB-only and optional.
+ */
+export type ImageSearchKey = [
+  query: string,
+  index: number,
+  size: number,
+  mediaType: MediaTypes,
+  distributorNames?: NTBDistributor[]
+]
+
 export interface ImageSearchHit {
   id: string
   uri: string


### PR DESCRIPTION
- bump @ttab/elephant-tt-api 0.4.2 -> 0.5.2
- read distributorNames from the SWR key in ntbFetcher and set outsideSubscription when a distributor is selected
- add distributor Select to ImageSearchInput, shown only for NTB
- default NPK-unit users to the NPK distributor via useHasUnit
- introduce shared ImageSearchKey tuple type used by both fetchers
- add distributor/allDistributors labels (sv, en, nb)
- cover the fetcher coupling and unit-driven default with tests