### PR TITLE
editor: localize Link plugin warning label, bump textbit-plugins 1.6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@ttab/elephant-tt-api": "^0.5.2",
         "@ttab/elephant-ui": "^1.4.5",
         "@ttab/textbit": "^1.5.2",
-        "@ttab/textbit-plugins": "^1.6.3",
+        "@ttab/textbit-plugins": "^1.6.4",
         "class-variance-authority": "^0.7.1",
         "cors": "^2.8.6",
         "date-fns": "^4.1.0",
@@ -6151,9 +6151,9 @@
       }
     },
     "node_modules/@ttab/textbit-plugins": {
-      "version": "1.6.3",
-      "resolved": "https://npm.pkg.github.com/download/@ttab/textbit-plugins/1.6.3/296e8c8f97581fb60c6ab94c2a63e4abb8e2ade7",
-      "integrity": "sha512-RLLI/tMc7KC6Fnsng2omcszKFUNYolU3si4ZoMclZGuo0val6i+bRs+NX+lrnlJsdLlYa62jTLf4dEUHKxYYiA==",
+      "version": "1.6.4",
+      "resolved": "https://npm.pkg.github.com/download/@ttab/textbit-plugins/1.6.4/cac852520fdab697278ddb14b1e086ce166e1b82",
+      "integrity": "sha512-HVmCrlIbmSELoLVwS5e+cARO0KJuw0temHDg2Bl3yCmNlPl4yikoFnQHpaJxd5+/FsG3Oo8Xc2YmhAAlpNZy+w==",
       "license": "MIT",
       "dependencies": {
         "@ttab/textbit": "^1.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@ttab/elephant-tt-api": "^0.5.2",
         "@ttab/elephant-ui": "^1.4.5",
         "@ttab/textbit": "^1.5.2",
-        "@ttab/textbit-plugins": "^1.6.4",
+        "@ttab/textbit-plugins": "^1.6.5",
         "class-variance-authority": "^0.7.1",
         "cors": "^2.8.6",
         "date-fns": "^4.1.0",
@@ -6151,9 +6151,9 @@
       }
     },
     "node_modules/@ttab/textbit-plugins": {
-      "version": "1.6.4",
-      "resolved": "https://npm.pkg.github.com/download/@ttab/textbit-plugins/1.6.4/cac852520fdab697278ddb14b1e086ce166e1b82",
-      "integrity": "sha512-HVmCrlIbmSELoLVwS5e+cARO0KJuw0temHDg2Bl3yCmNlPl4yikoFnQHpaJxd5+/FsG3Oo8Xc2YmhAAlpNZy+w==",
+      "version": "1.6.5",
+      "resolved": "https://npm.pkg.github.com/download/@ttab/textbit-plugins/1.6.5/63d68be4cf418be5747c9428dab8c8edc6197e6d",
+      "integrity": "sha512-sPVkRnSjlMRRE+JIEUlXL7hpkEvONOpUa225ryV0PvGh/qLrS2ZKlsJ1c/oW32wmkruBz0ACiro5GhV/T6RvuQ==",
       "license": "MIT",
       "dependencies": {
         "@ttab/textbit": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@ttab/elephant-tt-api": "^0.5.2",
     "@ttab/elephant-ui": "^1.4.5",
     "@ttab/textbit": "^1.5.2",
-    "@ttab/textbit-plugins": "^1.6.3",
+    "@ttab/textbit-plugins": "^1.6.4",
     "class-variance-authority": "^0.7.1",
     "cors": "^2.8.6",
     "date-fns": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@ttab/elephant-tt-api": "^0.5.2",
     "@ttab/elephant-ui": "^1.4.5",
     "@ttab/textbit": "^1.5.2",
-    "@ttab/textbit-plugins": "^1.6.4",
+    "@ttab/textbit-plugins": "^1.6.5",
     "class-variance-authority": "^0.7.1",
     "cors": "^2.8.6",
     "date-fns": "^4.1.0",

--- a/src/components/PlainEditor.tsx
+++ b/src/components/PlainEditor.tsx
@@ -26,9 +26,10 @@ export const Editor = ({ id, version, textOnly = false, direct, versionStatusHis
   const activeLocale = i18n.resolvedLanguage
 
   const getPlugins = () => {
-    const basePlugins = [Text, UnorderedList, OrderedList, Bold, Italic, Link, Table]
+    const basePlugins = [Text, UnorderedList, OrderedList, Bold, Italic, Table]
     return [
       ...basePlugins.map((initPlugin) => initPlugin()),
+      Link({ linkWarningLabel: t('linkWarningLabel') }),
       TTVisual({
         captionLabel: t('image.captionLabel'),
         bylineLabel: t('image.bylineLabel'),

--- a/src/locales/en/editor.json
+++ b/src/locales/en/editor.json
@@ -50,5 +50,6 @@
   "derivedFromTimelessLink": "timeless",
   "derivedFromArticleLink": "article",
   "derivedFromConnector": "and",
-  "derivedFromPlanningLink": "planning"
+  "derivedFromPlanningLink": "planning",
+  "linkWarningLabel": "Open link in a new tab? Continue only if you trust the source!"
 }

--- a/src/locales/nb/editor.json
+++ b/src/locales/nb/editor.json
@@ -50,5 +50,6 @@
   "derivedFromTimelessLink": "tidløs",
   "derivedFromArticleLink": "artikkel",
   "derivedFromConnector": "og",
-  "derivedFromPlanningLink": "plan"
+  "derivedFromPlanningLink": "plan",
+  "linkWarningLabel": "Vil du åpne lenken i en ny fane? Fortsett kun hvis du stoler på kilden!"
 }

--- a/src/locales/sv/editor.json
+++ b/src/locales/sv/editor.json
@@ -50,5 +50,6 @@
   "derivedFromTimelessLink": "tidlös",
   "derivedFromArticleLink": "artikel",
   "derivedFromConnector": "och",
-  "derivedFromPlanningLink": "planering"
+  "derivedFromPlanningLink": "planering",
+  "linkWarningLabel": "Vill du öppna länken i en ny flik? Fortsätt endast om du litar på källan!"
 }

--- a/src/views/Editor/index.tsx
+++ b/src/views/Editor/index.tsx
@@ -144,7 +144,7 @@ function EditorWrapper(props: ViewProps & {
     return [
       Bold(),
       Italic(),
-      Link(),
+      Link({ linkWarningLabel: t('editor:linkWarningLabel') }),
       ImageSearchPlugin({ openImageSearch }),
       FactboxPlugin({ openFactboxes }),
       Table(),

--- a/src/views/Factbox/index.tsx
+++ b/src/views/Factbox/index.tsx
@@ -348,14 +348,14 @@ const FactboxWrapper = (props: ViewProps & { documentId: string, data?: EleDocum
   const configuredPlugins = useMemo(() => {
     return [
       UnorderedList(),
-      Link(),
+      Link({ linkWarningLabel: t('editor:linkWarningLabel') }),
       OrderedList(),
       Bold(),
       Italic(),
       LocalizedQuotationMarks(),
       Text({ ...getContentMenuLabels() })
     ]
-  }, [])
+  }, [t])
 
   const isOldVersion = factboxversion !== undefined && factboxversion !== currentVersion
 


### PR DESCRIPTION
Bump textbit-plugins to 1.6.4 and pass a localized linkWarningLabel option to the Link plugin so the open-link confirmation is shown in the user's language (sv, nb, en).