### PR TITLE
feat(image-search): show distributor public names via label map

### DIFF
--- a/src/views/ImageSearch/SearchInput/index.tsx
+++ b/src/views/ImageSearch/SearchInput/index.tsx
@@ -2,7 +2,7 @@ import { SearchInput } from '@/components/SearchInput'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@ttab/elephant-ui'
 import React, { useState, type Dispatch, type SetStateAction, type JSX } from 'react'
 import type { MediaTypes } from '..'
-import { NTB_DISTRIBUTORS, type NTBDistributor } from '../lib/ntbFetcher'
+import { NTB_DISTRIBUTORS, getDistributorLabel, type NTBDistributor } from '../lib/ntbFetcher'
 import { useTranslation } from 'react-i18next'
 
 const ALL_DISTRIBUTORS = 'all'
@@ -55,7 +55,7 @@ export const ImageSearchInput = ({
                 </SelectItem>
                 {NTB_DISTRIBUTORS.map((distributor) => (
                   <SelectItem key={distributor} value={distributor}>
-                    {distributor}
+                    {getDistributorLabel(distributor)}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/src/views/ImageSearch/lib/ntbFetcher.ts
+++ b/src/views/ImageSearch/lib/ntbFetcher.ts
@@ -14,6 +14,18 @@ export const NTB_DISTRIBUTORS = [NPK_DISTRIBUTOR, 'NTB Tema'] as const
 
 export type NTBDistributor = (typeof NTB_DISTRIBUTORS)[number]
 
+/**
+ * Display names shown in the UI for distributors whose backend identifier
+ * differs from their public/brand name. The map key stays the API value;
+ * distributors not listed here are shown verbatim.
+ */
+const DISTRIBUTOR_LABELS: Partial<Record<NTBDistributor, string>> = {
+  'NTB Tema': 'Jubilant'
+}
+
+export const getDistributorLabel = (distributor: NTBDistributor): string =>
+  DISTRIBUTOR_LABELS[distributor] ?? distributor
+
 /** Keycloak unit marking a user as belonging to NPK (Nynorsk Pressekontor). */
 export const NPK_UNIT = '/redaktionen-npk'
 


### PR DESCRIPTION
Add DISTRIBUTOR_LABELS and getDistributorLabel in ntbFetcher to map distributor API values to display names; label NTB Tema as Jubilant. Replace the inline ternary in ImageSearchInput with the helper lookup.