### PR TITLE
fix(assignments): use assignment publish time only for withheld

### DIFF
--- a/__tests__/structureAssignments.test.ts
+++ b/__tests__/structureAssignments.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { structureAssignments } from '@/hooks/index/lib/assignments/structureAssignments'
+import type { AssignmentInterface } from '@/hooks/index/lib/assignments/types'
+
+const TIMEZONE = 'Europe/Stockholm'
+
+const SLOTS = [
+  { key: 'morning', label: 'Morning', hours: [6, 7, 8, 9, 10, 11] },
+  { key: 'afternoon', label: 'Afternoon', hours: [12, 13, 14, 15, 16, 17] },
+  { key: 'evening', label: 'Evening', hours: [18, 19, 20, 21, 22, 23] }
+]
+
+function makeAssignment(opts: {
+  id: string
+  status: string
+  publish?: string
+  start?: string
+  modified?: string
+  hasUsable?: boolean
+}): AssignmentInterface {
+  const statusData = {
+    heads: opts.hasUsable ? { usable: { id: `${opts.id}-usable` } } : {},
+    modified: opts.modified ?? '',
+    uuid: opts.id,
+    version: '1',
+    workflowState: '',
+    workflowCheckpoint: ''
+  }
+
+  return {
+    _id: opts.id,
+    _deliverableStatus: opts.status,
+    _statusData: JSON.stringify(statusData),
+    data: {
+      publish: opts.publish,
+      start: opts.start
+    }
+  } as unknown as AssignmentInterface
+}
+
+function slotOf(result: ReturnType<typeof structureAssignments>, id: string) {
+  return result.find((slot) => slot.items.some((item) => item._id === id))?.key
+}
+
+describe('structureAssignments', () => {
+  it('buckets a withheld deliverable by its stored publish time', () => {
+    // 08:00 UTC is 10:00 in Stockholm summer time -> morning slot
+    const result = structureAssignments(TIMEZONE, [
+      makeAssignment({ id: 'a', status: 'withheld', publish: '2026-06-23T08:00:00.000Z' })
+    ], SLOTS)
+
+    expect(slotOf(result, 'a')).toBe('morning')
+  })
+
+  it('ignores publish for a usable deliverable and falls back to the modified time', () => {
+    // publish would bucket to morning, but usable must use the status modified time (evening)
+    const result = structureAssignments(TIMEZONE, [
+      makeAssignment({
+        id: 'a',
+        status: 'usable',
+        publish: '2026-06-23T08:00:00.000Z',
+        modified: '2026-06-23T20:00:00',
+        hasUsable: true
+      })
+    ], SLOTS)
+
+    expect(slotOf(result, 'a')).toBe('evening')
+  })
+
+  it('sorts a withheld (scheduled) deliverable before a usable one in the same slot', () => {
+    const result = structureAssignments(TIMEZONE, [
+      makeAssignment({
+        id: 'usable',
+        status: 'usable',
+        publish: '2026-06-23T05:00:00.000Z',
+        modified: '2026-06-23T09:00:00',
+        hasUsable: true
+      }),
+      makeAssignment({ id: 'withheld', status: 'withheld', publish: '2026-06-23T08:00:00.000Z' })
+    ], SLOTS)
+
+    const morning = result.find((slot) => slot.key === 'morning')
+    expect(morning?.items.map((item) => item._id)).toEqual(['withheld', 'usable'])
+  })
+
+  it('orders two withheld deliverables by ascending publish time', () => {
+    const result = structureAssignments(TIMEZONE, [
+      makeAssignment({ id: 'later', status: 'withheld', publish: '2026-06-23T09:00:00.000Z' }),
+      makeAssignment({ id: 'earlier', status: 'withheld', publish: '2026-06-23T06:00:00.000Z' })
+    ], SLOTS)
+
+    const morning = result.find((slot) => slot.key === 'morning')
+    expect(morning?.items.map((item) => item._id)).toEqual(['earlier', 'later'])
+  })
+})

--- a/src/hooks/index/lib/assignments/fetchAssignments.ts
+++ b/src/hooks/index/lib/assignments/fetchAssignments.ts
@@ -195,10 +195,11 @@ export async function fetchAssignments({ index, repository, type, requireDeliver
     }
   })
 
-  // Sort assignments with fullday first, then in time order
+  // Sort assignments with fullday first, then in time order. Only a scheduled
+  // (withheld) deliverable sorts by its stored publish time.
   filteredTextAssignments.sort((a, b) => {
-    const at = a.data.publish ? parseISO(a.data.publish) : 0
-    const bt = b.data.publish ? parseISO(b.data.publish) : 0
+    const at = (a._deliverableStatus === 'withheld' && a.data.publish) ? parseISO(a.data.publish) : 0
+    const bt = (b._deliverableStatus === 'withheld' && b.data.publish) ? parseISO(b.data.publish) : 0
 
     return bt.valueOf() - at.valueOf()
   })

--- a/src/hooks/index/lib/assignments/structureAssignments.ts
+++ b/src/hooks/index/lib/assignments/structureAssignments.ts
@@ -54,8 +54,9 @@ export function structureAssignments(
     const { publish, start, publish_slot } = assignment.data
     let hour: number | undefined
 
-    if ((status === 'withheld' || status === 'usable') && publish) {
-      // When scheduled or auto-published, use the publish time.
+    if (status === 'withheld' && publish) {
+      // Only a scheduled (withheld) deliverable uses the stored publish time;
+      // anything else falls back to the modified/slot/start time below.
       hour = getHours(toZonedTime(parseISO(publish), timeZone))
     } else if (hasUsable && statusData.modified) {
       hour = getHours(parseISO(statusData.modified))
@@ -86,8 +87,8 @@ export function structureAssignments(
       if (a?._statusData && b?._statusData) {
         const aData = JSON.parse(a._statusData) as StatusData
         const bData = JSON.parse(b._statusData) as StatusData
-        const aHasPublish = ['withheld', 'usable'].includes(a._deliverableStatus || '') && a.data.publish
-        const bHasPublish = ['withheld', 'usable'].includes(b._deliverableStatus || '') && b.data.publish
+        const aHasPublish = a._deliverableStatus === 'withheld' && a.data.publish
+        const bHasPublish = b._deliverableStatus === 'withheld' && b.data.publish
 
         if (aHasPublish && bHasPublish) {
           return a.data.publish.localeCompare(b.data.publish)
@@ -104,8 +105,8 @@ export function structureAssignments(
       if (aHasSlot && !bHasSlot) return -1
       if (!aHasSlot && bHasSlot) return 1
 
-      const aHasPublish = ['withheld', 'usable'].includes(a._deliverableStatus || '') && a.data.publish
-      const bHasPublish = ['withheld', 'usable'].includes(b._deliverableStatus || '') && b.data.publish
+      const aHasPublish = a._deliverableStatus === 'withheld' && a.data.publish
+      const bHasPublish = b._deliverableStatus === 'withheld' && b.data.publish
       if (aHasPublish && bHasPublish) {
         return a.data.publish.localeCompare(b.data.publish)
       }

--- a/src/views/Approvals/TimeCard.tsx
+++ b/src/views/Approvals/TimeCard.tsx
@@ -75,7 +75,7 @@ function getAssignmentTime({ assignment, timeZone, locale, statusData, compareDa
     return getTimeslotLabel(parseInt(assignment.data.publish_slot), t)
   }
 
-  if (assignment.data.publish && ['withheld', 'usable'].includes(assignment._deliverableStatus || '')) {
+  if (assignment.data.publish && assignment._deliverableStatus === 'withheld') {
     return format(toZonedTime(parseISO(assignment.data.publish), timeZone), 'HH:mm')
   }
 
@@ -109,9 +109,8 @@ function getTimeTooltip({ assignment, statusData, timeZone, locale, compareDate,
   compareDate?: Date
   t: (key: string) => string
 }): string {
-  if (assignment.data.publish && ['withheld', 'usable'].includes(assignment._deliverableStatus || '')) {
-    const label = assignment._deliverableStatus === 'withheld' ? t('core:status.withheld') : t('core:status.usable')
-    return `${label} ${format(toZonedTime(parseISO(assignment.data.publish), timeZone), 'HH:mm')}`
+  if (assignment.data.publish && assignment._deliverableStatus === 'withheld') {
+    return `${t('core:status.withheld')} ${format(toZonedTime(parseISO(assignment.data.publish), timeZone), 'HH:mm')}`
   }
   if (statusData?.modified) {
     if (compareDate) {

--- a/src/views/Planning/components/AssignmentRow.tsx
+++ b/src/views/Planning/components/AssignmentRow.tsx
@@ -150,7 +150,9 @@ export const AssignmentRow = ({ ydoc, index, onSelect, isFocused = false, asDial
       }
     }
 
-    if (publishTime) {
+    // Only a scheduled (withheld) deliverable surfaces the publish time; once
+    // published or otherwise out of withheld it falls back to start/end below.
+    if (publishTime && workflowState === 'withheld') {
       return {
         time: [new Date(publishTime)],
         tooltip: t('planning:assignment.publishTime'),
@@ -173,7 +175,7 @@ export const AssignmentRow = ({ ydoc, index, onSelect, isFocused = false, asDial
         type: assignmentType
       }
     }
-  }, [publishTime, assignmentType, startTime, endTime, publishSlot, t])
+  }, [publishTime, workflowState, assignmentType, startTime, endTime, publishSlot, t])
 
   const isVisualType = isVisualAssignmentType(assignmentType)
 
@@ -192,10 +194,12 @@ export const AssignmentRow = ({ ydoc, index, onSelect, isFocused = false, asDial
       'start-end': ClockFadingIcon
     }
 
-    const type = publishTime ? 'publish' : endTime && startTime && endTime !== startTime ? 'start-end' : 'start'
+    const type = (publishTime && workflowState === 'withheld')
+      ? 'publish'
+      : endTime && startTime && endTime !== startTime ? 'start-end' : 'start'
 
     return timeIcons[type] || <></>
-  }, [publishTime, endTime, startTime])
+  }, [publishTime, workflowState, endTime, startTime])
 
   // Open a deliverable (e.g. article, flash, editorial-info) callback helper.
   // For readOnly pass version object


### PR DESCRIPTION
- structureAssignments buckets and sorts by data.publish only when the deliverable status is withheld; usable and other statuses fall back to the status modified time, publish_slot or start
- add structureAssignments tests for bucketing and sort ordering