### PR TITLE
fix(wires): create wire article assignments as public

### DIFF
--- a/__tests__/createArticle.test.tsx
+++ b/__tests__/createArticle.test.tsx
@@ -212,6 +212,27 @@ describe('createArticle', () => {
     })
   })
 
+  describe('assignment visibility', () => {
+    it('creates the assignment as public, like assignments added from the planning view', async () => {
+      // Text assignments are part of the planning's published artifact. Only
+      // flash and timeless assignments are non-public — a wire-sourced article
+      // is an ordinary text assignment.
+      const repository = buildRepository()
+
+      await createArticle({
+        ...baseArgs,
+        ydoc: buildYdoc({ title: 'T' }),
+        repository,
+        session: buildSession(),
+        translationMode: undefined
+      })
+
+      expect(mockAddAssignment).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'text', publicVisibility: true })
+      )
+    })
+  })
+
   describe('translation failure', () => {
     it('throws TranslationError and does NOT save or link when translation rejects', async () => {
       const repository = buildRepository()

--- a/src/views/WireCreation/lib/createArticle.tsx
+++ b/src/views/WireCreation/lib/createArticle.tsx
@@ -213,7 +213,10 @@ export async function createArticle({
     title: assignmentTitle || '',
     slugline: assignmentSlugline,
     priority: resolvedNewsValue ? parseInt(resolvedNewsValue) : undefined,
-    publicVisibility: false,
+    // A wire-sourced article is an ordinary text assignment, so it must be
+    // public like the ones created from the planning view. Only flash and
+    // timeless assignments are non-public.
+    publicVisibility: true,
     localDate,
     isoDateTime,
     section,


### PR DESCRIPTION
## Summary

Assignments created from the wires interface were linked into the planning with `data.public` set to `'false'`, unlike text assignments added from the planning view.

The planning view calls `createNewAssignment` with no `assignmentData`, so it gets the default from `assignmentPlanningTemplate` — `public: 'true'` for everything except `flash` and `timeless`. The wires flow instead goes through the backend `addassignment` endpoint, which maps its `publicVisibility` payload field straight onto `data.public`, and `createArticle` was passing `false` for what is an ordinary `text` assignment. Every other call site agrees with the template: QuickArticle, Hast and quick-article-after-flash pass `true`; only flash and timeless pass `false`.

This is a regression rather than a deliberate choice. Before #1466 the wires flow called `appendAssignment` directly with no `assignmentData` and picked up the template default. #1466 migrated it to the backend endpoint in the same commit that added the flash flow, and the `false` appears to have been copied from the flash call site.

Fixed by passing `publicVisibility: true`, with a regression test asserting `{ type: 'text', publicVisibility: true }`.

Note this only affects newly created articles — existing wire-created assignments still carry `public: 'false'` in the repository and would need a separate backfill if that matters.