### PR TITLE
fix(scheduling): clear assignment publish time when leaving withheld

### DIFF
--- a/__tests__/updateAssignmentTime.test.ts
+++ b/__tests__/updateAssignmentTime.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { TFunction } from 'i18next'
+import { updateAssignmentTime } from '@/lib/index/updateAssignmentPublishTime'
+
+vi.mock('sonner')
+
+const t = ((key: string) => key) as unknown as TFunction
+
+function mockFetch(ok: boolean) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok,
+    status: ok ? 200 : 500,
+    statusText: ok ? 'OK' : 'Internal Server Error'
+  })
+  global.fetch = fetchMock as unknown as typeof global.fetch
+  return fetchMock
+}
+
+function bodyOf(fetchMock: ReturnType<typeof vi.fn>) {
+  const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+  return (JSON.parse(init.body as string) as { assignment: Record<string, unknown> }).assignment
+}
+
+describe('updateAssignmentTime', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('includes the publish time when scheduling (withheld)', async () => {
+    const fetchMock = mockFetch(true)
+    const time = new Date('2026-06-23T10:00:00.000Z')
+
+    const result = await updateAssignmentTime('deliverable-1', 'planning-1', 'withheld', time, t)
+
+    expect(result).toBe(true)
+    expect(bodyOf(fetchMock)).toEqual({
+      deliverableId: 'deliverable-1',
+      type: 'core/article',
+      status: 'withheld',
+      time: '2026-06-23T10:00:00.000Z'
+    })
+  })
+
+  it('omits the time entirely when clearing (leaving withheld)', async () => {
+    const fetchMock = mockFetch(true)
+
+    const result = await updateAssignmentTime('deliverable-1', 'planning-1', 'usable', undefined, t)
+
+    expect(result).toBe(true)
+    const body = bodyOf(fetchMock)
+    expect(body).not.toHaveProperty('time')
+    expect(body.status).toBe('usable')
+  })
+
+  it('returns false when the backend call fails', async () => {
+    mockFetch(false)
+
+    const result = await updateAssignmentTime('deliverable-1', 'planning-1', 'draft', undefined, t)
+
+    expect(result).toBe(false)
+  })
+})

--- a/src-srv/api/documents/[id]/index.ts
+++ b/src-srv/api/documents/[id]/index.ts
@@ -7,7 +7,7 @@ import * as Y from 'yjs'
 import logger from '../../../lib/logger.js'
 
 import { type Context, isContext } from '../../../lib/context.js'
-import { getValueByYPath, setValueByYPath } from '../../../../shared/yUtils.js'
+import { deleteByYPath, getValueByYPath, setValueByYPath } from '../../../../shared/yUtils.js'
 import type { EleBlock } from '@/shared/types/index.js'
 import { getSession } from '../../../lib/context.js'
 import { snapshot } from '../../../utils/snapshot.js'
@@ -125,6 +125,7 @@ export const GET: RouteHandler = async (req: Request, { cache, repository, res }
  * Patch method, make partial updates to a document.
  * Supported edits:
  * - Set publish time for withheld.
+ * - Clear the stale publish time when leaving withheld (draft/usable).
  * - Set start time for draft
  */
 export const PATCH: RouteHandler = async (req: Request, { collaborationServer, res }) => {
@@ -155,10 +156,19 @@ export const PATCH: RouteHandler = async (req: Request, { collaborationServer, r
     time
   } = assignment || {}
 
-  if (!id || !assignment || !deliverableId || !deliverableType || !status || !time) {
+  if (!id || !assignment || !deliverableId || !deliverableType || !status) {
     return {
       statusCode: 400,
       statusMessage: 'Invalid input to document PATCH method'
+    }
+  }
+
+  // A publish time is only meaningful when scheduling. Clearing it (when leaving
+  // withheld) needs no timestamp.
+  if (status === 'withheld' && !time) {
+    return {
+      statusCode: 400,
+      statusMessage: 'A publish time is required when scheduling a document'
     }
   }
 
@@ -195,13 +205,21 @@ export const PATCH: RouteHandler = async (req: Request, { collaborationServer, r
     if (status === 'withheld') {
       // When scheduling we always set the publishTime to the given time
       setValueByYPath(yRoot, `${base}.data.publish`, time)
-    } else if (assignmentType && ['text', 'flash', 'editorial-info'].includes(assignmentType)) {
-      // If assignment type is text, flash or editorial info and the current start time is less
-      // than the given time we bump the start time.
-      const [currStartTime] = getValueByYPath<string | undefined>(yRoot, `${base}.data.start`)
+    } else {
+      // Leaving the scheduled (withheld) state: the stored publish time is now
+      // stale, so remove it entirely. structureAssignments falls back to the
+      // status modified time / start time for display and sorting.
+      deleteByYPath(yRoot, `${base}.data.publish`)
 
-      if (!currStartTime || (new Date(time) > new Date(currStartTime))) {
-        setValueByYPath(yRoot, `${base}.data.start`, time)
+      if (time && assignmentType && ['text', 'flash', 'editorial-info'].includes(assignmentType)) {
+        // If assignment type is text, flash or editorial info and the current start time is less
+        // than the given time we bump the start time. The clear-only transitions
+        // (e.g. leaving withheld for usable) send no time, so they skip this.
+        const [currStartTime] = getValueByYPath<string | undefined>(yRoot, `${base}.data.start`)
+
+        if (!currStartTime || (new Date(time) > new Date(currStartTime))) {
+          setValueByYPath(yRoot, `${base}.data.start`, time)
+        }
       }
     }
   })

--- a/src/components/QuickDocument/StatusMenu.tsx
+++ b/src/components/QuickDocument/StatusMenu.tsx
@@ -69,6 +69,13 @@ export const StatusMenuLogic = ({ ydoc, propPlanningId, view }: StatusMenuHeader
       })
     }
 
+    // Leaving the scheduled (withheld) state clears the stale publish time stored
+    // on the planning assignment. structureAssignments falls back to the status
+    // modified time for display and sorting.
+    if (workflowStatus?.name === 'withheld' && newStatus !== 'withheld' && ydoc.id && planningId) {
+      await updateAssignmentTime(ydoc.id, planningId, newStatus, undefined, t)
+    }
+
     // The logic for updating publish time is identical for both original components
     if (newStatus !== 'withheld') {
       return true

--- a/src/lib/index/updateAssignmentPublishTime.ts
+++ b/src/lib/index/updateAssignmentPublishTime.ts
@@ -4,7 +4,7 @@ import { toast } from 'sonner'
 const BASE_URL = import.meta.env.BASE_URL || ''
 
 export async function updateAssignmentTime<Ns extends Namespace>(
-  deliverableId: string, planningId: string, newStatus: string, newTime: Date, t: TFunction<Ns>
+  deliverableId: string, planningId: string, newStatus: string, newTime: Date | undefined, t: TFunction<Ns>
 ): Promise<boolean> {
   try {
     const response = await fetch(`${BASE_URL}/api/documents/${planningId}`, {

--- a/src/views/Editor/EditorHeader.tsx
+++ b/src/views/Editor/EditorHeader.tsx
@@ -106,6 +106,15 @@ export const EditorHeader = ({ ydoc, readOnly, readOnlyVersion, planningId: prop
       }
     }
 
+    // Publishing a scheduled article (withheld -> usable) clears the stale
+    // publish time stored on the planning assignment. structureAssignments
+    // falls back to the status modified time for display and sorting. A failed
+    // clear must not block the publish itself.
+    if (workflowStatus?.name === 'withheld' && newStatus === 'usable' && planningId) {
+      await snapshotDocument(planningId, {}, planningYdoc.document)
+      await updateAssignmentTime(ydoc.id, planningId, newStatus, undefined, t)
+    }
+
     // Transitioning from a used/readonly state needs a direct status write,
     // since the default snapshotDocument path expects a live Yjs session
     // which we don't have in the readonly editor.


### PR DESCRIPTION
- PATCH /api/documents/:id removes the assignment data.publish via deleteByYPath for any non-withheld status instead of only setting the start time
- require the publish time only when status is withheld; clear-only transitions omit it
- gate the start-time bump on a provided time so text/flash/editorial-info assignments still bump start on draft while usable clears only
- EditorHeader clears publish on withheld -> usable; QuickDocument clears publish whenever leaving withheld
- updateAssignmentTime accepts an optional time and omits it from the request body when absent
- add updateAssignmentTime request-body tests